### PR TITLE
Disable implicit builder publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "package:dir": "npm run build && electron-builder --dir",
-    "package:mac": "npm run build && electron-builder --mac",
-    "package:mac:arm64": "node scripts/verify-target.mjs darwin arm64 && npm run build && electron-builder --mac --arm64",
-    "package:mac:x64": "node scripts/verify-target.mjs darwin x64 && npm run build && electron-builder --mac --x64",
-    "package:win": "node scripts/verify-target.mjs win32 x64 && npm run build && electron-builder --win --x64"
+    "package:mac": "npm run build && electron-builder --mac --publish never",
+    "package:mac:arm64": "node scripts/verify-target.mjs darwin arm64 && npm run build && electron-builder --mac --arm64 --publish never",
+    "package:mac:x64": "node scripts/verify-target.mjs darwin x64 && npm run build && electron-builder --mac --x64 --publish never",
+    "package:win": "node scripts/verify-target.mjs win32 x64 && npm run build && electron-builder --win --x64 --publish never"
   },
   "dependencies": {
     "@deepseek-ai/dsh": "0.1.0-rc.6"

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -32,6 +32,21 @@ describe('GitHub release contract', () => {
     )
   })
 
+  it('keeps builder jobs from attempting implicit tag publishing', async () => {
+    const packageJson = JSON.parse(
+      await readFile(path.join(projectRoot, 'package.json'), 'utf8')
+    ) as { scripts: Record<string, string> }
+
+    for (const script of [
+      'package:mac',
+      'package:mac:arm64',
+      'package:mac:x64',
+      'package:win'
+    ]) {
+      expect(packageJson.scripts[script]).toContain('--publish never')
+    }
+  })
+
   it('builds and publishes every supported platform', async () => {
     const workflow = await readFile(
       path.join(projectRoot, '.github', 'workflows', 'release.yml'),


### PR DESCRIPTION
## What changed

- adds `--publish never` to all electron-builder packaging scripts
- keeps tag builds focused on producing artifacts
- leaves GitHub Release creation to the dedicated publish job after all three platforms succeed
- adds a regression test for the no-implicit-publish contract

## Root cause

electron-builder detected the v0.1.0 tag and attempted implicit publishing from each platform build. Those jobs intentionally do not receive a GitHub token, so they failed after successfully producing installers.

## Validation

- npm test (23 tests)
- npm run typecheck
- npm run package:mac:arm64
- git diff --check
