### PR TITLE
Add cross-platform release downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release desktop installers
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  macos-apple-silicon:
+    name: macOS Apple Silicon
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run typecheck
+      - run: npm run package:mac:arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-apple-silicon
+          path: |
+            dist/dsh-desktop-mac-arm64.dmg
+            dist/dsh-desktop-mac-arm64.zip
+          if-no-files-found: error
+
+  macos-intel:
+    name: macOS Intel
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run typecheck
+      - run: npm run package:mac:x64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-intel
+          path: |
+            dist/dsh-desktop-mac-x64.dmg
+            dist/dsh-desktop-mac-x64.zip
+          if-no-files-found: error
+
+  windows-x64:
+    name: Windows x64
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run typecheck
+      - run: npm run package:win
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-x64
+          path: |
+            dist/dsh-desktop-windows-x64-setup.exe
+            dist/dsh-desktop-windows-x64-portable.exe
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub Release
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.macos-apple-silicon.result == 'success' &&
+      needs.macos-intel.result == 'success' &&
+      needs.windows-x64.result == 'success'
+    needs:
+      - macos-apple-silicon
+      - macos-intel
+      - windows-x64
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$RELEASE_TAG" release-assets/* \
+              --verify-tag \
+              --generate-notes \
+              --title "DSH Desktop $RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY"
+          fi

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ DSH Desktop packages the local DeepSeek Harness web experience as a desktop appl
 > [!IMPORTANT]
 > DSH Desktop is currently an early preview and depends on the rapidly evolving `@deepseek-ai/dsh@0.1.0-rc.6`. Current builds are not code-signed or notarized by Apple and are not recommended for production use.
 
