### PR TITLE
feat: add Linux packaging support (AppImage + deb)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "package:mac": "npm run build && electron-builder --mac --publish never",
     "package:mac:arm64": "node scripts/verify-target.mjs darwin arm64 && npm run build && electron-builder --mac --arm64 --publish never",
     "package:mac:x64": "node scripts/verify-target.mjs darwin x64 && npm run build && electron-builder --mac --x64 --publish never",
-    "package:win": "node scripts/verify-target.mjs win32 x64 && npm run build && electron-builder --win --x64 --publish never"
+    "package:win": "node scripts/verify-target.mjs win32 x64 && npm run build && electron-builder --win --x64 --publish never",
+    "package:linux": "node scripts/verify-target.mjs linux x64 && npm run build && electron-builder --linux --publish never"
   },
   "dependencies": {
     "@deepseek-ai/cordis-plugin-group": "1.0.1",
@@ -153,6 +154,33 @@
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true
+    },
+    "linux": {
+      "icon": "build/icon.png",
+      "category": "Development",
+      "maintainer": "dsh-desktop",
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "syncDesktopName": true
+    },
+    "appImage": {
+      "artifactName": "dsh-desktop-${os}-${arch}.${ext}"
+    },
+    "deb": {
+      "artifactName": "dsh-desktop-${os}-${arch}.${ext}"
     }
-  }
+  },
+  "desktopName": "dsh-desktop"
 }


### PR DESCRIPTION
## Summary

Adds Linux packaging support so DSH Desktop can be built and distributed for Linux, mirroring the existing macOS/Windows package scripts.

Changes (all in `package.json`):
- **`linux` builder target**: AppImage + deb for x64, `Development` category, `syncDesktopName: true` for correct WM_CLASS/desktop-entry window association
- **`package:linux` script**: `verify-target.mjs linux x64 && electron-builder --linux --publish never` — same pattern as `package:mac*` / `package:win`
- **top-level `desktopName`** for desktop-environment window association (resolves the electron-builder warning about missing desktopName)

## Why

The app already supports Linux at runtime — the main process code has generic branches for PATH/node executable/window frame, and all native deps (`node-pty`, `koffi`, `sharp`) ship Linux prebuilds or compile on Linux — only the packaging targets were missing. No runtime code changes were needed.

## Verified

- Built on Arch Linux x64: `npm install` → `npm run package:linux` succeeds (AppImage + deb)
- Packaged app launches: window appears, bundled Harness server starts on a random loopback port and serves the UI
- `dsh-desktop.patch.yml` (native directory picker) works as-is on Linux

## Known limitations

- Auto-update remains macOS/Windows only by design (`update-policy.ts` `supportsAutoUpdates`); Linux builds report `updater status unsupported` — fine for first-party packaging, worth revisiting later (AppImageUpdate)
- AppImage on Wayland + Vulkan (Electron 43) can hit a GPU-process failure (`GPU process isn't usable`) in some environments; `--ozone-platform=x11` or `--disable-gpu` works around it. Unpacked builds are unaffected. This appears to be an Electron/Wayland issue rather than something this change introduces
- No CI job added yet for Linux — local `package:linux` only, to keep the change minimal

## Test plan

- [ ] `npm run package:linux` produces `dist/dsh-desktop-linux-x86_64.AppImage` and `dist/dsh-desktop-linux-amd64.deb`
- [ ] macOS/Windows packaging scripts still work (no changes to their config)