### PR TITLE
fix: 补全预设分组缺失的中英文翻译

### DIFF
--- a/patches/@deepseek-ai+dsh-client-ui-agent-preset+0.1.0-rc.7.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-agent-preset+0.1.0-rc.7.patch
@@ -2,7 +2,7 @@ diff --git a/node_modules/@deepseek-ai/dsh-client-ui-agent-preset/lib/client.js 
 index 259765c..ca9dd68 100644
 --- a/node_modules/@deepseek-ai/dsh-client-ui-agent-preset/lib/client.js
 +++ b/node_modules/@deepseek-ai/dsh-client-ui-agent-preset/lib/client.js
-@@ -64,7 +64,30 @@ window.__ModuleLoader__.load({
+@@ -64,7 +64,32 @@ window.__ModuleLoader__.load({
  			deleteTitle: "Delete this preset?",
  			deleteDescription: "The preset directory is deleted. Sessions already running on it keep working; new sessions cannot select it.",
  			deleteConfirm: "Delete",
@@ -12,6 +12,8 @@ index 259765c..ca9dd68 100644
 +			awesomePreset: "Awesome preset",
 +			searchPresets: "Search modes…",
 +			recentPresets: "Recent",
++			builtInGroup: "Built-in",
++			customGroup: "Custom",
 +			noMatchingPresets: "No matching modes",
 +			browseAwesomePresets: "Browse Awesome Presets…",
 +			exportPreset: "Export preset",
@@ -34,7 +36,7 @@ index 259765c..ca9dd68 100644
  		};
  		/** Simplified Chinese copy. */
  		const zh = {
-@@ -120,7 +143,30 @@ window.__ModuleLoader__.load({
+@@ -120,7 +145,32 @@ window.__ModuleLoader__.load({
  			deleteTitle: "删除该预设？",
  			deleteDescription: "预设目录将被删除。已在其上运行的会话不受影响；新会话将无法再选择它。",
  			deleteConfirm: "删除",
@@ -44,6 +46,8 @@ index 259765c..ca9dd68 100644
 +			awesomePreset: "Awesome preset",
 +			searchPresets: "搜索模式…",
 +			recentPresets: "最近使用",
++			builtInGroup: "内置",
++			customGroup: "自定义",
 +			noMatchingPresets: "没有匹配的模式",
 +			browseAwesomePresets: "浏览 Awesome Presets…",
 +			exportPreset: "导出预设",
@@ -66,7 +70,7 @@ index 259765c..ca9dd68 100644
  		};
  		const BUILT_IN_PRESET_KEYS = {
  			standard: {
-@@ -333,7 +379,7 @@ window.__ModuleLoader__.load({
+@@ -333,7 +383,7 @@ window.__ModuleLoader__.load({
  		}
  		//#endregion
  		//#region \0dsh-css:/home/runner/work/deepseek-harness/deepseek-harness/packages/client/ui-agent-preset/src/client/AgentPresetSeat.module.css.mjs
@@ -75,7 +79,7 @@ index 259765c..ca9dd68 100644
  		const tagId$1 = "@deepseek-ai/dsh-client-ui-agent-preset/AgentPresetSeat.module.css";
  		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId$1) + "]") === null) {
  			const tag = document.createElement("style");
-@@ -346,6 +392,21 @@ window.__ModuleLoader__.load({
+@@ -346,6 +396,21 @@ window.__ModuleLoader__.load({
  			"seatIcon": "cubgiG_seatIcon",
  			"introChar": "cubgiG_introChar",
  			"chevron": "cubgiG_chevron",
@@ -97,7 +101,7 @@ index 259765c..ca9dd68 100644
  			"itemName": "cubgiG_itemName",
  			"introIcon": "cubgiG_introIcon",
  			"itemDesc": "cubgiG_itemDesc",
-@@ -374,6 +435,8 @@ window.__ModuleLoader__.load({
+@@ -374,6 +439,8 @@ window.__ModuleLoader__.load({
  		const INTRO_CHAR_STAGGER_MS = 40;
  		const INTRO_TEXT_REVEAL_MS = 200;
  		const INTRO_CHAR_FADE_MS = 400;
@@ -106,7 +110,7 @@ index 259765c..ca9dd68 100644
  		/**
  		* Per-character start offset for the introduce reveal.
  		* @param count - character count of the shown preset name.
-@@ -391,6 +454,15 @@ window.__ModuleLoader__.load({
+@@ -391,6 +458,15 @@ window.__ModuleLoader__.load({
  		function AgentPresetSeat({ load, select, introduced, useAgentPresetSeat, t }) {
  			const state = useAgentPresetSeat((snapshot) => snapshot);
  			const [open, setOpen] = (0, react.useState)(false);
@@ -122,7 +126,7 @@ index 259765c..ca9dd68 100644
  			(0, react.useEffect)(() => {
  				load();
  			}, [load]);
-@@ -430,34 +502,114 @@ window.__ModuleLoader__.load({
+@@ -430,34 +506,114 @@ window.__ModuleLoader__.load({
  					children: character
  				}, index))
  			}) : label;
@@ -253,7 +257,7 @@ index 259765c..ca9dd68 100644
  				anchor: (0, react_jsx_runtime.jsxs)("button", {
  					type: "button",
  					className: AgentPresetSeat_module_css_default.seat,
-@@ -707,6 +859,8 @@ window.__ModuleLoader__.load({
+@@ -707,6 +863,8 @@ window.__ModuleLoader__.load({
  			rows: [],
  			copy: null,
  			view: null,
@@ -262,7 +266,7 @@ index 259765c..ca9dd68 100644
  			pendingDelete: null,
  			deleting: false,
  			revealedPaths: {}
-@@ -724,6 +878,13 @@ window.__ModuleLoader__.load({
+@@ -724,6 +882,13 @@ window.__ModuleLoader__.load({
  			if (!PRESET_ID.test(draft.id)) return "idInvalid";
  			if (rows.some((row) => row.id === draft.id)) return "idTaken";
  		}
@@ -276,7 +280,7 @@ index 259765c..ca9dd68 100644
  		/** Reads the roster and drives the copy dialog, viewer, and location reveals. */
  		var AgentPresetSectionController = class {
  			api;
-@@ -911,6 +1072,143 @@ window.__ModuleLoader__.load({
+@@ -911,6 +1076,143 @@ window.__ModuleLoader__.load({
  					this.set({ error: messageOf(error) });
  				}
  			}
@@ -420,7 +424,7 @@ index 259765c..ca9dd68 100644
  			/**
  			* Ask for confirmation before deleting one preset.
  			* @param id - the preset to delete, or null to dismiss the confirmation.
-@@ -974,16 +1272,25 @@ window.__ModuleLoader__.load({
+@@ -974,16 +1276,25 @@ window.__ModuleLoader__.load({
  		};
  		//#endregion
  		//#region \0dsh-css:/home/runner/work/deepseek-harness/deepseek-harness/packages/client/ui-agent-preset/src/client/AgentPresetSection.module.css.mjs
@@ -448,7 +452,7 @@ index 259765c..ca9dd68 100644
  			"brokenBadge": "rtSEdW_brokenBadge",
  			"inUse": "rtSEdW_inUse",
  			"cards": "rtSEdW_cards",
-@@ -1104,6 +1411,84 @@ window.__ModuleLoader__.load({
+@@ -1104,6 +1415,84 @@ window.__ModuleLoader__.load({
  				})
  			});
  		}
@@ -533,7 +537,7 @@ index 259765c..ca9dd68 100644
  		/**
  		* Render one card's description, clamped by CSS and offered in full on hover.
  		* The tooltip is attached only while the text is actually cut off, so a short
-@@ -1151,6 +1536,7 @@ window.__ModuleLoader__.load({
+@@ -1151,6 +1540,7 @@ window.__ModuleLoader__.load({
  		function AgentPresetSection(props) {
  			const { useAgentPresetSection, t, load } = props;
  			const state = useAgentPresetSection((snapshot) => snapshot);
@@ -541,7 +545,7 @@ index 259765c..ca9dd68 100644
  			const viewedId = state.view?.id;
  			const viewedRow = viewedId === void 0 ? void 0 : state.rows.find((row) => row.id === viewedId);
  			const viewedTitle = state.view === null ? "" : viewedRow === void 0 ? state.view.title : presetDisplayText(viewedRow, t).name;
-@@ -1191,9 +1577,40 @@ window.__ModuleLoader__.load({
+@@ -1191,9 +1581,40 @@ window.__ModuleLoader__.load({
  			return (0, react_jsx_runtime.jsxs)("div", {
  				className: AgentPresetSection_module_css_default.section,
  				children: [
@@ -585,7 +589,7 @@ index 259765c..ca9dd68 100644
  					}),
  					(0, react_jsx_runtime.jsx)("p", {
  						className: AgentPresetSection_module_css_default.intro,
-@@ -1289,7 +1706,7 @@ window.__ModuleLoader__.load({
+@@ -1289,7 +1710,7 @@ window.__ModuleLoader__.load({
  														},
  														children: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconFolderOpenOutline16, {})
  													}),
@@ -594,7 +598,7 @@ index 259765c..ca9dd68 100644
  														type: "button",
  														className: AgentPresetSection_module_css_default.iconButton,
  														disabled: !state.authorable || row.broken !== void 0,
-@@ -1298,9 +1715,20 @@ window.__ModuleLoader__.load({
+@@ -1298,9 +1719,20 @@ window.__ModuleLoader__.load({
  														onClick: () => {
  															props.beginCopy(row.id);
  														},
@@ -618,7 +622,7 @@ index 259765c..ca9dd68 100644
  														type: "button",
  														className: `${AgentPresetSection_module_css_default.iconButton} ${AgentPresetSection_module_css_default.iconDanger}`,
  														"data-tip": t("delete"),
-@@ -1329,13 +1757,22 @@ window.__ModuleLoader__.load({
+@@ -1329,13 +1761,22 @@ window.__ModuleLoader__.load({
  					(0, react_jsx_runtime.jsx)(CopyDialog, {
  						state,
  						t,
@@ -644,7 +648,7 @@ index 259765c..ca9dd68 100644
  					(0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Modal, {
  						open: state.view !== null,
  						onClose: () => {
-@@ -1689,6 +2126,15 @@ window.__ModuleLoader__.load({
+@@ -1689,6 +2130,15 @@ window.__ModuleLoader__.load({
  				},
  				confirmCopy: () => section.confirmCopy(),
  				openLocation: (id) => section.openLocation(id),


### PR DESCRIPTION
修复问题 #11：中文环境下，Agent Preset 选择器中的分组标签未翻译，显示为原始 key 名。

**根本原因**
补丁中新增了预设分组功能（Recent / Built-in / Custom），`builtInGroup` 和 `customGroup` 两个翻译 key 在代码中通过 `t()` 调用，但未在 en / zh 字典中定义，导致 UI 显示原始 key 字符串而非翻译文案。

**修复内容**
- 在英文字典中添加：
  - `builtInGroup: "Built-in"`
  - `customGroup: "Custom"`
- 在中文字典中添加：
  - `builtInGroup: "内置"`
  - `customGroup: "自定义"`

Fixes #11