+## Download
+
+| Platform | Package | Download |
+| --- | --- | --- |
+| macOS Apple Silicon | DMG installer | [Download for Apple Silicon](https://github.com/dataelement/dsh-desktop/releases/latest/download/dsh-desktop-mac-arm64.dmg) |
+| macOS Intel | DMG installer | [Download for Intel Mac](https://github.com/dataelement/dsh-desktop/releases/latest/download/dsh-desktop-mac-x64.dmg) |
+| Windows x64 | Setup installer | [Download Windows installer](https://github.com/dataelement/dsh-desktop/releases/latest/download/dsh-desktop-windows-x64-setup.exe) |
+| Windows x64 | Portable executable | [Download portable version](https://github.com/dataelement/dsh-desktop/releases/latest/download/dsh-desktop-windows-x64-portable.exe) |
+
+All current and historical packages are available on the [GitHub Releases page](https://github.com/dataelement/dsh-desktop/releases).
+
 ## Why this project exists
 
 DeepSeek Harness already provides a complete agent runtime and Web UI. DSH Desktop does not reimplement Harness; it supplies the host capabilities needed for a desktop product:
@@ -43,6 +54,7 @@ DeepSeek Harness already provides a complete agent runtime and Web UI. DSH Deskt
 - Gracefully terminates the Harness child process when the desktop app exits
 - Listens only on a random `127.0.0.1` port for each launch
 - Removes Node.js privileges from the renderer and enables `contextIsolation`, sandboxing, and navigation restrictions
+- Uses the DSH brand logo consistently in the desktop window and Harness sidebar
 - Includes a production DSH app icon in macOS ICNS and Windows ICO formats
 
 ## Model providers
@@ -76,7 +88,7 @@ npm install
 npm run dev
 ```
 
-`npm install` runs `patch-package` to reapply DSH Desktop's customized Harness model-provider onboarding, then installs the Electron runtime.
+`npm install` runs `patch-package` to reapply DSH Desktop's model-provider onboarding and sidebar branding, installs the brand asset, and then installs the Electron runtime.
 
 ### Quality checks
 
@@ -130,7 +142,7 @@ Harness runs in a separate Electron Node child process. The `--expose-internals`
 src/main/             Electron main process, windows, and Harness lifecycle
 src/shared/           Shared runtime types
 patches/              Reproducible UI customizations for the pinned DSH version
-scripts/              Target-platform packaging checks
+scripts/              Brand-asset installation and target-platform packaging checks
 test/                 Settings, runtime, security, and provider coverage tests
 build/                Application icon assets
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -24,6 +24,17 @@ DSH Desktop 把 DeepSeek Harness 的本地 Web 体验封装为桌面应用：选
 > [!IMPORTANT]
 > DSH Desktop 当前处于早期预览阶段，并依赖仍在快速迭代的 `@deepseek-ai/dsh@0.1.0-rc.6`。当前构建尚未代码签名或 Apple 公证，不建议直接用于生产环境。
 
+## 下载安装
+
+| 平台 | 安装包 | 下载 |
+| --- | --- | --- |
+| macOS Apple Silicon | DMG 安装包 | [下载 Apple 芯片版](https://github.com/dataelement/dsh-desktop/releases/latest/download/dsh-desktop-mac-arm64.dmg) |
+| macOS Intel | DMG 安装包 | [下载 Intel 芯片版](https://github.com/dataelement/dsh-desktop/releases/latest/download/dsh-desktop-mac-x64.dmg) |
+| Windows x64 | EXE 安装版 | [下载 Windows 安装版](https://github.com/dataelement/dsh-desktop/releases/latest/download/dsh-desktop-windows-x64-setup.exe) |
+| Windows x64 | EXE 便携版 | [下载 Windows 便携版](https://github.com/dataelement/dsh-desktop/releases/latest/download/dsh-desktop-windows-x64-portable.exe) |
+
+所有当前及历史版本可以在 [GitHub Releases 页面](https://github.com/dataelement/dsh-desktop/releases)查看。
+
 ## 为什么做这个项目
 
 DeepSeek Harness 本身提供完整的 Agent Runtime 与 Web UI。DSH Desktop 不重新实现 Harness，而是补上桌面产品所需的宿主能力：
@@ -43,6 +54,7 @@ DeepSeek Harness 本身提供完整的 Agent Runtime 与 Web UI。DSH Desktop �
 - 退出桌面应用时优雅终止 Harness 子进程
 - 每次启动仅监听随机的 `127.0.0.1` 端口
 - Renderer 关闭 Node.js 权限，启用 `contextIsolation`、sandbox 与导航限制
+- 在桌面窗口与 Harness 侧栏统一使用 DSH 品牌 Logo
 - 正式 DSH 应用图标，支持 macOS ICNS 与 Windows ICO
 
 ## 模型提供方
@@ -76,7 +88,7 @@ npm install
 npm run dev
 ```
 
-`npm install` 会运行 `patch-package`，重放 DSH Desktop 对 Harness 首次模型配置界面的定制，然后安装 Electron Runtime。
+`npm install` 会运行 `patch-package`，重放 DSH Desktop 对 Harness 首次模型配置和侧栏品牌的定制，安装品牌静态资源，然后安装 Electron Runtime。
 
 ### 质量检查
 
@@ -130,7 +142,7 @@ Harness 运行在独立的 Electron Node 子进程中。Cordis HMR 所需的 `--
 src/main/             Electron 主进程、窗口与 Harness 生命周期
 src/shared/           共享运行时类型
 patches/              对固定 DSH 版本的可复现界面定制
-scripts/              目标平台打包检查
+scripts/              品牌资源安装与目标平台打包检查
 test/                 设置、运行时、安全和 Provider 覆盖测试
 build/                应用图标资源
 ```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "agent"
   ],
   "scripts": {
-    "postinstall": "patch-package && install-electron --no",
+    "postinstall": "patch-package && node scripts/install-brand-assets.mjs && install-electron --no",
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
@@ -62,7 +62,7 @@
       "node_modules/**/*",
       "package.json"
     ],
-    "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
+    "artifactName": "dsh-desktop-${os}-${arch}.${ext}",
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.icns",
@@ -91,10 +91,14 @@
       ]
     },
     "nsis": {
+      "artifactName": "dsh-desktop-windows-${arch}-setup.${ext}",
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true
+    },
+    "portable": {
+      "artifactName": "dsh-desktop-windows-${arch}-portable.${ext}"
     }
   }
 }

