### PR TITLE
fix: distinguish quota and provider access errors

### DIFF
--- a/patches/@deepseek-ai+dsh-client-runtime+0.1.0-rc.7.patch
+++ b/patches/@deepseek-ai+dsh-client-runtime+0.1.0-rc.7.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@deepseek-ai/dsh-client-runtime/lib/client.js b/node_modules/@deepseek-ai/dsh-client-runtime/lib/client.js
+index 37b931e..ed1f7fd 100644
+--- a/node_modules/@deepseek-ai/dsh-client-runtime/lib/client.js
++++ b/node_modules/@deepseek-ai/dsh-client-runtime/lib/client.js
+@@ -10448,6 +10448,8 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
+ 		function displayFailureMessage(failure) {
+ 			if (failure === null || typeof failure !== "object") return String(failure);
+ 			const record = failure;
++			if (record.code === "QUOTA") return "Your account has insufficient quota or balance. Please add credits or check your provider's usage limits.";
++			if (record.code === "FORBIDDEN") return "The model provider denied this request. Check your account permissions, region, or quota.";
+ 			if (record.code === "AUTH") return "API key is invalid";
+ 			return typeof record.message === "string" ? record.message : JSON.stringify(failure);
+ 		}

--- a/patches/@deepseek-ai+dsh-llm-deepseek+0.1.0-rc.7.patch
+++ b/patches/@deepseek-ai+dsh-llm-deepseek+0.1.0-rc.7.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@deepseek-ai/dsh-llm-deepseek/lib/index.js b/node_modules/@deepseek-ai/dsh-llm-deepseek/lib/index.js
+index 6e62a9c..c95c213 100644
+--- a/node_modules/@deepseek-ai/dsh-llm-deepseek/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-llm-deepseek/lib/index.js
+@@ -467,13 +467,14 @@ function requestId(headers) {
+ * @returns the normalized harness error code.
+ */
+ function httpErrorCode(status, error) {
+-	if (status === 401 || status === 403) return "AUTH";
+ 	const detail = [
+ 		error?.code,
+ 		error?.type,
+ 		error?.message
+ 	].filter(Boolean).join(" ");
+ 	if (isQuotaExceededError(detail)) return QUOTA_EXCEEDED_CODE;
++	if (status === 401) return "AUTH";
++	if (status === 403) return "FORBIDDEN";
+ 	if (status === 429) return "RATE_LIMIT";
+ 	if (status === 400) {
+ 		if (isContextWindowExceededError(detail)) return CONTEXT_WINDOW_EXCEEDED_CODE;

--- a/patches/@deepseek-ai+dsh-llm-pi-ai+0.1.0-rc.7.patch
+++ b/patches/@deepseek-ai+dsh-llm-pi-ai+0.1.0-rc.7.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js b/node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js
+index 88204d4..6b4800c 100644
+--- a/node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js
+@@ -416,8 +416,9 @@ function mapUsage(usage) {
+ 	};
+ }
+ function classifyPiAiError(message) {
+-	if (/\b(?:401|403)\b/.test(message)) return "AUTH";
+ 	if (isQuotaExceededError(message)) return QUOTA_EXCEEDED_CODE;
++	if (/\b401\b/.test(message)) return "AUTH";
++	if (/\b403\b/.test(message)) return "FORBIDDEN";
+ 	if (/\b429\b|rate.?limit/i.test(message)) return "RATE_LIMIT";
+ 	if (/\b400\b|invalid.?request/i.test(message)) return "INVALID_REQUEST";
+ 	if (/\b5\d\d\b/.test(message)) return "SERVER";

--- a/test/provider-error-patch.test.ts
+++ b/test/provider-error-patch.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = path.resolve(import.meta.dirname, '..')
+
+async function readPatch(name: string): Promise<string> {
+  return readFile(path.join(projectRoot, 'patches', name), 'utf8')
+}
+
+describe('provider error classification patches', () => {
+  it('distinguishes quota, authentication, and forbidden failures', async () => {
+    const deepseekPatch = await readPatch(
+      '@deepseek-ai+dsh-llm-deepseek+0.1.0-rc.7.patch'
+    )
+    const piAiPatch = await readPatch('@deepseek-ai+dsh-llm-pi-ai+0.1.0-rc.7.patch')
+
+    expect(deepseekPatch).toContain('+\tif (status === 401) return "AUTH";')
+    expect(deepseekPatch).toContain(
+      '+\tif (status === 403) return "FORBIDDEN";'
+    )
+    expect(deepseekPatch.indexOf('isQuotaExceededError(detail)')).toBeLessThan(
+      deepseekPatch.lastIndexOf('status === 401')
+    )
+    expect(piAiPatch).toContain(
+      '+\tif (/\\b401\\b/.test(message)) return "AUTH";'
+    )
+    expect(piAiPatch).toContain(
+      '+\tif (/\\b403\\b/.test(message)) return "FORBIDDEN";'
+    )
+    expect(piAiPatch.indexOf('isQuotaExceededError(message)')).toBeLessThan(
+      piAiPatch.lastIndexOf('\\b401\\b')
+    )
+  })
+
+  it('shows distinct English quota, forbidden, and authentication messages', async () => {
+    const runtimePatch = await readPatch(
+      '@deepseek-ai+dsh-client-runtime+0.1.0-rc.7.patch'
+    )
+
+    expect(runtimePatch).toContain('record.code === "QUOTA"')
+    expect(runtimePatch).toContain(
+      "Your account has insufficient quota or balance. Please add credits or check your provider's usage limits."
+    )
+    expect(runtimePatch).toContain('record.code === "FORBIDDEN"')
+    expect(runtimePatch).toContain(
+      'The model provider denied this request. Check your account permissions, region, or quota.'
+    )
+    expect(runtimePatch).toContain('record.code === "AUTH"')
+    expect(runtimePatch).toContain('API key is invalid')
+  })
+})


### PR DESCRIPTION
## What changed

- Classify explicit quota, balance, and credit failures before HTTP status handling.
- Keep HTTP 401 as an invalid-credential error.
- Classify ambiguous HTTP 403 responses as provider access denial instead of invalid API keys.
- Show distinct user-facing messages for quota exhaustion, forbidden access, and invalid credentials.
- Add regression coverage for the tracked patch-package changes.

## Root cause

The provider adapters converted all HTTP 401 and 403 responses to AUTH before inspecting the provider error body. The client then rendered every AUTH failure as API key is invalid, including quota exhaustion.

## Impact

Users whose balance or quota is exhausted will be directed to add credits or inspect provider limits instead of repeatedly replacing a valid key. Ambiguous 403 responses now point to permissions, region, or quota rather than asserting that the key is invalid.

## Validation

- Clean npm ci; all patch-package patches applied
- npm test -- --run: 18 files, 95 tests passed
- npm run typecheck
- git diff --check