### PR TITLE
ci: switch release asset mirror from Tencent COS to ModelScope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -442,29 +442,31 @@ jobs:
               --title "DSH Desktop $RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY"
           fi
-      - name: Mirror release assets to Tencent COS
+      - name: Mirror release assets to ModelScope
         env:
-          COS_SECRET_ID: ${{ secrets.COS_SECRET_ID }}
-          COS_SECRET_KEY: ${{ secrets.COS_SECRET_KEY }}
-          COS_BUCKET: ${{ vars.COS_BUCKET }}
+          MODELSCOPE_TOKEN: ${{ secrets.MODELSCOPE_TOKEN }}
+          MODELSCOPE_REPO_ID: alexyaojin/dsh-desktop
         run: |
           set -euo pipefail
-          test -n "$COS_SECRET_ID" && test -n "$COS_SECRET_KEY" || { echo "::error::Missing secrets COS_SECRET_ID/COS_SECRET_KEY"; exit 1; }
-          test -n "$COS_BUCKET" || { echo "::error::Missing variable COS_BUCKET"; exit 1; }
-          curl -sSfL -o coscli https://github.com/tencentyun/coscli/releases/download/v1.0.8/coscli-v1.0.8-linux-amd64
-          chmod +x coscli
-          cat > "$HOME/.cos.yaml" <<YAML
-          cos:
-            base:
-              secretid: ${COS_SECRET_ID}
-              secretkey: ${COS_SECRET_KEY}
-              sessiontoken: ""
-              protocol: https
-            buckets:
-            - name: ${COS_BUCKET}
-              endpoint: cos.accelerate.myqcloud.com
-              accelerate: true
-              alias: ""
-          YAML
-          chmod 600 "$HOME/.cos.yaml"
-          ./coscli cp release-assets/ "cos://${COS_BUCKET}/releases/latest/" -r --routines 10 --thread-num 8 --long-links-nums 20 --disable-crc64
+          test -n "$MODELSCOPE_TOKEN" || { echo "::error::Missing secret MODELSCOPE_TOKEN"; exit 1; }
+          python3 -m venv "$RUNNER_TEMP/ms-env"
+          "$RUNNER_TEMP/ms-env/bin/pip" install -q modelscope
+          "$RUNNER_TEMP/ms-env/bin/python3" <<'PY'
+          import os, pathlib
+          from modelscope.hub.api import HubApi
+
+          api = HubApi()
+          token = os.environ["MODELSCOPE_TOKEN"]
+          repo_id = os.environ["MODELSCOPE_REPO_ID"]
+          tag = os.environ.get("GITHUB_REF_NAME", "unknown")
+          src = pathlib.Path("release-assets")
+
+          api.upload_folder(
+              repo_id=repo_id,
+              folder_path=str(src),
+              path_in_repo="releases/latest",
+              commit_message=f"Release {tag}",
+              token=token,
+          )
+          print(f"✅ Uploaded {src} -> {repo_id}/releases/latest")
+          PY


### PR DESCRIPTION
## Changes

Replace Tencent COS (`coscli`) mirror step in `release.yml` with ModelScope upload using `modelscope` Python SDK.

- Removed `COS_SECRET_ID`, `COS_SECRET_KEY`, `COS_BUCKET` dependencies
- Added `MODELSCOPE_TOKEN` secret (already configured)
- Target repo: `alexyaojin/dsh-desktop/releases/latest/`

## Secrets required

| Name | Type | Status |
|------|------|--------|
| `MODELSCOPE_TOKEN` | Secret | ✅ Configured |

## Verified

- Token upload test passed against `alexyaojin/dsh-desktop`
- YAML syntax validated