### PR TITLE
Preserve desktop data across upgrades

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,6 +50,11 @@ function configureAppIdentity(): void {
   }
 
   app.setName('DSH Desktop')
+  // Keep the historical lowercase directory stable across product-name and
+  // branding changes. Harness stores workspaces, sessions, credentials, and
+  // custom presets below userData, so deriving this path from app.getName()
+  // would make an ordinary upgrade look like a fresh installation.
+  app.setPath('userData', join(app.getPath('appData'), 'dsh-desktop'))
 }
 
 async function syncNativeTheme(window: BrowserWindow): Promise<void> {

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -133,6 +133,7 @@ describe('GitHub release contract', () => {
     expect(developmentConfig).toContain("output: 'dist-dev'")
     expect(developmentConfig).toContain("dshDesktopChannel: 'development'")
     expect(main).toContain("app.setPath('userData', join(app.getPath('appData'), 'dsh-desktop-dev'))")
+    expect(main).toContain("app.setPath('userData', join(app.getPath('appData'), 'dsh-desktop'))")
     expect(main).toContain('if (!developmentBuild)')
   })
 


### PR DESCRIPTION
## Summary
- pin the formal app user-data directory to the historical lowercase `dsh-desktop` path
- keep the development app isolated in `dsh-desktop-dev`
- prevent branding changes from making an upgrade appear as a fresh installation

## User impact
Existing workspaces, sessions, model credentials, and custom Presets remain in place and are read again after upgrading.

## Verification
- `npm ci`
- `npm run typecheck`
- `npx vitest run --exclude doc/**` (55 tests passed)
- `git diff --check`
- `npm run package:dir`
- macOS ad-hoc code-sign verification