### PR TITLE
fix(market-installer): ensure bundled Node and pnpm runtimes are used for plugin installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "dsh-desktop-market-installer": "file:packages/dsh-desktop-market-installer",
         "electron-updater": "^6.8.9",
         "node": "24.9.0",
+        "pnpm": "10.34.5",
         "qrcode": "^1.5.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "dsh-desktop-market-installer": "file:packages/dsh-desktop-market-installer",
     "electron-updater": "^6.8.9",
     "node": "24.9.0",
+    "pnpm": "10.34.5",
     "qrcode": "^1.5.4"
   },
   "devDependencies": {

--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -121,9 +121,17 @@ export async function ensurePnpmShim(home = dshHome()) {
 
   if (process.platform === 'win32') {
     const pnpmPath = join(directory, 'pnpm.cmd')
-    await writeFile(pnpmPath, `@echo off\r\n\"${executable}\" \"${pnpmEntry}\" %*\r\n`, 'utf8')
+    await writeFile(
+      pnpmPath,
+      `@chcp 65001 >nul\r\n@echo off\r\n\"${executable}\" \"${pnpmEntry}\" %*\r\n`,
+      'utf8'
+    )
     const nodePath = join(directory, 'node.cmd')
-    await writeFile(nodePath, `@echo off\r\n\"${executable}\" %*\r\n`, 'utf8')
+    await writeFile(
+      nodePath,
+      `@chcp 65001 >nul\r\n@echo off\r\n\"${executable}\" %*\r\n`,
+      'utf8'
+    )
   } else {
     const pnpmPath = join(directory, 'pnpm')
     await writeFile(
@@ -275,9 +283,17 @@ export function apply(ctx) {
       if (error?.code !== 'ENOENT') throw error
     }
 
+    const pathKey = process.platform === 'win32' ? 'Path' : 'PATH'
+    const envPath = process.env[pathKey] ?? process.env.PATH ?? process.env.Path ?? ''
     const child = spawn(process.execPath, buildInstallArguments(), {
       cwd: directory,
-      env: { ...process.env, CI: 'true', NO_COLOR: '1' },
+      env: {
+        ...process.env,
+        PATH: envPath,
+        Path: envPath,
+        CI: 'true',
+        NO_COLOR: '1'
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
       detached: process.platform !== 'win32'
@@ -351,9 +367,17 @@ export function apply(ctx) {
       if (error?.code !== 'ENOENT') throw error
     }
 
+    const pathKey = process.platform === 'win32' ? 'Path' : 'PATH'
+    const envPath = process.env[pathKey] ?? process.env.PATH ?? process.env.Path ?? ''
     const child = spawn(process.execPath, buildUninstallArguments(), {
       cwd: directory,
-      env: { ...process.env, CI: 'true', NO_COLOR: '1' },
+      env: {
+        ...process.env,
+        PATH: envPath,
+        Path: envPath,
+        CI: 'true',
+        NO_COLOR: '1'
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
       detached: process.platform !== 'win32'

--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -120,21 +120,38 @@ export async function ensurePnpmShim(home = dshHome()) {
   const executable = process.execPath
 
   if (process.platform === 'win32') {
-    const path = join(directory, 'pnpm.cmd')
-    await writeFile(path, `@\"${executable}\" \"${pnpmEntry}\" %*\r\n`, 'utf8')
+    const pnpmPath = join(directory, 'pnpm.cmd')
+    await writeFile(pnpmPath, `@\"${executable}\" \"${pnpmEntry}\" %*\r\n`, 'utf8')
+    const nodePath = join(directory, 'node.cmd')
+    await writeFile(nodePath, `@\"${executable}\" %*\r\n`, 'utf8')
   } else {
-    const path = join(directory, 'pnpm')
+    const pnpmPath = join(directory, 'pnpm')
     await writeFile(
-      path,
+      pnpmPath,
       `#!/bin/sh\nexec ${shellQuote(executable)} ${shellQuote(pnpmEntry)} \"$@\"\n`,
       { encoding: 'utf8', mode: 0o755 }
     )
-    await chmod(path, 0o755)
+    await chmod(pnpmPath, 0o755)
+    const nodePath = join(directory, 'node')
+    await writeFile(
+      nodePath,
+      `#!/bin/sh\nexec ${shellQuote(executable)} \"$@\"\n`,
+      { encoding: 'utf8', mode: 0o755 }
+    )
+    await chmod(nodePath, 0o755)
   }
 
-  const current = process.env.PATH ?? ''
-  if (!current.split(delimiter).includes(directory)) {
-    process.env.PATH = current ? `${directory}${delimiter}${current}` : directory
+  const nodeDir = dirname(executable)
+  const pathKey = process.platform === 'win32' ? 'Path' : 'PATH'
+  const current = process.env[pathKey] ?? process.env.PATH ?? process.env.Path ?? ''
+  const parts = current.split(delimiter).filter(Boolean)
+  const additions = [directory, nodeDir].filter((dir) => !parts.includes(dir))
+  if (additions.length > 0) {
+    const updated = [...additions, current].filter(Boolean).join(delimiter)
+    process.env.PATH = updated
+    if (process.platform === 'win32') {
+      process.env.Path = updated
+    }
   }
   return directory
 }

--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -121,9 +121,9 @@ export async function ensurePnpmShim(home = dshHome()) {
 
   if (process.platform === 'win32') {
     const pnpmPath = join(directory, 'pnpm.cmd')
-    await writeFile(pnpmPath, `@\"${executable}\" \"${pnpmEntry}\" %*\r\n`, 'utf8')
+    await writeFile(pnpmPath, `@echo off\r\n\"${executable}\" \"${pnpmEntry}\" %*\r\n`, 'utf8')
     const nodePath = join(directory, 'node.cmd')
-    await writeFile(nodePath, `@\"${executable}\" %*\r\n`, 'utf8')
+    await writeFile(nodePath, `@echo off\r\n\"${executable}\" %*\r\n`, 'utf8')
   } else {
     const pnpmPath = join(directory, 'pnpm')
     await writeFile(

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -10,6 +10,7 @@ import {
   UNINSTALL_PATH,
   buildInstallArguments,
   buildUninstallArguments,
+  ensurePnpmShim,
   isTrustedRequest,
   readMarketInstallation,
   resolvePnpmEntry
@@ -43,6 +44,26 @@ describe('desktop plugin market installer', () => {
 
   it('ships a resolvable pnpm binary instead of relying on the user PATH', () => {
     expect(resolvePnpmEntry()).toMatch(/node_modules[/\\]pnpm[/\\]bin[/\\]pnpm\.(c|m)js$/u)
+  })
+
+  it('generates packaged node and pnpm shims in desktop-bin', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-market-shim-'))
+    const binDir = await ensurePnpmShim(home)
+    expect(binDir).toBe(join(home, '.desktop-bin'))
+
+    if (process.platform === 'win32') {
+      const pnpmCmd = await readFile(join(binDir, 'pnpm.cmd'), 'utf8')
+      const nodeCmd = await readFile(join(binDir, 'node.cmd'), 'utf8')
+      expect(pnpmCmd).toContain(process.execPath)
+      expect(pnpmCmd).toContain('pnpm')
+      expect(nodeCmd).toContain(process.execPath)
+    } else {
+      const pnpmScript = await readFile(join(binDir, 'pnpm'), 'utf8')
+      const nodeScript = await readFile(join(binDir, 'node'), 'utf8')
+      expect(pnpmScript).toContain(process.execPath)
+      expect(pnpmScript).toContain('pnpm')
+      expect(nodeScript).toContain(process.execPath)
+    }
   })
 
   it('reports both the requested dependency and installed package version', async () => {


### PR DESCRIPTION
### Summary

- **Bundled pnpm dependency**: Added `pnpm: 10.34.5` directly to root `package.json` dependencies to ensure it is always included in the packaged Electron distribution.
- **Node & pnpm Shims**: Enhanced `ensurePnpmShim` in `packages/dsh-desktop-market-installer` to generate shims for both `pnpm` and `node` (supporting `.cmd` on Windows and executable shell scripts on POSIX), pointing directly to the app's bundled Node runtime (`process.execPath`).
- **Path Resolution**: Prepended both the `.desktop-bin` directory and the bundled Node runtime directory to `PATH` (handling Windows `Path`/`PATH` case differences), guaranteeing that any plugin install or subprocess runs with the bundled runtimes without requiring a system Node.js install.
- **Tests**: Added test assertions to `test/market-installer.test.js` to verify that both `node` and `pnpm` shims are properly generated.