### PR TITLE
feat: integrate the Windows titlebar menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   Menu,
   nativeTheme,
   shell,
+  type IpcMainInvokeEvent,
   type MessageBoxOptions
 } from 'electron'
 import { HarnessRuntime } from './runtime/harness-runtime'
@@ -25,6 +26,11 @@ import {
 } from './update/update-manager'
 import type { RuntimeSnapshot } from '../shared/contracts'
 import { resolveHarnessLocale } from './application-locale'
+import {
+  WINDOWS_TITLEBAR_HEIGHT,
+  isDesktopMenuCommand,
+  type DesktopMenuCommand
+} from '../shared/desktop-menu'
 
 let mainWindow: BrowserWindow | undefined
 let mobileWindow: BrowserWindow | undefined
@@ -49,6 +55,22 @@ function isDevelopmentBuild(): boolean {
 }
 
 const developmentBuild = isDevelopmentBuild()
+
+function windowsTitleBarOverlay(isDark: boolean): Electron.TitleBarOverlayOptions {
+  return {
+    color: isDark ? '#19191b' : '#f7f8fa',
+    symbolColor: isDark ? '#f3f4f6' : '#202124',
+    height: WINDOWS_TITLEBAR_HEIGHT
+  }
+}
+
+function applyWindowChromeTheme(window: BrowserWindow, isDark: boolean): void {
+  if (window.isDestroyed()) return
+  window.setBackgroundColor(isDark ? '#141416' : '#ffffff')
+  if (process.platform === 'win32') {
+    window.setTitleBarOverlay(windowsTitleBarOverlay(isDark))
+  }
+}
 
 function configureAppIdentity(): void {
   if (developmentBuild) {
@@ -96,10 +118,17 @@ async function syncNativeTheme(window: BrowserWindow): Promise<void> {
           document.body.appendChild(dragRegion)
         }
       }
-      return document.body.hasAttribute('data-ds-dark-theme')
+      if (document.body.hasAttribute('data-ds-dark-theme')) return true
+      const color = getComputedStyle(document.body).backgroundColor
+      const channels = color.match(/[\\d.]+/g)?.slice(0, 3).map(Number)
+      if (!channels || channels.length < 3) {
+        return matchMedia('(prefers-color-scheme: dark)').matches
+      }
+      const [red, green, blue] = channels
+      return red * 0.2126 + green * 0.7152 + blue * 0.0722 < 128
     })()`
   )
-  window.setBackgroundColor(isDark ? '#141416' : '#ffffff')
+  applyWindowChromeTheme(window, isDark)
 }
 
 function dshEntryPath(): string {
@@ -182,6 +211,7 @@ function harnessThemePreference(): 'light' | 'dark' | 'system' {
 }
 
 function createWindow(): BrowserWindow {
+  const isWindows = process.platform === 'win32'
   const window = new BrowserWindow({
     width: 1380,
     height: 900,
@@ -191,6 +221,13 @@ function createWindow(): BrowserWindow {
     title: '',
     icon: desktopIconPath(),
     frame: process.platform !== 'darwin',
+    ...(isWindows
+      ? {
+          titleBarStyle: 'hidden' as const,
+          titleBarOverlay: windowsTitleBarOverlay(nativeTheme.shouldUseDarkColors),
+          autoHideMenuBar: true
+        }
+      : {}),
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#141416' : '#f8f8f6',
     webPreferences: {
       contextIsolation: true,
@@ -203,6 +240,8 @@ function createWindow(): BrowserWindow {
   if (process.platform === 'darwin') {
     window.setWindowButtonVisibility(true)
     window.setWindowButtonPosition({ x: 12, y: 9 })
+  } else if (isWindows) {
+    window.setMenuBarVisibility(false)
   }
   window.on('page-title-updated', (event) => {
     event.preventDefault()
@@ -266,6 +305,109 @@ function registerHarnessHandlers(): void {
     await launchHarness()
     return { ok: runtime.snapshot().phase === 'ready' }
   })
+
+  ipcMain.removeHandler('desktop-menu:execute')
+  ipcMain.handle('desktop-menu:execute', async (event, command: unknown) => {
+    assertTrustedMainWindowEvent(event)
+    if (!isDesktopMenuCommand(command)) {
+      throw new Error('Unknown DSH Desktop menu command.')
+    }
+    await executeDesktopMenuCommand(command)
+    return { ok: true }
+  })
+
+  ipcMain.removeHandler('desktop-titlebar:set-theme')
+  ipcMain.handle('desktop-titlebar:set-theme', (event, isDark: unknown) => {
+    assertTrustedMainWindowEvent(event)
+    if (typeof isDark !== 'boolean') {
+      throw new Error('The DSH Desktop titlebar theme must be a boolean.')
+    }
+    if (process.platform === 'win32' && mainWindow) {
+      applyWindowChromeTheme(mainWindow, isDark)
+    }
+    return { ok: true }
+  })
+}
+
+function assertTrustedMainWindowEvent(event: IpcMainInvokeEvent): void {
+  if (
+    !mainWindow ||
+    mainWindow.isDestroyed() ||
+    event.sender !== mainWindow.webContents ||
+    event.senderFrame !== mainWindow.webContents.mainFrame
+  ) {
+    throw new Error('This action is only available from the main DSH Desktop window.')
+  }
+}
+
+async function executeDesktopMenuCommand(command: DesktopMenuCommand): Promise<void> {
+  const window = mainWindow
+  if (!window || window.isDestroyed()) return
+  const contents = window.webContents
+
+  switch (command) {
+    case 'connect-phone':
+      await showMobilePairing()
+      break
+    case 'restart-harness':
+      await launchHarness()
+      break
+    case 'show-harness-log':
+      shell.showItemInFolder(join(app.getPath('logs'), 'harness.log'))
+      break
+    case 'check-for-updates':
+      await checkForUpdates(true)
+      break
+    case 'undo':
+      contents.undo()
+      break
+    case 'redo':
+      contents.redo()
+      break
+    case 'cut':
+      contents.cut()
+      break
+    case 'copy':
+      contents.copy()
+      break
+    case 'paste':
+      contents.paste()
+      break
+    case 'select-all':
+      contents.selectAll()
+      break
+    case 'reload':
+      contents.reload()
+      break
+    case 'toggle-devtools':
+      contents.toggleDevTools()
+      break
+    case 'zoom-reset':
+      contents.setZoomLevel(0)
+      break
+    case 'zoom-in':
+      contents.setZoomLevel(Math.min(3, contents.getZoomLevel() + 0.5))
+      break
+    case 'zoom-out':
+      contents.setZoomLevel(Math.max(-3, contents.getZoomLevel() - 0.5))
+      break
+    case 'toggle-fullscreen':
+      window.setFullScreen(!window.isFullScreen())
+      break
+    case 'about':
+      await dialog.showMessageBox(window, {
+        type: 'info',
+        title: 'DSH Desktop',
+        message: `DSH Desktop ${app.getVersion()}`,
+        detail: 'A desktop application for DeepSeek Harness.',
+        buttons: ['OK'],
+        noLink: true
+      })
+      break
+    case 'quit':
+      app.quit()
+      break
+  }
 }
 
 function showUnexpectedError(error: unknown): void {
@@ -402,6 +544,9 @@ function installMenu(): void {
     { label: 'Window', submenu: [{ role: 'minimize' }, { role: 'close' }] }
   ]
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+  if (process.platform === 'win32' && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.setMenuBarVisibility(false)
+  }
 }
 
 async function showMobilePairing(): Promise<void> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -59,7 +59,7 @@ const developmentBuild = isDevelopmentBuild()
 
 function windowsTitleBarOverlay(isDark: boolean): Electron.TitleBarOverlayOptions {
   return {
-    color: isDark ? '#19191b' : '#f7f8fa',
+    color: '#00000000',
     symbolColor: isDark ? '#f3f4f6' : '#202124',
     height: WINDOWS_TITLEBAR_HEIGHT
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,6 +6,7 @@ import {
   updateMessage,
   type UpdateLocale
 } from './update-view'
+import { mountWindowsTitlebar } from './windows-titlebar'
 
 const ROOT_ID = 'dsh-desktop-update-root'
 const MOBILE_BUTTON_ID = 'dsh-desktop-mobile-button'
@@ -77,6 +78,9 @@ async function refreshMobileStatus(): Promise<void> {
 }
 
 function initializeUi(): void {
+  if (process.platform === 'win32') {
+    mountWindowsTitlebar({ document, ipcRenderer, locale })
+  }
   mount()
   mountMobileButton()
   mobileButtonObserver.observe(document.documentElement, {

--- a/src/preload/windows-titlebar.ts
+++ b/src/preload/windows-titlebar.ts
@@ -1,0 +1,429 @@
+import type { IpcRenderer } from 'electron'
+import {
+  WINDOWS_TITLEBAR_HEIGHT,
+  type DesktopMenuCommand
+} from '../shared/desktop-menu'
+
+const HOST_ID = 'dsh-desktop-windows-titlebar'
+const LAYOUT_STYLE_ID = `${HOST_ID}-layout`
+
+type MenuEntry =
+  | { kind: 'command'; command: DesktopMenuCommand; label: string; shortcut?: string }
+  | { kind: 'separator' }
+  | { kind: 'label'; label: string }
+  | { kind: 'zoom'; label: string }
+
+interface TitlebarMountOptions {
+  document: Document
+  ipcRenderer: Pick<IpcRenderer, 'invoke'>
+  locale: 'en' | 'zh'
+}
+
+export function mountWindowsTitlebar(options: TitlebarMountOptions): void {
+  const { document, ipcRenderer, locale } = options
+  if (!document.body || document.getElementById(HOST_ID)) return
+
+  installLayout(document)
+
+  const host = document.createElement('div')
+  host.id = HOST_ID
+  host.setAttribute('aria-label', locale === 'zh' ? 'DSH Desktop 标题栏' : 'DSH Desktop title bar')
+  const shadow = host.attachShadow({ mode: 'closed' })
+  const style = document.createElement('style')
+  style.textContent = titlebarStyles
+
+  const bar = document.createElement('div')
+  bar.className = 'bar'
+  const safeArea = document.createElement('div')
+  safeArea.className = 'safeArea'
+  const menuButton = document.createElement('button')
+  menuButton.className = 'menuButton'
+  menuButton.type = 'button'
+  menuButton.setAttribute('aria-haspopup', 'menu')
+  menuButton.setAttribute('aria-expanded', 'false')
+  menuButton.setAttribute('aria-label', locale === 'zh' ? '打开应用菜单' : 'Open application menu')
+  menuButton.title = locale === 'zh' ? '应用菜单' : 'Application menu'
+  menuButton.innerHTML = chevronIcon
+
+  const menu = document.createElement('div')
+  menu.className = 'menu'
+  menu.hidden = true
+  menu.setAttribute('role', 'menu')
+  menu.setAttribute('aria-label', locale === 'zh' ? '应用菜单' : 'Application menu')
+  renderMenu(document, menu, menuEntries(locale), ipcRenderer, () => closeMenu(false))
+
+  function openMenu(): void {
+    menu.hidden = false
+    menuButton.classList.add('isOpen')
+    menuButton.setAttribute('aria-expanded', 'true')
+    const first = menu.querySelector<HTMLButtonElement>('button:not(:disabled)')
+    window.requestAnimationFrame(() => first?.focus())
+  }
+
+  function closeMenu(restoreFocus = true): void {
+    if (menu.hidden) return
+    menu.hidden = true
+    menuButton.classList.remove('isOpen')
+    menuButton.setAttribute('aria-expanded', 'false')
+    if (restoreFocus) menuButton.focus()
+  }
+
+  menuButton.addEventListener('pointerdown', (event) => event.preventDefault())
+  menuButton.addEventListener('click', () => (menu.hidden ? openMenu() : closeMenu()))
+  menu.addEventListener('keydown', (event) => {
+    const buttons = [...menu.querySelectorAll<HTMLButtonElement>('button:not(:disabled)')]
+    const current = buttons.indexOf(document.activeElement as HTMLButtonElement)
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeMenu()
+    } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const direction = event.key === 'ArrowDown' ? 1 : -1
+      const next = current < 0
+        ? 0
+        : (current + direction + buttons.length) % buttons.length
+      buttons[next]?.focus()
+    }
+  })
+  document.addEventListener('pointerdown', (event) => {
+    if (!menu.hidden && !event.composedPath().includes(host)) closeMenu(false)
+  })
+  window.addEventListener('blur', () => closeMenu(false))
+
+  safeArea.append(menuButton, menu)
+  bar.appendChild(safeArea)
+  shadow.append(style, bar)
+  document.body.appendChild(host)
+  syncTheme(document, ipcRenderer)
+
+  const themeObserver = new MutationObserver(() => syncTheme(document, ipcRenderer))
+  themeObserver.observe(document.body, {
+    attributes: true,
+    attributeFilter: ['data-ds-dark-theme', 'class', 'style']
+  })
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    syncTheme(document, ipcRenderer)
+  })
+}
+
+function installLayout(document: Document): void {
+  document.body.classList.add('dsh-desktop-windows-titlebar-layout')
+  if (document.getElementById(LAYOUT_STYLE_ID)) return
+
+  const style = document.createElement('style')
+  style.id = LAYOUT_STYLE_ID
+  style.textContent = `
+    html, body { height: 100% !important; }
+    body.dsh-desktop-windows-titlebar-layout {
+      box-sizing: border-box !important;
+      height: 100% !important;
+      padding-top: ${WINDOWS_TITLEBAR_HEIGHT}px !important;
+    }
+    body.dsh-desktop-windows-titlebar-layout > #root {
+      height: 100% !important;
+      min-height: 0 !important;
+    }
+  `
+  document.head.appendChild(style)
+}
+
+function renderMenu(
+  document: Document,
+  menu: HTMLElement,
+  entries: MenuEntry[],
+  ipcRenderer: Pick<IpcRenderer, 'invoke'>,
+  close: () => void
+): void {
+  for (const entry of entries) {
+    if (entry.kind === 'separator') {
+      const separator = document.createElement('div')
+      separator.className = 'separator'
+      separator.setAttribute('role', 'separator')
+      menu.appendChild(separator)
+      continue
+    }
+    if (entry.kind === 'label') {
+      const label = document.createElement('div')
+      label.className = 'sectionLabel'
+      label.textContent = entry.label
+      menu.appendChild(label)
+      continue
+    }
+    if (entry.kind === 'zoom') {
+      const row = document.createElement('div')
+      row.className = 'zoomRow'
+      const label = document.createElement('span')
+      label.textContent = entry.label
+      row.append(label)
+      for (const [command, text, title] of [
+        ['zoom-out', '−', 'Zoom out'],
+        ['zoom-reset', '100%', 'Reset zoom'],
+        ['zoom-in', '+', 'Zoom in']
+      ] as const) {
+        const zoom = document.createElement('button')
+        zoom.type = 'button'
+        zoom.className = command === 'zoom-reset' ? 'zoomReset' : 'zoomButton'
+        zoom.textContent = text
+        zoom.title = title
+        zoom.setAttribute('aria-label', title)
+        zoom.addEventListener('pointerdown', (event) => event.preventDefault())
+        zoom.addEventListener('click', () => execute(ipcRenderer, command, close))
+        row.appendChild(zoom)
+      }
+      menu.appendChild(row)
+      continue
+    }
+
+    const item = document.createElement('button')
+    item.type = 'button'
+    item.className = entry.command === 'quit' ? 'item danger' : 'item'
+    item.setAttribute('role', 'menuitem')
+    const label = document.createElement('span')
+    label.textContent = entry.label
+    item.appendChild(label)
+    if (entry.shortcut) {
+      const shortcut = document.createElement('kbd')
+      shortcut.textContent = entry.shortcut
+      item.appendChild(shortcut)
+    }
+    item.addEventListener('pointerdown', (event) => event.preventDefault())
+    item.addEventListener('click', () => execute(ipcRenderer, entry.command, close))
+    menu.appendChild(item)
+  }
+}
+
+function execute(
+  ipcRenderer: Pick<IpcRenderer, 'invoke'>,
+  command: DesktopMenuCommand,
+  close: () => void
+): void {
+  close()
+  void ipcRenderer.invoke('desktop-menu:execute', command).catch((error: unknown) => {
+    console.error(`[desktop-menu] unable to execute ${command}`, error)
+  })
+}
+
+function syncTheme(document: Document, ipcRenderer: Pick<IpcRenderer, 'invoke'>): void {
+  const isDark = documentIsDark(document)
+  void ipcRenderer.invoke('desktop-titlebar:set-theme', isDark).catch((error: unknown) => {
+    console.warn('[desktop-titlebar] unable to synchronize native theme', error)
+  })
+}
+
+export function documentIsDark(document: Document): boolean {
+  if (document.body.hasAttribute('data-ds-dark-theme')) return true
+  const color = document.defaultView?.getComputedStyle(document.body).backgroundColor ?? ''
+  const channels = color.match(/[\d.]+/g)?.slice(0, 3).map(Number)
+  if (!channels || channels.length < 3 || channels.some(Number.isNaN)) {
+    return document.defaultView?.matchMedia('(prefers-color-scheme: dark)').matches ?? false
+  }
+  const [red = 255, green = 255, blue = 255] = channels
+  return red * 0.2126 + green * 0.7152 + blue * 0.0722 < 128
+}
+
+function menuEntries(locale: 'en' | 'zh'): MenuEntry[] {
+  const zh = locale === 'zh'
+  return [
+    { kind: 'label', label: 'HARNESS' },
+    {
+      kind: 'command',
+      command: 'connect-phone',
+      label: zh ? '连接手机…' : 'Connect Phone…',
+      shortcut: 'Ctrl+Shift+M'
+    },
+    {
+      kind: 'command',
+      command: 'restart-harness',
+      label: zh ? '重启 Harness' : 'Restart Harness',
+      shortcut: 'Ctrl+Shift+R'
+    },
+    {
+      kind: 'command',
+      command: 'show-harness-log',
+      label: zh ? '显示 Harness 日志' : 'Show Harness Log'
+    },
+    {
+      kind: 'command',
+      command: 'check-for-updates',
+      label: zh ? '检查更新…' : 'Check for Updates…',
+      shortcut: 'Ctrl+U'
+    },
+    { kind: 'separator' },
+    { kind: 'label', label: zh ? '编辑' : 'EDIT' },
+    { kind: 'command', command: 'undo', label: zh ? '撤销' : 'Undo', shortcut: 'Ctrl+Z' },
+    { kind: 'command', command: 'redo', label: zh ? '重做' : 'Redo', shortcut: 'Ctrl+Y' },
+    { kind: 'command', command: 'cut', label: zh ? '剪切' : 'Cut', shortcut: 'Ctrl+X' },
+    { kind: 'command', command: 'copy', label: zh ? '复制' : 'Copy', shortcut: 'Ctrl+C' },
+    { kind: 'command', command: 'paste', label: zh ? '粘贴' : 'Paste', shortcut: 'Ctrl+V' },
+    {
+      kind: 'command',
+      command: 'select-all',
+      label: zh ? '全选' : 'Select All',
+      shortcut: 'Ctrl+A'
+    },
+    { kind: 'separator' },
+    { kind: 'label', label: zh ? '视图' : 'VIEW' },
+    { kind: 'command', command: 'reload', label: zh ? '重新加载' : 'Reload', shortcut: 'Ctrl+R' },
+    {
+      kind: 'command',
+      command: 'toggle-devtools',
+      label: zh ? '开发者工具' : 'Developer Tools',
+      shortcut: 'Ctrl+Shift+I'
+    },
+    { kind: 'zoom', label: zh ? '界面缩放' : 'Interface scale' },
+    {
+      kind: 'command',
+      command: 'toggle-fullscreen',
+      label: zh ? '切换全屏' : 'Toggle Full Screen',
+      shortcut: 'F11'
+    },
+    { kind: 'separator' },
+    {
+      kind: 'command',
+      command: 'about',
+      label: zh ? '关于 DSH Desktop' : 'About DSH Desktop'
+    },
+    { kind: 'command', command: 'quit', label: zh ? '退出' : 'Exit' }
+  ]
+}
+
+const chevronIcon = `<svg viewBox="0 0 20 20" width="17" height="17" fill="none" aria-hidden="true"><path d="m6.5 8 3.5 3.5L13.5 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>`
+
+const titlebarStyles = `
+  :host { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  .bar {
+    position: fixed;
+    z-index: 2147483645;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: ${WINDOWS_TITLEBAR_HEIGHT}px;
+    color: var(--dsw-alias-label-primary, #202124);
+    background: var(--dsw-specific-sidebar-fill, #f7f8fa);
+    border-bottom: 1px solid var(--dsw-alias-border-l1, rgba(32, 33, 36, 0.08));
+    font-family: var(--dsw-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+    -webkit-app-region: drag;
+    user-select: none;
+  }
+  .safeArea {
+    position: absolute;
+    top: 0;
+    left: env(titlebar-area-x, 0px);
+    width: env(titlebar-area-width, calc(100vw - 140px));
+    height: 100%;
+    display: flex;
+    justify-content: flex-end;
+    align-items: stretch;
+    pointer-events: none;
+  }
+  .menuButton {
+    appearance: none;
+    width: 44px;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    padding: 0;
+    color: var(--dsw-alias-label-secondary, #61666b);
+    background: transparent;
+    border: 0;
+    border-left: 1px solid var(--dsw-alias-border-l1, rgba(32, 33, 36, 0.08));
+    cursor: pointer;
+    pointer-events: auto;
+    -webkit-app-region: no-drag;
+  }
+  .menuButton:hover, .menuButton.isOpen {
+    color: var(--dsw-alias-label-primary, #202124);
+    background: var(--dsw-alias-interactive-bg-hover, rgba(32, 33, 36, 0.08));
+  }
+  .menuButton:focus-visible { outline: 2px solid #4d6bfe; outline-offset: -3px; }
+  .menu {
+    position: absolute;
+    top: calc(100% + 7px);
+    right: 0;
+    width: 304px;
+    max-height: calc(100vh - ${WINDOWS_TITLEBAR_HEIGHT + 20}px);
+    overflow: auto;
+    padding: 7px;
+    color: var(--dsw-alias-label-primary, #202124);
+    background: var(--dsw-specific-menu, #fff);
+    border: 1px solid var(--dsw-alias-border-l2, rgba(32, 33, 36, 0.13));
+    border-radius: 12px;
+    box-shadow: var(--dsw-shadow-lv3, 0 14px 36px rgba(0, 0, 0, 0.17));
+    pointer-events: auto;
+    -webkit-app-region: no-drag;
+    user-select: none;
+    scrollbar-width: thin;
+  }
+  .menu[hidden] { display: none; }
+  .sectionLabel {
+    padding: 7px 10px 4px;
+    color: var(--dsw-alias-label-tertiary, #81858c);
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 14px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+  .item {
+    appearance: none;
+    width: 100%;
+    min-height: 33px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 6px 10px;
+    color: inherit;
+    background: transparent;
+    border: 0;
+    border-radius: 7px;
+    font: inherit;
+    font-size: 13px;
+    line-height: 20px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .item:hover, .item:focus-visible, .zoomButton:hover, .zoomButton:focus-visible, .zoomReset:hover, .zoomReset:focus-visible {
+    outline: none;
+    background: var(--dsw-alias-interactive-bg-hover, rgba(32, 33, 36, 0.08));
+  }
+  .item.danger { color: var(--dsw-alias-state-error-primary, #d93025); }
+  kbd {
+    flex: none;
+    color: var(--dsw-alias-label-tertiary, #81858c);
+    font: 11px/16px var(--ds-font-family-code, ui-monospace, "SFMono-Regular", Consolas, monospace);
+  }
+  .separator {
+    height: 1px;
+    margin: 6px 3px;
+    background: var(--dsw-alias-border-l1, rgba(32, 33, 36, 0.09));
+  }
+  .zoomRow {
+    min-height: 37px;
+    display: grid;
+    grid-template-columns: 1fr 30px 54px 30px;
+    align-items: center;
+    gap: 3px;
+    padding: 3px 7px 3px 10px;
+    font-size: 13px;
+  }
+  .zoomButton, .zoomReset {
+    appearance: none;
+    height: 27px;
+    padding: 0;
+    color: inherit;
+    background: var(--dsw-alias-bg-layer-2, rgba(32, 33, 36, 0.06));
+    border: 0;
+    border-radius: 6px;
+    font: inherit;
+    cursor: pointer;
+  }
+  .zoomReset { font-size: 11px; }
+  @media (prefers-color-scheme: dark) {
+    .bar { color: var(--dsw-alias-label-primary, #f3f4f6); background: var(--dsw-specific-sidebar-fill, #19191b); }
+    .menu { color: var(--dsw-alias-label-primary, #f3f4f6); background: var(--dsw-specific-menu, #28282b); border-color: rgba(255,255,255,.12); box-shadow: 0 18px 42px rgba(0,0,0,.46); }
+    .menuButton { color: var(--dsw-alias-label-secondary, #b5b7bd); border-left-color: rgba(255,255,255,.08); }
+  }
+  @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; } }
+`