--- a/patches/@deepseek-ai+dsh-client-ui-sidebar+0.1.0-rc.6.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-sidebar+0.1.0-rc.6.patch
@@ -1,0 +1,63 @@
+diff --git a/node_modules/@deepseek-ai/dsh-client-ui-sidebar/lib/client.js b/node_modules/@deepseek-ai/dsh-client-ui-sidebar/lib/client.js
+index 629e313..9f234b3 100644
+--- a/node_modules/@deepseek-ai/dsh-client-ui-sidebar/lib/client.js
++++ b/node_modules/@deepseek-ai/dsh-client-ui-sidebar/lib/client.js
+@@ -56,6 +56,37 @@ window.__ModuleLoader__.load({
+ 			"newSessionLabel": "hHd-Xa_newSessionLabel"
+ 		};
+ 		//#endregion
++		//#region lib/types/client/DshDesktopLogo.js
++		const DSH_DESKTOP_LOGO_URL = "/dsh-desktop-logo.png";
++		function DshDesktopLogo({ collapsed = false, className }) {
++			const height = collapsed ? 16 : 34;
++			return (0, react_jsx_runtime.jsxs)("svg", {
++				width: height * 1030 / 590,
++				height,
++				className,
++				viewBox: "150 330 1030 590",
++				fill: "none",
++				"aria-hidden": "true",
++				children: [(0, react_jsx_runtime.jsx)("defs", {
++					children: (0, react_jsx_runtime.jsx)("filter", {
++						id: "dsh-desktop-logo-knockout",
++						colorInterpolationFilters: "sRGB",
++						children: (0, react_jsx_runtime.jsx)("feColorMatrix", {
++							values: "1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  -1 -1 -1 0 3"
++						})
++					})
++				}), (0, react_jsx_runtime.jsx)("image", {
++					href: DSH_DESKTOP_LOGO_URL,
++					x: 0,
++					y: 0,
++					width: 1254,
++					height: 1254,
++					preserveAspectRatio: "none",
++					filter: "url(#dsh-desktop-logo-knockout)"
++				})]
++			});
++		}
++		//#endregion
+ 		//#region lib/types/client/SidebarRoot.js
+ 		/**
+ 		* Sidebar shell: column geometry only. Collapse is a slide plus crossfade:
+@@ -157,7 +188,7 @@ window.__ModuleLoader__.load({
+ 							onClick: () => {
+ 								startSession();
+ 							},
+-							children: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.BrandWordmark, {})
++							children: (0, react_jsx_runtime.jsx)(DshDesktopLogo, {})
+ 						}), (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Tooltip, {
+ 							label: collapsed ? t("toggle.open") : t("toggle.collapse"),
+ 							delayMs: 500,
+@@ -168,9 +199,9 @@ window.__ModuleLoader__.load({
+ 								onClick: () => {
+ 									toggleSidebar();
+ 								},
+-								children: [!wide && (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.FishLogo, {
++								children: [!wide && (0, react_jsx_runtime.jsx)(DshDesktopLogo, {
+ 									className: SidebarRoot_module_css_default.railFish,
+-									size: 24
++									collapsed: true
+ 								}), (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconPanelLeftOutline16, {
+ 									className: SidebarRoot_module_css_default.panelIcon,
+ 									size: wide ? 16 : 18

--- a/scripts/install-brand-assets.mjs
+++ b/scripts/install-brand-assets.mjs
@@ -1,0 +1,19 @@
+import { copyFile, mkdir } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const source = path.join(projectRoot, 'build', 'icon.png')
+const destinationDirectory = path.join(
+  projectRoot,
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-web-frontend',
+  'dist'
+)
+const destination = path.join(destinationDirectory, 'dsh-desktop-logo.png')
+
+await mkdir(destinationDirectory, { recursive: true })
+await copyFile(source, destination)
+
+console.log(`Installed DSH Desktop brand asset: ${path.relative(projectRoot, destination)}`)

--- a/test/branding-patch.test.ts
+++ b/test/branding-patch.test.ts
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = path.resolve(import.meta.dirname, '..')
+
+describe('DSH Desktop sidebar branding', () => {
+  it('replaces both sidebar wordmark states with the DSH Desktop logo', async () => {
+    const patch = await readFile(
+      path.join(projectRoot, 'patches', '@deepseek-ai+dsh-client-ui-sidebar+0.1.0-rc.6.patch'),
+      'utf8'
+    )
+
+    expect(patch).toContain('DshDesktopLogo')
+    expect(patch).toContain('/dsh-desktop-logo.png')
+    expect(patch).toContain('collapsed: true')
+    expect(patch).toContain('dsh-desktop-logo-knockout')
+  })
+
+  it('installs the source logo into the Harness static frontend', async () => {
+    const packageJson = JSON.parse(
+      await readFile(path.join(projectRoot, 'package.json'), 'utf8')
+    ) as { scripts: { postinstall: string } }
+    const installer = await readFile(
+      path.join(projectRoot, 'scripts', 'install-brand-assets.mjs'),
+      'utf8'
+    )
+
+    expect(packageJson.scripts.postinstall).toContain('node scripts/install-brand-assets.mjs')
+    expect(installer).toContain("'build', 'icon.png'")
+    expect(installer).toContain("'dsh-desktop-logo.png'")
+  })
+})

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -1,0 +1,62 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = path.resolve(import.meta.dirname, '..')
+
+const releaseAssets = [
+  'dsh-desktop-mac-arm64.dmg',
+  'dsh-desktop-mac-x64.dmg',
+  'dsh-desktop-windows-x64-setup.exe',
+  'dsh-desktop-windows-x64-portable.exe'
+]
+
+describe('GitHub release contract', () => {
+  it('uses stable platform-specific artifact names', async () => {
+    const packageJson = JSON.parse(
+      await readFile(path.join(projectRoot, 'package.json'), 'utf8')
+    ) as {
+      build: {
+        artifactName: string
+        nsis: { artifactName: string }
+        portable: { artifactName: string }
+      }
+    }
+
+    expect(packageJson.build.artifactName).toBe('dsh-desktop-${os}-${arch}.${ext}')
+    expect(packageJson.build.nsis.artifactName).toBe(
+      'dsh-desktop-windows-${arch}-setup.${ext}'
+    )
+    expect(packageJson.build.portable.artifactName).toBe(
+      'dsh-desktop-windows-${arch}-portable.${ext}'
+    )
+  })
+
+  it('builds and publishes every supported platform', async () => {
+    const workflow = await readFile(
+      path.join(projectRoot, '.github', 'workflows', 'release.yml'),
+      'utf8'
+    )
+
+    expect(workflow).toContain('runs-on: macos-15')
+    expect(workflow).toContain('runs-on: macos-15-intel')
+    expect(workflow).toContain('runs-on: windows-2022')
+    for (const asset of releaseAssets) expect(workflow).toContain(asset)
+  })
+
+  it('keeps English and Chinese latest-download links aligned with the assets', async () => {
+    const readmes = await Promise.all(
+      ['README.md', 'README.zh.md'].map((file) =>
+        readFile(path.join(projectRoot, file), 'utf8')
+      )
+    )
+
+    for (const readme of readmes) {
+      for (const asset of releaseAssets) {
+        expect(readme).toContain(
+          `https://github.com/dataelement/dsh-desktop/releases/latest/download/${asset}`
+        )
+      }
+    }
+  })
+})


### PR DESCRIPTION
## What changed

- replaces the Harness sidebar wordmark with the DSH Desktop whale logo in expanded and collapsed states
- adds reproducible brand asset installation during npm install
- adds tag-driven GitHub Actions builds for macOS Apple Silicon, macOS Intel, and Windows x64
- publishes DMG, ZIP, setup EXE, and portable EXE assets to GitHub Releases
- adds stable latest-release download links to both English and Chinese READMEs
- adds branding and release contract regression tests

## Validation

- npm ci
- npm test (22 tests)
- npm run typecheck
- npm run package:mac:arm64
- git diff --check
- verified the packaged macOS app contains the original logo asset and patched sidebar
