### PR TITLE
docs: add dsh-market friendship link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,9 @@ DeepSeek Harness already provides a complete agent runtime and Web UI. DSH Deskt
 - Imports and exports complete custom Agent presets as portable [`.dshpreset` packages](docs/preset-packages.md), with conflict checks and a trust warning before installation
 - Includes a production DSH app icon in macOS ICNS and Windows ICO formats
 
-## Model providers
+## Friends
 
-During initial setup, you can choose a model provider and enter its API key directly. DSH Desktop uses the real Harness Settings and Credentials APIs: the key is written only to the credential store, the corresponding provider route is created automatically, and its built-in model catalog is inherited without requiring model IDs to be entered manually.
-
-The initial setup currently includes:
-
-| Type | Providers |
-| --- | --- |
-| Model vendors | DeepSeek, OpenAI, Anthropic, Google Gemini, xAI, Moonshot/Kimi, MiniMax, Zhipu GLM, Mistral AI |
-| Model aggregation | OpenRouter |
-| Inference platforms | Groq, Together AI |
-
-Additional built-in or custom providers can be added from **Settings → Models** in Harness.
+[dsh-market](https://github.com/dsh-market/dsh-market) — the DeepSeek Harness plugin market: browse and search 900+ community plugins, preview screenshots, and install, update, enable or disable plugins, or switch themes with one click. Most plugins take effect instantly without a restart.
 
 ## Quick start
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -65,19 +65,9 @@ DeepSeek Harness 本身提供完整的 Agent Runtime 与 Web UI。DSH Desktop �
 - 可把完整的自定义 Agent 预设导入/导出为便携的 [`.dshpreset` 压缩包](docs/preset-packages.md)，安装前会检查命名冲突并提示信任风险
 - 正式 DSH 应用图标，支持 macOS ICNS 与 Windows ICO
 
-## 模型提供方
+## 友情链接
 
-首次配置时可选择模型提供方并直接填写 API Key。DSH Desktop 复用 Harness 的真实 Settings/Credentials API：Key 只写入凭据存储，对应 Provider 路由会自动创建，并继承其内置模型目录，无需手工填写模型 ID。
-
-当前首启列表包括：
-
-| 类型 | Provider |
-| --- | --- |
-| 模型厂商 | DeepSeek、OpenAI、Anthropic、Google Gemini、xAI、Moonshot/Kimi、MiniMax、智谱 GLM、Mistral AI |
-| 模型聚合平台 | OpenRouter |
-| 推理服务平台 | Groq、Together AI |
-
-更多内置或自定义 Provider 可以在 Harness 的“设置 → 模型”中添加。
+[dsh-market](https://github.com/dsh-market/dsh-market) — DeepSeek Harness 插件市场：浏览、搜索社区 900+ 插件，截图预览、一键安装 / 更新 / 启停 / 换主题，多数插件免重启即时生效。
 
 ## 快速开始
 

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -98,7 +98,7 @@ describe('GitHub release contract', () => {
     ) as {
       dependencies: Record<string, string>
       build: {
-        publish: Array<{ provider: string; owner: string; repo: string }>
+        publish: Array<{ provider: string; url: string }>
         win: { verifyUpdateCodeSignature: boolean }
       }
     }
@@ -109,7 +109,7 @@ describe('GitHub release contract', () => {
 
     expect(packageJson.dependencies['electron-updater']).toBeTruthy()
     expect(packageJson.build.publish).toEqual([
-      { provider: 'github', owner: 'dataelement', repo: 'dsh-desktop' }
+      { provider: 'generic', url: 'https://dshdesktop.com/updates/latest/' }
     ])
     expect(packageJson.build.win.verifyUpdateCodeSignature).toBe(false)
     for (const asset of [


### PR DESCRIPTION
## What changed

- replace the outdated model-provider section in both READMEs with a Friends/友情链接 entry for dsh-market
- place the friendship entry immediately before Quick start/快速开始
- keep the English and Chinese documentation aligned
- align the release-contract test with the generic update source already configured on main

## Why

dsh-market lists DSH Desktop in its Friends section, and DSH Desktop now reciprocates with a concise description of the community plugin market.

The release test still expected the previous GitHub updater provider after main switched to the official generic update endpoint, which made every new PR fail independently of its diff.

## Validation

- `git diff --check`
- verified heading order in both README files
- verified the live registry currently contains more than 900 plugins
- `npm test` (59 passed)
- `npm run typecheck`
- `npm run build`
