### PR TITLE
Add model provider support caption

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ![DSH Desktop model provider settings](docs/images/model-provider-settings-v011.png)
 
+<p align="center"><strong>Beyond official DeepSeek models, DSH Desktop supports mainstream third-party model providers.</strong></p>
+
 DSH Desktop packages the local DeepSeek Harness web experience as a desktop application. Choose a workspace and the app launches a local Harness instance, manages a random loopback port, persists profiles, plugins, and sessions, and opens the full interface as soon as Harness is ready.
 
 > [!IMPORTANT]

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,6 +20,8 @@
 
 ![DSH Desktop 模型提供方设置界面](docs/images/model-provider-settings-v011.png)
 
+<p align="center"><strong>不止 DeepSeek 官方模型，也支持接入主流第三方模型提供方。</strong></p>
+
 DSH Desktop 把 DeepSeek Harness 的本地 Web 体验封装为桌面应用：选择一个工作区，应用会启动本地 Harness、管理随机回环端口、持久化 Profile/插件/会话，并在 Harness 就绪后直接进入完整界面。
 
 > [!IMPORTANT]


### PR DESCRIPTION
Add a centered caption below the README hero image explaining that DSH Desktop supports mainstream third-party model providers beyond official DeepSeek models. Includes matching English and Chinese copy.