### PR TITLE
Add select-all toggle to available model picker

### DIFF
--- a/patches/@deepseek-ai+dsh-client-ui-settings-models+0.1.0-rc.6.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-settings-models+0.1.0-rc.6.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js b/node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js
-index 644a0f2..42e2f81 100644
+index 644a0f2..bdad343 100644
 --- a/node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js
 +++ b/node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js
 @@ -66,6 +66,14 @@ window.__ModuleLoader__.load({
@@ -17,7 +17,45 @@ index 644a0f2..42e2f81 100644
  		var ModelsSection_module_css_default = {
  			"iconButtonDanger": "zGbnIq_iconButtonDanger",
  			"editorActions": "zGbnIq_editorActions",
-@@ -1753,6 +1761,26 @@ window.__ModuleLoader__.load({
+@@ -837,6 +845,11 @@ window.__ModuleLoader__.load({
+ 					return next;
+ 				});
+ 			};
++			const allCandidatesPicked = candidates !== void 0 && candidates.length > 0 && candidates.every((candidate) => picked.has(candidate.id));
++			const toggleAllCandidates = () => {
++				if (candidates === void 0) return;
++				setPicked(allCandidatesPicked ? /* @__PURE__ */ new Set() : new Set(candidates.map((candidate) => candidate.id)));
++			};
+ 			const askable = probe.provider !== void 0 || probe.baseURL !== void 0 && probe.baseURL.length > 0;
+ 			return (0, react_jsx_runtime.jsxs)("section", {
+ 				className: ModelsSection_module_css_default["modelCatalog"],
+@@ -1003,7 +1016,15 @@ window.__ModuleLoader__.load({
+ 							onClick: adoptPicked,
+ 							children: t("fetchAdopt")
+ 						})] }),
+-						children: (0, react_jsx_runtime.jsx)("ul", {
++						children: (0, react_jsx_runtime.jsxs)(react_jsx_runtime.Fragment, { children: [(0, react_jsx_runtime.jsx)("div", {
++							className: ModelsSection_module_css_default["editorActions"],
++							children: (0, react_jsx_runtime.jsx)("button", {
++								type: "button",
++								className: ModelsSection_module_css_default["linkButton"],
++								onClick: toggleAllCandidates,
++								children: t(allCandidatesPicked ? "fetchDeselectAll" : "fetchSelectAll")
++							})
++						}), (0, react_jsx_runtime.jsx)("ul", {
+ 							className: ModelsSection_module_css_default["candidateList"],
+ 							children: (candidates ?? []).map((candidate) => (0, react_jsx_runtime.jsx)("li", {
+ 								className: ModelsSection_module_css_default["candidate"],
+@@ -1021,7 +1042,7 @@ window.__ModuleLoader__.load({
+ 									})]
+ 								})
+ 							}, candidate.id))
+-						})
++						})] })
+ 					})
+ 				]
+ 			});
+@@ -1753,6 +1774,26 @@ window.__ModuleLoader__.load({
  		function providerCopy(template, target) {
  			return template.replace("{provider}", () => providerTargetLabel(target));
  		}
@@ -44,7 +82,7 @@ index 644a0f2..42e2f81 100644
  		/**
  		* Render the Models section content column.
  		* @param props - slot-delivered injected dependencies.
-@@ -1778,6 +1806,8 @@ window.__ModuleLoader__.load({
+@@ -1778,6 +1819,8 @@ window.__ModuleLoader__.load({
  			const [deleteFailure, setDeleteFailure] = (0, react.useState)(void 0);
  			const [savedTarget, setSavedTarget] = (0, react.useState)(void 0);
  			const [declaring, setDeclaring] = (0, react.useState)(false);
@@ -53,7 +91,7 @@ index 644a0f2..42e2f81 100644
  			const [dismissedSetup, setDismissedSetup] = (0, react.useState)(() => /* @__PURE__ */ new Set());
  			const announceSaved = (target) => {
  				controller.load().then(() => {
-@@ -1847,10 +1877,16 @@ window.__ModuleLoader__.load({
+@@ -1847,10 +1890,16 @@ window.__ModuleLoader__.load({
  			};
  			const anyUsable = state.rows.some(providerUsable);
  			const configured = state.rows.filter((row) => row.configured);
@@ -71,7 +109,7 @@ index 644a0f2..42e2f81 100644
  			return (0, react_jsx_runtime.jsxs)("div", {
  				className: ModelsSection_module_css_default["section"],
  				children: [
-@@ -1967,24 +2003,66 @@ window.__ModuleLoader__.load({
+@@ -1967,24 +2016,66 @@ window.__ModuleLoader__.load({
  							className: ModelsSection_module_css_default["addCard"],
  							children: [(0, react_jsx_runtime.jsxs)("div", {
  								className: ModelsSection_module_css_default["field"],
@@ -153,7 +191,7 @@ index 644a0f2..42e2f81 100644
  							}), (0, react_jsx_runtime.jsx)(ProviderEditor, {
  								provider: addTarget.provider,
  								displayName: addTarget.displayName,
-@@ -2027,6 +2105,8 @@ window.__ModuleLoader__.load({
+@@ -2027,6 +2118,8 @@ window.__ModuleLoader__.load({
  									setDeclaring(false);
  									setAdding(true);
  									setEditing(targetOf(first));
@@ -162,7 +200,7 @@ index 644a0f2..42e2f81 100644
  								},
  								children: [(0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconPlusOutline16, { size: 14 }), t("add")]
  							}), (0, react_jsx_runtime.jsxs)("button", {
-@@ -2135,7 +2215,7 @@ window.__ModuleLoader__.load({
+@@ -2135,7 +2228,7 @@ window.__ModuleLoader__.load({
  		}
  		//#endregion
  		//#region \0dsh-css:/home/runner/work/deepseek-harness/deepseek-harness/packages/client/ui-settings-models/src/client/DeepSeekOnboardingDialog.module.css.mjs
@@ -171,7 +209,7 @@ index 644a0f2..42e2f81 100644
  		const tagId$1 = "@deepseek-ai/dsh-client-ui-settings-models/DeepSeekOnboardingDialog.module.css";
  		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId$1) + "]") === null) {
  			const tag = document.createElement("style");
-@@ -2146,50 +2226,60 @@ window.__ModuleLoader__.load({
+@@ -2146,50 +2239,60 @@ window.__ModuleLoader__.load({
  		}
  		var DeepSeekOnboardingDialog_module_css_default = {
  			"description": "GL8Viq_description",
@@ -261,7 +299,7 @@ index 644a0f2..42e2f81 100644
  			const finishCredential = (changed) => {
  				if (!changed) {
  					complete();
-@@ -2199,28 +2289,54 @@ window.__ModuleLoader__.load({
+@@ -2199,28 +2302,54 @@ window.__ModuleLoader__.load({
  			};
  			return (0, react_jsx_runtime.jsxs)(OnboardingModal, {
  				title: t("onboardingTitle"),
@@ -321,7 +359,7 @@ index 644a0f2..42e2f81 100644
  				})]
  			});
  		}
-@@ -2457,6 +2573,8 @@ window.__ModuleLoader__.load({
+@@ -2457,6 +2586,8 @@ window.__ModuleLoader__.load({
  			deleting: "Deleting {provider}…",
  			add: "Add provider",
  			provider: "Provider",
@@ -330,7 +368,16 @@ index 644a0f2..42e2f81 100644
  			close: "Close",
  			cancel: "Cancel",
  			apply: "Apply",
-@@ -2530,10 +2648,14 @@ window.__ModuleLoader__.load({
+@@ -2511,6 +2642,8 @@ window.__ModuleLoader__.load({
+ 			fetchEmpty: "The provider listed no models. Add them by hand.",
+ 			fetchTitle: "Choose models to add",
+ 			fetchDescription: "These are the models this provider has available. Choose the ones to add.",
++			fetchSelectAll: "Select all",
++			fetchDeselectAll: "Deselect all",
+ 			fetchAdopt: "Add selected",
+ 			customAdd: "Add a custom provider",
+ 			customTitle: "Custom provider",
+@@ -2530,10 +2663,14 @@ window.__ModuleLoader__.load({
  			welcomeBody: WELCOME_NOTICE_COPY.en.body,
  			welcomeContinue: WELCOME_NOTICE_COPY.en.continueLabel,
  			welcomeError: "The acknowledgement could not be saved. Please try again.",
@@ -348,7 +395,7 @@ index 644a0f2..42e2f81 100644
  			onboardingSaving: "Saving…",
  			keyRequired: "Enter an API key to continue."
  		};
-@@ -2553,6 +2675,8 @@ window.__ModuleLoader__.load({
+@@ -2553,6 +2690,8 @@ window.__ModuleLoader__.load({
  			deleting: "正在删除 {provider}…",
  			add: "添加提供方",
  			provider: "提供方",
@@ -357,7 +404,16 @@ index 644a0f2..42e2f81 100644
  			close: "关闭",
  			cancel: "取消",
  			apply: "保存",
-@@ -2626,10 +2750,14 @@ window.__ModuleLoader__.load({
+@@ -2607,6 +2746,8 @@ window.__ModuleLoader__.load({
+ 			fetchEmpty: "该提供方没有列出任何模型，请手动添加。",
+ 			fetchTitle: "选择要添加的模型",
+ 			fetchDescription: "以下是模型提供方的可用模型，勾选要添加的模型。",
++			fetchSelectAll: "全选",
++			fetchDeselectAll: "取消全选",
+ 			fetchAdopt: "添加所选",
+ 			customAdd: "添加自定义提供方",
+ 			customTitle: "自定义提供方",
+@@ -2626,10 +2767,14 @@ window.__ModuleLoader__.load({
  			welcomeBody: WELCOME_NOTICE_COPY.zh.body,
  			welcomeContinue: WELCOME_NOTICE_COPY.zh.continueLabel,
  			welcomeError: "暂时无法保存确认状态，请重试。",

--- a/test/model-picker-patch.test.ts
+++ b/test/model-picker-patch.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = path.resolve(import.meta.dirname, '..')
+const patchPath = path.join(
+  projectRoot,
+  'patches',
+  '@deepseek-ai+dsh-client-ui-settings-models+0.1.0-rc.6.patch'
+)
+
+describe('DSH Desktop available-model picker', () => {
+  it('ships one state-driven select-all toggle in the patch', async () => {
+    const patch = await readFile(patchPath, 'utf8')
+
+    expect(patch).toContain('const allCandidatesPicked =')
+    expect(patch).toContain(
+      'candidates.every((candidate) => picked.has(candidate.id))'
+    )
+    expect(patch).toContain(
+      'children: t(allCandidatesPicked ? "fetchDeselectAll" : "fetchSelectAll")'
+    )
+    expect(patch).toContain('new Set(candidates.map((candidate) => candidate.id))')
+  })
+
+  it('includes English and Chinese copy for both toggle states', async () => {
+    const patch = await readFile(patchPath, 'utf8')
+
+    expect(patch).toContain('fetchSelectAll: "Select all"')
+    expect(patch).toContain('fetchDeselectAll: "Deselect all"')
+    expect(patch).toContain('fetchSelectAll: "全选"')
+    expect(patch).toContain('fetchDeselectAll: "取消全选"')
+  })
+})


### PR DESCRIPTION
## Summary

- add a single state-driven Select all / Deselect all action to the fetched-model picker
- show Deselect all only when every candidate is selected; otherwise show Select all
- include English and Chinese copy plus focused patch-contract coverage

## Testing

- `npm ci`
- `npm test` (39 passed)
- `npm run typecheck`
- `npm run build`

## Acceptance

- the arm64 DMG was reviewed and accepted locally before submission