### PR TITLE
feat: add native conversation context menus

### DIFF
--- a/src/main/context-menu-template.ts
+++ b/src/main/context-menu-template.ts
@@ -1,0 +1,141 @@
+import type { MenuItemConstructorOptions } from 'electron'
+
+export interface ContextMenuState {
+  isEditable: boolean
+  selectionText: string
+  linkURL: string
+  hasImageContents: boolean
+  editFlags: {
+    canUndo: boolean
+    canRedo: boolean
+    canCut: boolean
+    canCopy: boolean
+    canPaste: boolean
+    canSelectAll: boolean
+  }
+}
+
+export interface ContextMenuActions {
+  openLink: (url: string) => void
+  copyLink: (url: string) => void
+  copyImage: () => void
+}
+
+interface ContextMenuLabels {
+  openLink: string
+  copyLink: string
+  copyImage: string
+  undo: string
+  redo: string
+  cut: string
+  copy: string
+  paste: string
+  selectAll: string
+}
+
+const labels: Record<'en' | 'zh', ContextMenuLabels> = {
+  en: {
+    openLink: 'Open Link in Browser',
+    copyLink: 'Copy Link Address',
+    copyImage: 'Copy Image',
+    undo: 'Undo',
+    redo: 'Redo',
+    cut: 'Cut',
+    copy: 'Copy',
+    paste: 'Paste',
+    selectAll: 'Select All'
+  },
+  zh: {
+    openLink: '在浏览器中打开链接',
+    copyLink: '复制链接地址',
+    copyImage: '复制图片',
+    undo: '撤销',
+    redo: '重做',
+    cut: '剪切',
+    copy: '复制',
+    paste: '粘贴',
+    selectAll: '全选'
+  }
+}
+
+export function isExternalWebUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl)
+    return (
+      (url.protocol === 'https:' || url.protocol === 'http:') &&
+      url.hostname !== '127.0.0.1' &&
+      url.hostname !== 'localhost'
+    )
+  } catch {
+    return false
+  }
+}
+
+function appendSection(
+  template: MenuItemConstructorOptions[],
+  section: MenuItemConstructorOptions[]
+): void {
+  if (section.length === 0) return
+  if (template.length > 0) template.push({ type: 'separator' })
+  template.push(...section)
+}
+
+export function buildContextMenuTemplate(
+  state: ContextMenuState,
+  locale: 'en' | 'zh',
+  actions: ContextMenuActions
+): MenuItemConstructorOptions[] {
+  const text = labels[locale]
+  const template: MenuItemConstructorOptions[] = []
+  const hasSelection = state.selectionText.trim().length > 0
+
+  if (state.linkURL) {
+    const linkItems: MenuItemConstructorOptions[] = []
+    if (isExternalWebUrl(state.linkURL)) {
+      linkItems.push({
+        label: text.openLink,
+        click: () => actions.openLink(state.linkURL)
+      })
+    }
+    linkItems.push({
+      label: text.copyLink,
+      click: () => actions.copyLink(state.linkURL)
+    })
+    appendSection(template, linkItems)
+  }
+
+  if (state.hasImageContents) {
+    appendSection(template, [
+      {
+        label: text.copyImage,
+        click: actions.copyImage
+      }
+    ])
+  }
+
+  if (state.isEditable) {
+    appendSection(template, [
+      { label: text.undo, role: 'undo', enabled: state.editFlags.canUndo },
+      { label: text.redo, role: 'redo', enabled: state.editFlags.canRedo },
+      { type: 'separator' },
+      { label: text.cut, role: 'cut', enabled: state.editFlags.canCut },
+      {
+        label: text.copy,
+        role: 'copy',
+        enabled: state.editFlags.canCopy || hasSelection
+      },
+      { label: text.paste, role: 'paste', enabled: state.editFlags.canPaste },
+      { type: 'separator' },
+      { label: text.selectAll, role: 'selectAll', enabled: state.editFlags.canSelectAll }
+    ])
+  } else {
+    const contentItems: MenuItemConstructorOptions[] = []
+    if (hasSelection) {
+      contentItems.push({ label: text.copy, role: 'copy' })
+    }
+    contentItems.push({ label: text.selectAll, role: 'selectAll' })
+    appendSection(template, contentItems)
+  }
+
+  return template
+}

--- a/src/main/context-menu.ts
+++ b/src/main/context-menu.ts
@@ -1,0 +1,23 @@
+import { clipboard, Menu, shell, type BrowserWindow } from 'electron'
+import { buildContextMenuTemplate } from './context-menu-template'
+
+export function installContextMenu(
+  window: BrowserWindow,
+  locale: () => 'en' | 'zh'
+): void {
+  window.webContents.on('context-menu', (_event, params) => {
+    const template = buildContextMenuTemplate(params, locale(), {
+      openLink: (url) => {
+        void shell.openExternal(url)
+      },
+      copyLink: (url) => clipboard.writeText(url),
+      copyImage: () => {
+        if (window.isDestroyed()) return
+        window.webContents.copyImageAt(params.x, params.y)
+      }
+    })
+
+    if (template.length === 0 || window.isDestroyed()) return
+    Menu.buildFromTemplate(template).popup({ window })
+  })
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,7 @@ import {
 } from './update/update-manager'
 import type { RuntimeSnapshot } from '../shared/contracts'
 import { resolveHarnessLocale } from './application-locale'
+import { installContextMenu } from './context-menu'
 
 let mainWindow: BrowserWindow | undefined
 let mobileWindow: BrowserWindow | undefined
@@ -210,6 +211,7 @@ function createWindow(): BrowserWindow {
     window.setTitle('')
   })
   secureWindow(window)