--- a/src/preload/windows-titlebar.ts
+++ b/src/preload/windows-titlebar.ts
@@ -6,9 +6,7 @@ import {
 
 const HOST_ID = 'dsh-desktop-windows-titlebar'
 const LAYOUT_STYLE_ID = `${HOST_ID}-layout`
-const FLUSH_SIDEBAR_CLASS = 'dsh-desktop-windows-sidebar-flush'
 const SIDEBAR_WIDTH_PROPERTY = '--dsh-desktop-windows-sidebar-width'
-const CONTENT_COLUMN_ATTRIBUTE = 'data-dsh-desktop-windows-content-column'
 
 type MenuEntry =
   | { kind: 'command'; command: DesktopMenuCommand; label: string; shortcut?: string }
@@ -121,19 +119,11 @@ function installLayout(document: Document): void {
     body.dsh-desktop-windows-titlebar-layout {
       box-sizing: border-box !important;
       height: 100% !important;
-      padding-top: ${WINDOWS_TITLEBAR_HEIGHT}px !important;
-    }
-    body.dsh-desktop-windows-titlebar-layout.${FLUSH_SIDEBAR_CLASS} {
       padding-top: 0 !important;
     }
     body.dsh-desktop-windows-titlebar-layout > #root {
       height: 100% !important;
       min-height: 0 !important;
-    }
-    body.dsh-desktop-windows-titlebar-layout [${CONTENT_COLUMN_ATTRIBUTE}] {
-      box-sizing: border-box !important;
-      min-height: 0 !important;
-      padding-top: ${WINDOWS_TITLEBAR_HEIGHT}px !important;
     }
     body.dsh-desktop-windows-titlebar-layout [data-dsh-sidebar-root][data-dsh-sidebar-wide="true"] {
       padding-top: 6px !important;
@@ -157,13 +147,8 @@ function trackSidebarLayout(document: Document): void {
   const sync = (): void => {
     const sidebarRoot = document.querySelector<HTMLElement>('[data-dsh-sidebar-root]')
     const sidebarColumn = sidebarRoot?.parentElement ?? null
-    const centerColumn = sidebarColumn?.nextElementSibling as HTMLElement | null
-    const detailsColumn = centerColumn?.nextElementSibling as HTMLElement | null
-    if (!sidebarColumn || !centerColumn || !detailsColumn) return
+    if (!sidebarColumn) return
 
-    centerColumn.setAttribute(CONTENT_COLUMN_ATTRIBUTE, '')
-    detailsColumn.setAttribute(CONTENT_COLUMN_ATTRIBUTE, '')
-    document.body.classList.add(FLUSH_SIDEBAR_CLASS)
     if (sidebarColumn !== observedSidebarColumn) {
       if (observedSidebarColumn) resizeObserver.unobserve(observedSidebarColumn)
       observedSidebarColumn = sidebarColumn
@@ -350,26 +335,11 @@ const titlebarStyles = `
     width: 100vw;
     height: ${WINDOWS_TITLEBAR_HEIGHT}px;
     color: var(--dsw-alias-label-primary, #202124);
-    background: linear-gradient(
-      to right,
-      transparent 0,
-      transparent var(${SIDEBAR_WIDTH_PROPERTY}, 280px),
-      var(--dsw-specific-sidebar-fill, #f7f8fa) var(${SIDEBAR_WIDTH_PROPERTY}, 280px),
-      var(--dsw-specific-sidebar-fill, #f7f8fa) 100%
-    );
+    background: transparent;
     font-family: var(--dsw-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
-    -webkit-app-region: drag;
+    -webkit-app-region: no-drag;
     pointer-events: none;
     user-select: none;
-  }
-  .bar::after {
-    content: "";
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    left: var(${SIDEBAR_WIDTH_PROPERTY}, 280px);
-    height: 1px;
-    background: var(--dsw-alias-border-l1, rgba(32, 33, 36, 0.08));
   }
   .safeArea {
     position: absolute;
@@ -387,7 +357,7 @@ const titlebarStyles = `
     position: absolute;
     top: 0;
     right: 44px;
-    bottom: 0;
+    height: 5px;
     left: var(${SIDEBAR_WIDTH_PROPERTY}, 280px);
     pointer-events: auto;
     -webkit-app-region: drag;

--- a/src/preload/windows-titlebar.ts
+++ b/src/preload/windows-titlebar.ts
@@ -6,6 +6,9 @@ import {
 
 const HOST_ID = 'dsh-desktop-windows-titlebar'
 const LAYOUT_STYLE_ID = `${HOST_ID}-layout`
+const FLUSH_SIDEBAR_CLASS = 'dsh-desktop-windows-sidebar-flush'
+const SIDEBAR_WIDTH_PROPERTY = '--dsh-desktop-windows-sidebar-width'
+const CONTENT_COLUMN_ATTRIBUTE = 'data-dsh-desktop-windows-content-column'
 
 type MenuEntry =
   | { kind: 'command'; command: DesktopMenuCommand; label: string; shortcut?: string }
@@ -24,6 +27,7 @@ export function mountWindowsTitlebar(options: TitlebarMountOptions): void {
   if (!document.body || document.getElementById(HOST_ID)) return
 
   installLayout(document)
+  trackSidebarLayout(document)
 
   const host = document.createElement('div')
   host.id = HOST_ID
@@ -119,12 +123,58 @@ function installLayout(document: Document): void {
       height: 100% !important;
       padding-top: ${WINDOWS_TITLEBAR_HEIGHT}px !important;
     }
+    body.dsh-desktop-windows-titlebar-layout.${FLUSH_SIDEBAR_CLASS} {
+      padding-top: 0 !important;
+    }
     body.dsh-desktop-windows-titlebar-layout > #root {
       height: 100% !important;
       min-height: 0 !important;
     }
+    body.dsh-desktop-windows-titlebar-layout [${CONTENT_COLUMN_ATTRIBUTE}] {
+      box-sizing: border-box !important;
+      min-height: 0 !important;
+      padding-top: ${WINDOWS_TITLEBAR_HEIGHT}px !important;
+    }
+    body.dsh-desktop-windows-titlebar-layout [data-dsh-sidebar-root][data-dsh-sidebar-wide="true"] {
+      padding-top: 6px !important;
+    }
   `
   document.head.appendChild(style)
+}
+
+function trackSidebarLayout(document: Document): void {
+  let observedSidebarColumn: HTMLElement | null = null
+  const resizeObserver = new ResizeObserver(() => updateSidebarWidth())
+
+  const updateSidebarWidth = (): void => {
+    if (!observedSidebarColumn) return
+    const width = observedSidebarColumn.getBoundingClientRect().width
+    if (width > 0) {
+      document.documentElement.style.setProperty(SIDEBAR_WIDTH_PROPERTY, `${width}px`)
+    }
+  }
+
+  const sync = (): void => {
+    const sidebarRoot = document.querySelector<HTMLElement>('[data-dsh-sidebar-root]')
+    const sidebarColumn = sidebarRoot?.parentElement ?? null
+    const centerColumn = sidebarColumn?.nextElementSibling as HTMLElement | null
+    const detailsColumn = centerColumn?.nextElementSibling as HTMLElement | null
+    if (!sidebarColumn || !centerColumn || !detailsColumn) return
+
+    centerColumn.setAttribute(CONTENT_COLUMN_ATTRIBUTE, '')
+    detailsColumn.setAttribute(CONTENT_COLUMN_ATTRIBUTE, '')
+    document.body.classList.add(FLUSH_SIDEBAR_CLASS)
+    if (sidebarColumn !== observedSidebarColumn) {
+      if (observedSidebarColumn) resizeObserver.unobserve(observedSidebarColumn)
+      observedSidebarColumn = sidebarColumn
+      resizeObserver.observe(sidebarColumn)
+    }
+    updateSidebarWidth()
+  }
+
+  const observer = new MutationObserver(sync)
+  observer.observe(document.documentElement, { childList: true, subtree: true })
+  sync()
 }
 
 function renderMenu(
@@ -300,11 +350,26 @@ const titlebarStyles = `
     width: 100vw;
     height: ${WINDOWS_TITLEBAR_HEIGHT}px;
     color: var(--dsw-alias-label-primary, #202124);
-    background: var(--dsw-specific-sidebar-fill, #f7f8fa);
-    border-bottom: 1px solid var(--dsw-alias-border-l1, rgba(32, 33, 36, 0.08));
+    background: linear-gradient(
+      to right,
+      transparent 0,
+      transparent var(${SIDEBAR_WIDTH_PROPERTY}, 280px),
+      var(--dsw-specific-sidebar-fill, #f7f8fa) var(${SIDEBAR_WIDTH_PROPERTY}, 280px),
+      var(--dsw-specific-sidebar-fill, #f7f8fa) 100%
+    );
     font-family: var(--dsw-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
     -webkit-app-region: drag;
+    pointer-events: none;
     user-select: none;
+  }
+  .bar::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: var(${SIDEBAR_WIDTH_PROPERTY}, 280px);
+    height: 1px;
+    background: var(--dsw-alias-border-l1, rgba(32, 33, 36, 0.08));
   }
   .safeArea {
     position: absolute;
@@ -316,6 +381,16 @@ const titlebarStyles = `
     justify-content: flex-end;
     align-items: stretch;
     pointer-events: none;
+  }
+  .safeArea::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 44px;
+    bottom: 0;
+    left: var(${SIDEBAR_WIDTH_PROPERTY}, 280px);
+    pointer-events: auto;
+    -webkit-app-region: drag;
   }
   .menuButton {
     appearance: none;
@@ -421,7 +496,7 @@ const titlebarStyles = `
   }
   .zoomReset { font-size: 11px; }
   @media (prefers-color-scheme: dark) {
-    .bar { color: var(--dsw-alias-label-primary, #f3f4f6); background: var(--dsw-specific-sidebar-fill, #19191b); }
+    .bar { color: var(--dsw-alias-label-primary, #f3f4f6); }
     .menu { color: var(--dsw-alias-label-primary, #f3f4f6); background: var(--dsw-specific-menu, #28282b); border-color: rgba(255,255,255,.12); box-shadow: 0 18px 42px rgba(0,0,0,.46); }
     .menuButton { color: var(--dsw-alias-label-secondary, #b5b7bd); border-left-color: rgba(255,255,255,.08); }
   }

--- a/src/shared/desktop-menu.ts
+++ b/src/shared/desktop-menu.ts
@@ -1,0 +1,30 @@
+export const WINDOWS_TITLEBAR_HEIGHT = 36
+
+export const desktopMenuCommands = [
+  'connect-phone',
+  'restart-harness',
+  'show-harness-log',
+  'check-for-updates',
+  'undo',
+  'redo',
+  'cut',
+  'copy',
+  'paste',
+  'select-all',
+  'reload',
+  'toggle-devtools',
+  'zoom-reset',
+  'zoom-in',
+  'zoom-out',
+  'toggle-fullscreen',
+  'about',
+  'quit'
+] as const
+
+export type DesktopMenuCommand = (typeof desktopMenuCommands)[number]
+
+const desktopMenuCommandSet = new Set<string>(desktopMenuCommands)
+
+export function isDesktopMenuCommand(value: unknown): value is DesktopMenuCommand {
+  return typeof value === 'string' && desktopMenuCommandSet.has(value)
+}

--- a/test/windows-titlebar.test.ts
+++ b/test/windows-titlebar.test.ts
@@ -1,0 +1,56 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+import {
+  WINDOWS_TITLEBAR_HEIGHT,
+  desktopMenuCommands,
+  isDesktopMenuCommand
+} from '../src/shared/desktop-menu'
+
+describe('Windows titlebar menu', () => {
+  it('uses a Windows-only overlay while preserving the macOS frame behavior', async () => {
+    const main = await readFile('src/main/index.ts', 'utf8')
+
+    expect(main).toContain("const isWindows = process.platform === 'win32'")
+    expect(main).toContain("frame: process.platform !== 'darwin'")
+    expect(main).toContain("titleBarStyle: 'hidden' as const")
+    expect(main).toContain('titleBarOverlay: windowsTitleBarOverlay')
+    expect(main).toContain('autoHideMenuBar: true')
+    expect(main).toContain('window.setMenuBarVisibility(false)')
+    expect(main).toContain('Menu.setApplicationMenu(Menu.buildFromTemplate(template))')
+  })
+
+  it('reserves a draggable titlebar without covering the Harness root', async () => {
+    const preload = await readFile('src/preload/windows-titlebar.ts', 'utf8')
+
+    expect(WINDOWS_TITLEBAR_HEIGHT).toBe(36)
+    expect(preload).toContain(`padding-top: \${WINDOWS_TITLEBAR_HEIGHT}px !important`)
+    expect(preload).toContain('body.dsh-desktop-windows-titlebar-layout > #root')
+    expect(preload).toContain('-webkit-app-region: drag')
+    expect(preload).toContain('-webkit-app-region: no-drag')
+    expect(preload).toContain('env(titlebar-area-width')
+  })
+
+  it('accepts only the fixed menu command allowlist', async () => {
+    const main = await readFile('src/main/index.ts', 'utf8')
+
+    expect(desktopMenuCommands).toContain('connect-phone')
+    expect(desktopMenuCommands).toContain('check-for-updates')
+    expect(desktopMenuCommands).toContain('toggle-fullscreen')
+    expect(isDesktopMenuCommand('copy')).toBe(true)
+    expect(isDesktopMenuCommand('run-shell-command')).toBe(false)
+    expect(isDesktopMenuCommand({ command: 'quit' })).toBe(false)
+    expect(main).toContain("ipcMain.handle('desktop-menu:execute'")
+    expect(main).toContain('event.senderFrame !== mainWindow.webContents.mainFrame')
+    expect(main).toContain('if (!isDesktopMenuCommand(command))')
+  })
+
+  it('synchronizes the native controls with Harness light and dark themes', async () => {
+    const main = await readFile('src/main/index.ts', 'utf8')
+    const preload = await readFile('src/preload/windows-titlebar.ts', 'utf8')
+
+    expect(main).toContain('window.setTitleBarOverlay(windowsTitleBarOverlay(isDark))')
+    expect(main).toContain("ipcMain.handle('desktop-titlebar:set-theme'")
+    expect(preload).toContain("attributeFilter: ['data-ds-dark-theme', 'class', 'style']")
+    expect(preload).toContain("ipcRenderer.invoke('desktop-titlebar:set-theme', isDark)")
+  })
+})

--- a/test/windows-titlebar.test.ts
+++ b/test/windows-titlebar.test.ts
@@ -19,20 +19,21 @@ describe('Windows titlebar menu', () => {
     expect(main).toContain('Menu.setApplicationMenu(Menu.buildFromTemplate(template))')
   })
 
-  it('keeps the Windows sidebar full-height while reserving the titlebar for content', async () => {
+  it('keeps the entire Windows app full-height without a visible titlebar band', async () => {
+    const main = await readFile('src/main/index.ts', 'utf8')
     const preload = await readFile('src/preload/windows-titlebar.ts', 'utf8')
 
     expect(WINDOWS_TITLEBAR_HEIGHT).toBe(36)
-    expect(preload).toContain(`padding-top: \${WINDOWS_TITLEBAR_HEIGHT}px !important`)
-    expect(preload).toContain(`body.dsh-desktop-windows-titlebar-layout.\${FLUSH_SIDEBAR_CLASS}`)
+    expect(main).toContain("color: '#00000000'")
+    expect(preload).not.toContain(`padding-top: \${WINDOWS_TITLEBAR_HEIGHT}px !important`)
     expect(preload).toContain('padding-top: 0 !important')
-    expect(preload).toContain(`[\${CONTENT_COLUMN_ATTRIBUTE}]`)
     expect(preload).toContain('[data-dsh-sidebar-root][data-dsh-sidebar-wide="true"]')
     expect(preload).toContain('padding-top: 6px !important')
     expect(preload).toContain('trackSidebarLayout(document)')
     expect(preload).toContain("document.documentElement.style.setProperty(SIDEBAR_WIDTH_PROPERTY")
-    expect(preload).toContain('transparent var(${SIDEBAR_WIDTH_PROPERTY}, 280px)')
+    expect(preload).toContain('background: transparent')
     expect(preload).toContain('.safeArea::before')
+    expect(preload).toContain('height: 5px')
     expect(preload).toContain('body.dsh-desktop-windows-titlebar-layout > #root')
     expect(preload).toContain('-webkit-app-region: drag')
     expect(preload).toContain('-webkit-app-region: no-drag')

--- a/test/windows-titlebar.test.ts
+++ b/test/windows-titlebar.test.ts
@@ -19,11 +19,20 @@ describe('Windows titlebar menu', () => {
     expect(main).toContain('Menu.setApplicationMenu(Menu.buildFromTemplate(template))')
   })
 
-  it('reserves a draggable titlebar without covering the Harness root', async () => {
+  it('keeps the Windows sidebar full-height while reserving the titlebar for content', async () => {
     const preload = await readFile('src/preload/windows-titlebar.ts', 'utf8')
 
     expect(WINDOWS_TITLEBAR_HEIGHT).toBe(36)
     expect(preload).toContain(`padding-top: \${WINDOWS_TITLEBAR_HEIGHT}px !important`)
+    expect(preload).toContain(`body.dsh-desktop-windows-titlebar-layout.\${FLUSH_SIDEBAR_CLASS}`)
+    expect(preload).toContain('padding-top: 0 !important')
+    expect(preload).toContain(`[\${CONTENT_COLUMN_ATTRIBUTE}]`)
+    expect(preload).toContain('[data-dsh-sidebar-root][data-dsh-sidebar-wide="true"]')
+    expect(preload).toContain('padding-top: 6px !important')
+    expect(preload).toContain('trackSidebarLayout(document)')
+    expect(preload).toContain("document.documentElement.style.setProperty(SIDEBAR_WIDTH_PROPERTY")
+    expect(preload).toContain('transparent var(${SIDEBAR_WIDTH_PROPERTY}, 280px)')
+    expect(preload).toContain('.safeArea::before')
     expect(preload).toContain('body.dsh-desktop-windows-titlebar-layout > #root')
     expect(preload).toContain('-webkit-app-region: drag')
     expect(preload).toContain('-webkit-app-region: no-drag')


### PR DESCRIPTION
## Summary

- replace the default Windows menu bar with a compact titlebar menu beside the native window controls
- remove the visible titlebar spacer so the sidebar and conversation surface extend to the top edge
- keep a minimal draggable strip while preserving clickable application content
- synchronize the native controls and menu with Harness light and dark themes
- keep macOS window behavior unchanged

## Validation

- `npm run typecheck`
- `npm test` (19 files, 99 tests)
- `npm run build`
- Windows x64 CI build and packaged Harness smoke test: https://github.com/dataelement/dsh-desktop/actions/runs/32225897069