### PR TITLE
fix: allow Windows drive-root installation

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,63 @@
+!ifndef BUILD_UNINSTALLER
+  !ifndef ONE_CLICK
+    !include "LogicLib.nsh"
+    !include "nsDialogs.nsh"
+
+    Var DshDirectoryPage
+    Var DshDirectoryEdit
+    Var DshDirectoryNormalizationActive
+
+    ; MUI invokes this after the assisted installer's directory page is ready.
+    ; Normalize a selected drive root immediately so the page does not reject it
+    ; before electron-builder's later install-time sanitization can run.
+    !define MUI_PAGE_CUSTOMFUNCTION_SHOW DshDirectoryPageShow
+
+    Function DshDirectoryPageShow
+      FindWindow $DshDirectoryPage "#32770" "" $HWNDPARENT
+      GetDlgItem $DshDirectoryEdit $DshDirectoryPage 1019
+      ${NSD_OnChange} $DshDirectoryEdit DshDirectoryChanged
+      Call DshNormalizeDriveRoot
+    FunctionEnd
+
+    Function DshDirectoryChanged
+      Pop $0
+      Call DshNormalizeDriveRoot
+    FunctionEnd
+
+    Function DshNormalizeDriveRoot
+      ${If} $DshDirectoryNormalizationActive == "1"
+        Return
+      ${EndIf}
+
+      ${NSD_GetText} $DshDirectoryEdit $0
+      StrLen $1 $0
+
+      ; Accept both forms produced by typing or the Windows folder picker:
+      ; "D:" and "D:\". Any non-root directory is left untouched.
+      ${If} $1 == 2
+        StrCpy $2 $0 1 1
+        ${If} $2 != ":"
+          Return
+        ${EndIf}
+        StrCpy $3 "$0\${APP_FILENAME}"
+      ${ElseIf} $1 == 3
+        StrCpy $2 $0 1 1
+        ${If} $2 != ":"
+          Return
+        ${EndIf}
+        StrCpy $2 $0 1 2
+        ${If} $2 != "\"
+          Return
+        ${EndIf}
+        StrCpy $3 "$0${APP_FILENAME}"
+      ${Else}
+        Return
+      ${EndIf}
+
+      StrCpy $DshDirectoryNormalizationActive "1"
+      StrCpy $INSTDIR $3
+      ${NSD_SetText} $DshDirectoryEdit $3
+      StrCpy $DshDirectoryNormalizationActive "0"
+    FunctionEnd
+  !endif
+!endif

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     },
     "nsis": {
       "artifactName": "dsh-desktop-windows-${arch}-setup.${ext}",
+      "include": "build/installer.nsh",
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -50,7 +50,7 @@ describe('GitHub release contract', () => {
         artifactName: string
         extraResources: Array<{ from: string; to: string }>
         win: { target: Array<{ target: string; arch: string[] }> }
-        nsis: { artifactName: string }
+        nsis: { artifactName: string; include: string }
         portable?: unknown
       }
     }
@@ -71,8 +71,22 @@ describe('GitHub release contract', () => {
     expect(packageJson.build.nsis.artifactName).toBe(
       'dsh-desktop-windows-${arch}-setup.${ext}'
     )
+    expect(packageJson.build.nsis.include).toBe('build/installer.nsh')
     expect(packageJson.build.win.target).toEqual([{ target: 'nsis', arch: ['x64'] }])
     expect(packageJson.build.portable).toBeUndefined()
+  })
+
+  it('turns a selected Windows drive root into an application directory', async () => {
+    const installer = await readFile(
+      path.join(projectRoot, 'build', 'installer.nsh'),
+      'utf8'
+    )
+
+    expect(installer).toContain('!define MUI_PAGE_CUSTOMFUNCTION_SHOW DshDirectoryPageShow')
+    expect(installer).toContain('${NSD_OnChange} $DshDirectoryEdit DshDirectoryChanged')
+    expect(installer).toContain('StrCpy $3 "$0\\${APP_FILENAME}"')
+    expect(installer).toContain('StrCpy $3 "$0${APP_FILENAME}"')
+    expect(installer).toContain('${NSD_SetText} $DshDirectoryEdit $3')
   })
 
   it('shows a packaged startup surface and pins the Electron directory picker surface', async () => {


### PR DESCRIPTION
## What changed

- add an NSIS directory-page hook for assisted Windows installs
- turn a selected drive root such as `D:\` into `D:\DSH Desktop`
- reuse the configured product filename so development builds use `D:\DSH Desktop Dev`
- keep explicitly selected non-root directories unchanged
- add release-contract coverage for the custom installer include

## Why

NSIS rejects a bare drive root on the directory page before electron-builder's later install-time path sanitization runs. As a result, selecting `D:\` disables the Install button even though installing into a child application directory is valid.

The new hook normalizes drive roots as soon as the directory field changes, allowing users to choose a drive without manually creating or typing an application subdirectory.

## Validation

- `npm test -- --run` — 80 tests passed
- `npm run typecheck`
- `npm run build`
- formal Windows x64 NSIS installer compiled successfully
- development Windows x64 NSIS installer compiled successfully
- `git diff --check`