+  installContextMenu(window, harnessLocale)
   window.on('closed', () => {
     if (mainWindow === window) mainWindow = undefined
   })

--- a/test/context-menu.test.ts
+++ b/test/context-menu.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildContextMenuTemplate,
+  isExternalWebUrl,
+  type ContextMenuActions,
+  type ContextMenuState
+} from '../src/main/context-menu-template'
+
+function state(overrides: Partial<ContextMenuState> = {}): ContextMenuState {
+  return {
+    isEditable: false,
+    selectionText: '',
+    linkURL: '',
+    hasImageContents: false,
+    editFlags: {
+      canUndo: false,
+      canRedo: false,
+      canCut: false,
+      canCopy: false,
+      canPaste: false,
+      canSelectAll: true
+    },
+    ...overrides
+  }
+}
+
+function actions(): ContextMenuActions {
+  return {
+    openLink: vi.fn(),
+    copyLink: vi.fn(),
+    copyImage: vi.fn()
+  }
+}
+
+describe('conversation context menu', () => {
+  it('offers copy for selected conversation text', () => {
+    const template = buildContextMenuTemplate(
+      state({ selectionText: '选中的回答' }),
+      'zh',
+      actions()
+    )
+
+    expect(template).toEqual([
+      { label: '复制', role: 'copy' },
+      { label: '全选', role: 'selectAll' }
+    ])
+  })
+
+  it('offers the standard editing commands inside the composer', () => {
+    const template = buildContextMenuTemplate(
+      state({
+        isEditable: true,
+        selectionText: 'draft',
+        editFlags: {
+          canUndo: true,
+          canRedo: false,
+          canCut: true,
+          canCopy: true,
+          canPaste: true,
+          canSelectAll: true
+        }
+      }),
+      'en',
+      actions()
+    )
+
+    expect(template.map((item) => item.role ?? item.type)).toEqual([
+      'undo',
+      'redo',
+      'separator',
+      'cut',
+      'copy',
+      'paste',
+      'separator',
+      'selectAll'
+    ])
+    expect(template[1]?.enabled).toBe(false)
+  })
+
+  it('opens safe web links externally and can copy their address', () => {
+    const callbacks = actions()
+    const template = buildContextMenuTemplate(
+      state({ linkURL: 'https://example.com/docs' }),
+      'en',
+      callbacks
+    )
+
+    template[0]?.click?.({} as never, undefined, {} as never)
+    template[1]?.click?.({} as never, undefined, {} as never)
+    expect(callbacks.openLink).toHaveBeenCalledWith('https://example.com/docs')
+    expect(callbacks.copyLink).toHaveBeenCalledWith('https://example.com/docs')
+  })
+
+  it('never offers to open non-web link schemes externally', () => {
+    const callbacks = actions()
+    const template = buildContextMenuTemplate(
+      state({ linkURL: 'javascript:alert(1)' }),
+      'en',
+      callbacks
+    )
+
+    expect(template[0]?.label).toBe('Copy Link Address')
+    expect(template.some((item) => item.label === 'Open Link in Browser')).toBe(false)
+  })
+
+  it('supports copying rendered images', () => {
+    const callbacks = actions()
+    const template = buildContextMenuTemplate(
+      state({ hasImageContents: true }),
+      'en',
+      callbacks
+    )
+
+    template[0]?.click?.({} as never, undefined, {} as never)
+    expect(callbacks.copyImage).toHaveBeenCalledOnce()
+  })
+
+  it('recognizes only HTTP and HTTPS as external web URLs', () => {
+    expect(isExternalWebUrl('https://example.com')).toBe(true)
+    expect(isExternalWebUrl('http://example.com')).toBe(true)
+    expect(isExternalWebUrl('http://127.0.0.1:43127/session')).toBe(false)
+    expect(isExternalWebUrl('http://localhost:43127/settings')).toBe(false)
+    expect(isExternalWebUrl('file:///tmp/report.html')).toBe(false)
+    expect(isExternalWebUrl('not a URL')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- add a native context menu for selected conversation text with Copy and Select All
- add the standard editing actions for the composer and other editable fields
- add safe link actions for opening HTTP(S) links externally and copying their addresses
- add image copying while avoiding external navigation to the local Harness origin
- localize the menu labels using the resolved Harness locale

## Validation

- `npm run typecheck`
- `npm test` (20 files, 105 tests after syncing current `main`)
- `npm run build`
- manually validated selected-text Copy and composer editing menus on macOS
- Windows x64 CI build and packaged Harness smoke test on the original feature commit: https://github.com/dataelement/dsh-desktop/actions/runs/32223763446