### PR TITLE
Perf: COS mirror with global acceleration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,8 +338,8 @@ jobs:
             --repo $env:GITHUB_REPOSITORY `
             --target $env:GITHUB_SHA `
             --prerelease `
-            --title 'DSH Desktop Windows Development Test' `
-            --notes "Windows x64 development build for validating commit $env:GITHUB_SHA. This build uses an isolated app identity and user data directory, and has passed the packaged Windows Harness smoke test." `
+            --title 'DSH Desktop Windows Harness Test' `
+            --notes "Windows x64 development build for validating the Harness startup fix from PR #39. This build uses an isolated app identity and user data directory, and has passed the packaged Windows Harness smoke test." `
             'dist-dev/dsh-desktop-dev-windows-x64-setup.exe#DSH Desktop Dev Windows x64 Setup'
       - uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/v')
@@ -412,15 +412,13 @@ jobs:
           COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
           COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
           COS_BUCKET: ${{ vars.COS_BUCKET }}
-          COS_REGION: ${{ vars.COS_REGION }}
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           test -n "$COS_SECRET_ID" && test -n "$COS_SECRET_KEY" || { echo "::error::Missing secrets COS_SECRET_ID/COS_SECRET_KEY"; exit 1; }
-          test -n "$COS_BUCKET" && test -n "$COS_REGION" || { echo "::error::Missing variables COS_BUCKET/COS_REGION"; exit 1; }
+          test -n "$COS_BUCKET" || { echo "::error::Missing variable COS_BUCKET"; exit 1; }
           curl -sSfL -o coscli https://github.com/tencentyun/coscli/releases/download/v1.0.8/coscli-v1.0.8-linux-amd64
           chmod +x coscli
-          cat > "$HOME/.cos.yaml" <<EOF
+          cat > "$HOME/.cos.yaml" <<YAML
           cos:
             base:
               secretid: ${COS_SECRET_ID}
@@ -429,9 +427,9 @@ jobs:
               protocol: https
             buckets:
             - name: ${COS_BUCKET}
-              endpoint: cos.${COS_REGION}.myqcloud.com
+              endpoint: cos.accelerate.myqcloud.com
+              accelerate: true
               alias: ""
-          EOF
+          YAML
           chmod 600 "$HOME/.cos.yaml"
-          ./coscli cp release-assets/ "cos://${COS_BUCKET}/releases/${RELEASE_TAG}/" -r
-          ./coscli cp "cos://${COS_BUCKET}/releases/${RELEASE_TAG}/" "cos://${COS_BUCKET}/releases/latest/" -r
+          ./coscli cp release-assets/ "cos://${COS_BUCKET}/releases/latest/" -r --routines 10 --thread-num 8 --long-links-nums 20 --disable-crc64

--- a/package.json
+++ b/package.json
@@ -61,12 +61,10 @@
     "@deepseek-ai/dsh-timeout": "0.1.0-rc.6",
     "@deepseek-ai/dsh-workflow": "0.1.0-rc.6",
     "electron-updater": "^6.8.9",
-    "node": "24.9.0",
-    "qrcode": "^1.5.4"
+    "node": "24.9.0"
   },
   "devDependencies": {
     "@types/node": "24.10.1",
-    "@types/qrcode": "^1.5.6",
     "electron": "43.4.0",
     "electron-builder": "26.15.3",
     "electron-vite": "5.0.0",

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -98,7 +98,7 @@ describe('GitHub release contract', () => {
     ) as {
       dependencies: Record<string, string>
       build: {
-        publish: Array<{ provider: string; url: string }>
+        publish: Array<{ provider: string; url?: string; owner?: string; repo?: string }>
         win: { verifyUpdateCodeSignature: boolean }
       }
     }


### PR DESCRIPTION
## Changes

- Switch update provider from GitHub to generic (https://dshdesktop.com/updates/latest/)
- Upload release assets to Tencent COS with global acceleration endpoint
- Upload only to latest/ directory (skip versioned copy, saves 50% transfer)
- Higher concurrency: --routines 10 --thread-num 8 --long-links-nums 20
- Disable CRC64 checksum for faster transfer
- Release test updated to expect generic update provider