### PR TITLE
fix: declare runtime-only @deepseek-ai deps so electron-builder bundles them

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,26 @@
     "package:win": "node scripts/verify-target.mjs win32 x64 && npm run build && electron-builder --win --x64 --publish never"
   },
   "dependencies": {
-    "@deepseek-ai/dsh": "0.1.0-rc.6"
+    "@deepseek-ai/dsh": "0.1.0-rc.6",
+    "@deepseek-ai/cordis-plugin-group": "1.0.1",
+    "@deepseek-ai/dsh-anonymous-user-id": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-atomic-write": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-bash-local": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-code-runtime": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-compaction": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-fs": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-invariants": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-output-retention": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-sandbox": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-scope": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-session-telemetry": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-session-title-llm": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-shell": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-spill": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-subagent-in-process-driver": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-subprocess": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-timeout": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-workflow": "0.1.0-rc.6"
   },
   "devDependencies": {
     "@types/node": "24.10.1",


### PR DESCRIPTION
## Problem

The packaged app crashes at startup on all platforms:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@deepseek-ai/cordis-plugin-group' imported from .../dsh-app-boot/lib/index.js
```

The app bundle is missing 19 `@deepseek-ai` packages (dsh-shell, dsh-subprocess, dsh-sandbox, dsh-fs, ...). See issue #9.

## Root cause

These packages are loaded **dynamically at runtime** by the DSH web profile — they are not declared as dependencies of `@deepseek-ai/dsh`, so npm does not install them and electron-builder prunes them from the bundle (the `files` list includes `node_modules/**/*`, but they were never there).

## Fix

Declare the 19 runtime packages as **direct dependencies** (pinned to the same rc.6 line as `@deepseek-ai/dsh`), so electron-builder includes them.

## Verification

Copying these packages from a full dsh install into the app bundle fixes the crash — the Harness then boots and serves HTTP 200 (verified on macOS x64). This PR makes that copy unnecessary.

## Notes

- Versions pinned to match the bundled dsh line: 18 packages at `0.1.0-rc.6`, `@deepseek-ai/cordis-plugin-group` at `1.0.1`.
- A fresh build is needed to confirm packaging end-to-end; I don't have an Apple Silicon/Windows runner here, so CI verification on this PR would be valuable.