### PR TITLE
Add coming soon message to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ![DSH Desktop model provider settings](docs/images/model-provider-settings-v011.png)
 
-<p align="center"><strong>Beyond official DeepSeek models, DSH Desktop supports mainstream third-party model providers.</strong></p>
+<p align="center"><strong>Beyond official DeepSeek models, DSH Desktop supports mainstream third-party model providers—with more DSH-powered desktop experiences coming soon.</strong></p>
 
 DSH Desktop packages the local DeepSeek Harness web experience as a desktop application. It launches a local Harness instance automatically, manages a random loopback port, persists profiles, plugins, and sessions, and opens the full interface as soon as Harness is ready. Project workspaces are added and managed entirely in the Harness interface.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,7 @@
 
 ![DSH Desktop 模型提供方设置界面](docs/images/model-provider-settings-v011.png)
 
-<p align="center"><strong>不止 DeepSeek 官方模型，也支持接入主流第三方模型提供方。</strong></p>
+<p align="center"><strong>除了 DeepSeek 官方模型，DSH Desktop 也支持主流第三方模型提供方。更多基于 DSH 的有趣桌面体验即将推出。</strong></p>
 
 DSH Desktop 把 DeepSeek Harness 的本地 Web 体验封装为桌面应用：应用会自动启动本地 Harness、管理随机回环端口、持久化 Profile/插件/会话，并在 Harness 就绪后直接进入完整界面。项目工作区在 Harness 界面中统一添加和管理。
 


### PR DESCRIPTION
## What changed

- extend the prominent model-provider message with a short coming-soon statement
- keep the English and Chinese README copy aligned

## Why

This signals that DSH Desktop will expand beyond its current model-provider support while keeping the message near the top product screenshot.

## Validation

- git diff --check
- reviewed the top section of both README files