### PR TITLE
fix: 插件冲突与启动异常自动识别与一键卸载恢复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/icon-1024.png
 .env
 .env.*
 !.env.example
+.coaligne/
+.coaligneignore
+

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,10 +12,11 @@ import {
   shell,
   type MessageBoxOptions
 } from 'electron'
-import { HarnessRuntime } from './runtime/harness-runtime'
+import { extractFailureCause, extractOffendingPlugin, HarnessRuntime } from './runtime/harness-runtime'
 import { LanMobileBridge } from './mobile/lan-mobile-bridge'
 import { secureWindow } from './security'
 import { ensureLaunchRoot } from './state/launch-root'
+import { resetPluginProfile, uninstallPluginFromProfile } from './state/plugin-recovery'
 import { isAbortedNavigationError, shouldLoadHarnessUrl } from './window-navigation'
 import {
   checkForUpdates,
@@ -277,31 +278,63 @@ async function showRuntimeFailure(snapshot: RuntimeSnapshot): Promise<void> {
   if (failureDialogVisible || quitting) return
   failureDialogVisible = true
 
+  const dshHome = join(app.getPath('userData'), 'harness')
+  const isChinese = harnessLocale() === 'zh'
+
   try {
     while (!quitting && runtime.snapshot().phase === 'failed') {
+      const offendingPlugin = extractOffendingPlugin(runtime.snapshot().logs)
+      const buttons = offendingPlugin
+        ? (isChinese
+            ? [`卸载 "${offendingPlugin}" 并重试`, '重试', '查看日志', '退出']
+            : [`Uninstall "${offendingPlugin}" & Retry`, 'Retry', 'Show Log', 'Quit'])
+        : (isChinese
+            ? ['重试', '查看日志', '退出']
+            : ['Retry', 'Show Log', 'Quit'])
+
+      const detailText = isChinese
+        ? (snapshot.launchDirectory
+            ? `工作区目录: ${snapshot.launchDirectory}\n\n${offendingPlugin ? `检测到插件 "${offendingPlugin}" 引发错误。可尝试一键卸载该插件并重试，或查看日志排查。` : '您可以重试或查看日志排查。'}`
+            : (offendingPlugin ? `检测到插件 "${offendingPlugin}" 引发错误。可尝试一键卸载该插件并重试，或查看日志排查。` : '您可以重试或查看日志排查。'))
+        : (snapshot.launchDirectory
+            ? `Launch directory: ${snapshot.launchDirectory}\n\n${offendingPlugin ? `Plugin "${offendingPlugin}" caused a startup error. You can uninstall it and retry, or inspect the Harness log.` : 'You can retry or inspect the Harness log.'}`
+            : (offendingPlugin ? `Plugin "${offendingPlugin}" caused a startup error. You can uninstall it and retry, or inspect the Harness log.` : 'You can retry or inspect the Harness log.'))
+
       const options: MessageBoxOptions = {
         type: 'error',
-        title: 'Harness could not start',
+        title: isChinese ? 'Harness 启动失败' : 'Harness could not start',
         message: snapshot.message,
-        detail: snapshot.launchDirectory
-          ? `Launch directory: ${snapshot.launchDirectory}\n\nYou can retry or inspect the Harness log.`
-          : 'You can retry or inspect the Harness log.',
-        buttons: ['Retry', 'Show Log', 'Quit'],
+        detail: detailText,
+        buttons,
         defaultId: 0,
-        cancelId: 2,
+        cancelId: buttons.length - 1,
         noLink: true
       }
       const result = mainWindow
         ? await dialog.showMessageBox(mainWindow, options)
         : await dialog.showMessageBox(options)
 
-      if (result.response === 0) {
-        await launchHarness()
-      } else if (result.response === 1) {
-        shell.showItemInFolder(join(app.getPath('logs'), 'harness.log'))
-        continue
+      if (offendingPlugin) {
+        if (result.response === 0) {
+          await uninstallPluginFromProfile(dshHome, offendingPlugin)
+          await launchHarness()
+        } else if (result.response === 1) {
+          await launchHarness()
+        } else if (result.response === 2) {
+          shell.showItemInFolder(join(app.getPath('logs'), 'harness.log'))
+          continue
+        } else {
+          app.quit()
+        }
       } else {
-        app.quit()
+        if (result.response === 0) {
+          await launchHarness()
+        } else if (result.response === 1) {
+          shell.showItemInFolder(join(app.getPath('logs'), 'harness.log'))
+          continue
+        } else {
+          app.quit()
+        }
       }
 
       if (runtime.snapshot().phase !== 'failed') return
@@ -351,12 +384,12 @@ function installMenu(): void {
         },
         { type: 'separator' },
         {
-          label: 'Restart Harness',
+          label: isChinese ? '重启 Harness' : 'Restart Harness',
           accelerator: 'CmdOrCtrl+Shift+R',
           click: () => void launchHarness().catch(showUnexpectedError)
         },
         {
-          label: 'Show Harness Log',
+          label: isChinese ? '查看 Harness 日志' : 'Show Harness Log',
           click: () => shell.showItemInFolder(join(app.getPath('logs'), 'harness.log'))
         },
         ...(process.platform === 'darwin'
@@ -506,6 +539,15 @@ async function bootstrap(): Promise<void> {
   })
   ipcMain.handle('mobile:open-pairing', () => showMobilePairing())
   ipcMain.handle('mobile:status', () => ({ connected: mobileBridge.snapshot().connected }))
+  ipcMain.handle('harness:show-log', () => {
+    shell.showItemInFolder(join(app.getPath('logs'), 'harness.log'))
+  })
+  ipcMain.handle('harness:reset-plugins', async (_event, pluginName?: string) => {
+    const dshHome = join(app.getPath('userData'), 'harness')
+    await resetPluginProfile(dshHome, pluginName)
+    await launchHarness()
+    return { ok: runtime.snapshot().phase === 'ready' }
+  })
   installMenu()
   await launchHarness()
   if (!developmentBuild) {

--- a/src/main/runtime/harness-runtime.ts
+++ b/src/main/runtime/harness-runtime.ts
@@ -293,6 +293,42 @@ export function extractFailureCause(logLines: readonly string[]): string | undef
   return undefined
 }
 
+const CORE_BUNDLES = new Set(['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'])
+
+export function extractOffendingPlugin(logLines: readonly string[]): string | undefined {
+  for (const line of logLines) {
+    if (!line.startsWith('[stderr] ')) continue
+    const text = line.slice(8)
+
+    const m1 = text.match(/failed to apply loader entry [^\s]+ \((@[^)]+|[^)]+)\)/i)
+    if (m1 && m1[1] && !CORE_BUNDLES.has(m1[1].trim())) {
+      return m1[1].trim()
+    }
+
+    const m2 = text.match(/cannot resolve profile bundle ["']([^"']+)["']/i)
+    if (m2 && m2[1] && !CORE_BUNDLES.has(m2[1].trim())) {
+      return m2[1].trim()
+    }
+
+    const m3 = text.match(/profile bundle ["']([^"']+)["'] declares no dsh\.bundle/i)
+    if (m3 && m3[1] && !CORE_BUNDLES.has(m3[1].trim())) {
+      return m3[1].trim()
+    }
+
+    const m4 = text.match(/failed to import loader entry [^\s]+ \((@[^)]+|[^)]+)\)/i)
+    if (m4 && m4[1] && !CORE_BUNDLES.has(m4[1].trim())) {
+      return m4[1].trim()
+    }
+
+    const m5 = text.match(/plugin\(s\) failed to load:\s*([a-zA-Z0-9@/_-]+)/i)
+    if (m5 && m5[1] && !CORE_BUNDLES.has(m5[1].trim())) {
+      return m5[1].trim()
+    }
+  }
+
+  return undefined
+}
+
 export function formatExitCode(code: number): string {
   const unsigned = code >>> 0
   const hexadecimal = `0x${unsigned.toString(16).padStart(8, '0').toUpperCase()}`

--- a/src/main/state/plugin-recovery.ts
+++ b/src/main/state/plugin-recovery.ts
@@ -1,0 +1,117 @@
+import { existsSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export function profilePackageJsonPath(dshHome: string): string {
+  return join(dshHome, 'profiles', 'web', 'package.json')
+}
+
+export function profileCordisPatchPath(dshHome: string): string {
+  return join(dshHome, 'profiles', 'web', 'cordis.patch.yml')
+}
+
+interface ProfileManifest {
+  name?: string
+  private?: boolean
+  dependencies?: Record<string, string>
+  dsh?: {
+    profile?: {
+      bundles?: string[]
+    }
+  }
+}
+
+export async function uninstallPluginFromProfile(
+  dshHome: string,
+  pluginName: string
+): Promise<boolean> {
+  const manifestPath = profilePackageJsonPath(dshHome)
+  if (!existsSync(manifestPath)) return false
+
+  try {
+    const raw = await readFile(manifestPath, 'utf8')
+    const manifest = JSON.parse(raw) as ProfileManifest
+    let modified = false
+
+    if (manifest.dependencies && pluginName in manifest.dependencies) {
+      delete manifest.dependencies[pluginName]
+      modified = true
+    }
+
+    if (manifest.dsh?.profile?.bundles) {
+      const originalLength = manifest.dsh.profile.bundles.length
+      manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter(
+        (bundle) => bundle !== pluginName
+      )
+      if (manifest.dsh.profile.bundles.length !== originalLength) {
+        modified = true
+      }
+    }
+
+    if (modified) {
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8')
+      return true
+    }
+  } catch {
+    return false
+  }
+
+  return false
+}
+
+export async function resetPluginProfile(
+  dshHome: string,
+  failingPlugin?: string
+): Promise<boolean> {
+  const manifestPath = profilePackageJsonPath(dshHome)
+  if (!existsSync(manifestPath)) return false
+
+  try {
+    const raw = await readFile(manifestPath, 'utf8')
+    const manifest = JSON.parse(raw) as ProfileManifest
+
+    if (failingPlugin) {
+      const scope = failingPlugin.startsWith('@') ? failingPlugin.split('/')[0] : undefined
+      if (manifest.dependencies) {
+        delete manifest.dependencies[failingPlugin]
+        for (const dep of Object.keys(manifest.dependencies)) {
+          if (
+            failingPlugin.includes(dep) ||
+            dep.includes(failingPlugin) ||
+            (scope && dep.startsWith(scope))
+          ) {
+            delete manifest.dependencies[dep]
+          }
+        }
+      }
+      if (manifest.dsh?.profile?.bundles) {
+        manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter(
+          (b) =>
+            b !== failingPlugin &&
+            !failingPlugin.includes(b) &&
+            !b.includes(failingPlugin) &&
+            (!scope || !b.startsWith(scope))
+        )
+      }
+    } else {
+      // If no specific plugin given, reset bundles to safe core bundles
+      const safeBundles = ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app']
+      if (manifest.dependencies?.dshmarket) safeBundles.push('dshmarket')
+      if (manifest.dsh?.profile?.bundles) {
+        manifest.dsh.profile.bundles = safeBundles
+      }
+    }
+
+    await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8')
+
+    // Reset cordis.patch.yml to clean state
+    const patchPath = profileCordisPatchPath(dshHome)
+    if (existsSync(patchPath)) {
+      await writeFile(patchPath, '[]\n', 'utf8')
+    }
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,13 +6,25 @@ import {
   updateMessage,
   type UpdateLocale
 } from './update-view'
+import {
+  isPluginLoadError,
+  extractPluginName,
+  pluginErrorMessage
+} from './plugin-error-view'
 
 const ROOT_ID = 'dsh-desktop-update-root'
+const PLUGIN_ERROR_ROOT_ID = 'dsh-desktop-plugin-error-root'
 const MOBILE_BUTTON_ID = 'dsh-desktop-mobile-button'
 const locale: UpdateLocale = navigator.language.toLowerCase().startsWith('zh') ? 'zh' : 'en'
 
 let host: HTMLDivElement | undefined
 let content: HTMLDivElement | undefined
+let pluginErrorHost: HTMLDivElement | undefined
+let pluginErrorContent: HTMLDivElement | undefined
+let activePluginErrorName: string | undefined
+let pluginErrorVisible = false
+let restartingHarness = false
+let resettingHarness = false
 let currentStatus: UpdateStatus | undefined
 let dismissedVersion: string | null = null
 let dismissedTransientPhase: UpdateStatus['phase'] | null = null
@@ -20,7 +32,59 @@ let installing = false
 let receivedStatusEvent = false
 let phoneConnected = false
 let mobileStatusTimer: number | undefined
-const mobileButtonObserver = new MutationObserver(mountMobileButton)
+
+function checkBootFailureInDom(): void {
+  const root = document.body || document.documentElement
+  if (!root) return
+  const divs = Array.from(root.querySelectorAll('div'))
+  const failedTitle = divs.find((el) => el.textContent?.trim() === 'Failed to load plugins')
+  if (!failedTitle || !failedTitle.parentElement) return
+
+  const failedContainer = failedTitle.parentElement
+  const errorText = failedContainer.textContent ?? ''
+  const pluginName = extractPluginName(errorText)
+
+  const INJECTED_ID = 'dsh-desktop-boot-recovery-actions'
+  if (document.getElementById(INJECTED_ID)) return
+
+  const actionsDiv = document.createElement('div')
+  actionsDiv.id = INJECTED_ID
+  actionsDiv.style.cssText = [
+    'display:flex',
+    'margin-top:20px',
+    'justify-content:center',
+    'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif'
+  ].join(';')
+
+  const restartBtn = document.createElement('button')
+  restartBtn.type = 'button'
+  restartBtn.textContent = locale === 'zh' ? '重启 Harness' : 'Restart Harness'
+  restartBtn.style.cssText = [
+    'appearance:none',
+    'border:none',
+    'background:#4d6bfe',
+    'color:#ffffff',
+    'padding:9px 22px',
+    'border-radius:8px',
+    'font-size:13px',
+    'font-weight:600',
+    'cursor:pointer',
+    'box-shadow:0 2px 8px rgba(77,107,254,0.35)'
+  ].join(';')
+  restartBtn.addEventListener('click', () => {
+    restartBtn.disabled = true
+    restartBtn.textContent = locale === 'zh' ? '正在重启…' : 'Restarting…'
+    void ipcRenderer.invoke('harness:reset-plugins', pluginName)
+  })
+
+  actionsDiv.appendChild(restartBtn)
+  failedContainer.appendChild(actionsDiv)
+}
+
+const domObserver = new MutationObserver(() => {
+  mountMobileButton()
+  checkBootFailureInDom()
+})
 
 contextBridge.exposeInMainWorld('dshDesktopDirectoryPicker', {
   pick: (): Promise<string | null> => ipcRenderer.invoke('directory-picker:open')
@@ -78,16 +142,30 @@ async function refreshMobileStatus(): Promise<void> {
 
 function initializeUi(): void {
   mount()
+  mountPluginErrorCard()
   mountMobileButton()
-  mobileButtonObserver.observe(document.documentElement, {
+  checkBootFailureInDom()
+  domObserver.observe(document.documentElement, {
     childList: true,
-    subtree: true,
-    attributes: true,
-    attributeFilter: ['data-dsh-sidebar-wide']
+    subtree: true
   })
   void refreshMobileStatus()
   mobileStatusTimer ??= window.setInterval(() => void refreshMobileStatus(), 1000)
 }
+
+window.addEventListener('error', (event) => {
+  const err = event.error ?? event.message
+  if (isPluginLoadError(err)) {
+    showPluginErrorNotification(extractPluginName(err))
+  }
+})
+
+window.addEventListener('unhandledrejection', (event) => {
+  const reason = event.reason
+  if (isPluginLoadError(reason)) {
+    showPluginErrorNotification(extractPluginName(reason))
+  }
+})
 
 contextBridge.exposeInMainWorld(
   'dshDesktop',
@@ -95,6 +173,115 @@ contextBridge.exposeInMainWorld(
     restartHarness: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('harness:restart')
   })
 )
+
+function mountPluginErrorCard(): void {
+  if (document.getElementById(PLUGIN_ERROR_ROOT_ID)) return
+
+  pluginErrorHost = document.createElement('div')
+  pluginErrorHost.id = PLUGIN_ERROR_ROOT_ID
+  pluginErrorHost.style.cssText = [
+    'position:fixed',
+    'right:20px',
+    'bottom:20px',
+    'z-index:2147483647',
+    'display:none',
+    'width:min(384px,calc(100vw - 40px))',
+    'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif'
+  ].join(';')
+
+  const shadow = pluginErrorHost.attachShadow({ mode: 'closed' })
+  const style = document.createElement('style')
+  style.textContent = styles
+  pluginErrorContent = document.createElement('div')
+  shadow.append(style, pluginErrorContent)
+  document.documentElement.appendChild(pluginErrorHost)
+  renderPluginError()
+}
+
+function showPluginErrorNotification(pluginName?: string): void {
+  activePluginErrorName = pluginName || activePluginErrorName
+  pluginErrorVisible = true
+  mountPluginErrorCard()
+  renderPluginError()
+}
+
+function dismissPluginError(): void {
+  pluginErrorVisible = false
+  if (pluginErrorHost) {
+    pluginErrorHost.style.display = 'none'
+  }
+}
+
+function renderPluginError(): void {
+  if (!pluginErrorHost || !pluginErrorContent) return
+
+  if (!pluginErrorVisible) {
+    pluginErrorHost.style.display = 'none'
+    pluginErrorContent.replaceChildren()
+    return
+  }
+
+  pluginErrorHost.style.display = 'block'
+  const info = pluginErrorMessage(locale, activePluginErrorName)
+
+  const card = element('aside', 'card')
+  card.setAttribute('aria-live', 'polite')
+  card.setAttribute('aria-label', info.title)
+
+  const row = element('div', 'row')
+  const indicator = element('span', restartingHarness || resettingHarness ? 'spinner' : 'dot warning')
+  indicator.setAttribute('aria-hidden', 'true')
+  row.appendChild(indicator)
+
+  const body = element('div', 'body')
+  const title = element('p', 'message')
+  title.textContent = info.title
+  body.appendChild(title)
+
+  const detail = element('p', 'detail')
+  detail.textContent = info.message
+  body.appendChild(detail)
+
+  const actions = element('div', 'actions')
+  const restartBtn = button(
+    restartingHarness
+      ? locale === 'zh'
+        ? '正在重启…'
+        : 'Restarting…'
+      : locale === 'zh'
+        ? '重启 Harness'
+        : 'Restart Harness',
+    'primary'
+  )
+  restartBtn.disabled = restartingHarness
+  restartBtn.addEventListener('click', () => {
+    restartingHarness = true
+    renderPluginError()
+    void ipcRenderer
+      .invoke('harness:reset-plugins', activePluginErrorName)
+      .finally(() => {
+        restartingHarness = false
+        dismissPluginError()
+      })
+  })
+
+  const ignoreBtn = button(locale === 'zh' ? '忽略' : 'Dismiss', 'secondary')
+  ignoreBtn.disabled = restartingHarness
+  ignoreBtn.addEventListener('click', dismissPluginError)
+
+  actions.append(restartBtn, ignoreBtn)
+  body.appendChild(actions)
+
+  row.appendChild(body)
+
+  const close = button('×', 'close')
+  close.setAttribute('aria-label', locale === 'zh' ? '关闭' : 'Close')
+  close.addEventListener('click', dismissPluginError)
+  row.appendChild(close)
+
+  card.appendChild(row)
+  pluginErrorContent.replaceChildren(card)
+}
 
 function mount(): void {
   if (document.getElementById(ROOT_ID)) return
@@ -280,6 +467,10 @@ const styles = `
     border-radius: 999px;
     background: #4d6bfe;
     box-shadow: 0 0 0 4px rgba(77, 107, 254, 0.12);
+  }
+  .dot.warning {
+    background: #f59e0b;
+    box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.18);
   }
   .spinner {
     width: 17px;

--- a/src/preload/plugin-error-view.ts
+++ b/src/preload/plugin-error-view.ts
@@ -1,0 +1,58 @@
+import type { UpdateLocale } from './update-view'
+
+export function isPluginLoadError(error: unknown): boolean {
+  if (!error) return false
+  const message =
+    error instanceof Error
+      ? `${error.message}\n${error.stack ?? ''}`
+      : typeof error === 'string'
+        ? error
+        : typeof (error as { message?: unknown }).message === 'string'
+          ? (error as { message: string }).message
+          : typeof (error as { reason?: unknown }).reason === 'string'
+            ? (error as { reason: string }).reason
+            : String((error as { reason?: { message?: unknown } }).reason?.message ?? '')
+
+  return (
+    /client-modules:\s*bundle\s*script\s*.*failed\s*to\s*load/i.test(message) ||
+    /failed\s*to\s*import\s*loader\s*entry/i.test(message) ||
+    /client-modules:.*missed\s*the\s*module\s*table/i.test(message)
+  )
+}
+
+export function extractPluginName(error: unknown): string | undefined {
+  if (!error) return undefined
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : String((error as { reason?: unknown }).reason ?? (error as { message?: unknown }).message ?? '')
+
+  // Matches pattern: entry <hash> (@scope/pkg or pkg)
+  const entryMatch = /loader\s+entry\s+[a-f0-9]+\s+\((@[^)]+|[^)]+)\)/i.exec(message)
+  if (entryMatch?.[1]) return entryMatch[1].trim()
+
+  // Matches pattern: /plugins/<name>/client.js
+  const scriptMatch = /\/plugins\/((?:@[^/]+\/)?[^/?]+)\/client\.js/i.exec(message)
+  if (scriptMatch?.[1]) return scriptMatch[1].trim()
+
+  return undefined
+}
+
+export function pluginErrorMessage(
+  locale: UpdateLocale,
+  pluginName?: string
+): { title: string; message: string } {
+  const zh = locale === 'zh'
+  return {
+    title: zh ? '插件加载异常' : 'Plugin Loading Error',
+    message: zh
+      ? pluginName
+        ? `插件 ${pluginName} 加载失败或已被卸载，请重启 Harness 运行时使更改生效。`
+        : '检测到插件已被卸载或加载失败，请重启 Harness 运行时使更改生效。'
+      : pluginName
+        ? `Plugin ${pluginName} failed to load or was uninstalled. Restart Harness to apply changes.`
+        : 'A plugin was uninstalled or failed to load. Restart Harness to apply changes.'
+  }
+}

--- a/test/plugin-error-view.test.ts
+++ b/test/plugin-error-view.test.ts
@@ -1,0 +1,63 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+import {
+  extractPluginName,
+  isPluginLoadError,
+  pluginErrorMessage
+} from '../src/preload/plugin-error-view'
+
+const sampleLoaderError =
+  'failed to import loader entry 516a3af0 (@linxin666/dsh-client-ui-web-ui-settings): client-modules: bundle script /plugins/@linxin666/dsh-client-ui-web-ui-settings/client.js?rev=54840dfe7860 failed to load'
+
+const sampleScriptError =
+  'client-modules: bundle script /plugins/custom-plugin/client.js failed to load'
+
+describe('plugin load error detection and extraction', () => {
+  it('detects bundle script and loader entry failure errors', () => {
+    expect(isPluginLoadError(new Error(sampleLoaderError))).toBe(true)
+    expect(isPluginLoadError(sampleLoaderError)).toBe(true)
+    expect(isPluginLoadError({ message: sampleScriptError })).toBe(true)
+    expect(isPluginLoadError({ reason: sampleLoaderError })).toBe(true)
+    expect(isPluginLoadError(new Error('SyntaxError: Unexpected token'))).toBe(false)
+    expect(isPluginLoadError(undefined)).toBe(false)
+    expect(isPluginLoadError(null)).toBe(false)
+  })
+
+  it('extracts plugin name from error messages', () => {
+    expect(extractPluginName(sampleLoaderError)).toBe('@linxin666/dsh-client-ui-web-ui-settings')
+    expect(extractPluginName(sampleScriptError)).toBe('custom-plugin')
+    expect(extractPluginName('some generic error')).toBeUndefined()
+  })
+
+  it('formats localized messages for Chinese and English', () => {
+    const zhWithPlugin = pluginErrorMessage('zh', '@linxin666/dsh-client-ui-web-ui-settings')
+    expect(zhWithPlugin.title).toBe('插件加载异常')
+    expect(zhWithPlugin.message).toContain('@linxin666/dsh-client-ui-web-ui-settings')
+    expect(zhWithPlugin.message).toContain('重启 Harness')
+
+    const enWithPlugin = pluginErrorMessage('en', 'custom-plugin')
+    expect(enWithPlugin.title).toBe('Plugin Loading Error')
+    expect(enWithPlugin.message).toContain('custom-plugin')
+    expect(enWithPlugin.message).toContain('Restart Harness')
+
+    const zhDefault = pluginErrorMessage('zh')
+    expect(zhDefault.message).toContain('检测到插件已被卸载或加载失败')
+
+    const enDefault = pluginErrorMessage('en')
+    expect(enDefault.message).toContain('A plugin was uninstalled or failed to load')
+  })
+})
+
+describe('preload wiring for plugin error toast', () => {
+  it('installs error listeners and exposes restart button', async () => {
+    const preload = await readFile('src/preload/index.ts', 'utf8')
+
+    expect(preload).toContain('dsh-desktop-plugin-error-root')
+    expect(preload).toContain("window.addEventListener('error'")
+    expect(preload).toContain("window.addEventListener('unhandledrejection'")
+    expect(preload).toContain('isPluginLoadError')
+    expect(preload).toContain("harness:restart")
+    expect(preload).toContain("harness:reset-plugins")
+    expect(preload).toContain('mountPluginErrorCard')
+  })
+})

--- a/test/plugin-recovery.test.ts
+++ b/test/plugin-recovery.test.ts
@@ -1,0 +1,119 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  profilePackageJsonPath,
+  resetPluginProfile,
+  uninstallPluginFromProfile
+} from '../src/main/state/plugin-recovery'
+
+describe('plugin-recovery', () => {
+  const testDir = join(__dirname, '.temp-plugin-recovery-test')
+
+  beforeEach(async () => {
+    await mkdir(join(testDir, 'profiles', 'web'), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('uninstalls specific offending plugin from package.json dependencies and bundles', async () => {
+    const pkgPath = profilePackageJsonPath(testDir)
+    const originalPkg = {
+      name: 'dsh-profile-web',
+      dependencies: {
+        'dsh-better-sidebar': '^0.13.1',
+        '@linxin666/dsh-web-ui-all': '^0.2.2',
+        dshmarket: '1.9.0'
+      },
+      dsh: {
+        profile: {
+          bundles: [
+            '@deepseek-ai/dsh-base',
+            '@deepseek-ai/dsh-web-app',
+            'dshmarket',
+            'dsh-better-sidebar',
+            '@linxin666/dsh-web-ui-all'
+          ]
+        }
+      }
+    }
+    await writeFile(pkgPath, JSON.stringify(originalPkg, null, 2))
+
+    const success = await uninstallPluginFromProfile(testDir, 'dsh-better-sidebar')
+    expect(success).toBe(true)
+
+    const updatedPkg = JSON.parse(await readFile(pkgPath, 'utf8'))
+    expect(updatedPkg.dependencies).toEqual({
+      '@linxin666/dsh-web-ui-all': '^0.2.2',
+      dshmarket: '1.9.0'
+    })
+    expect(updatedPkg.dsh.profile.bundles).toEqual([
+      '@deepseek-ai/dsh-base',
+      '@deepseek-ai/dsh-web-app',
+      'dshmarket',
+      '@linxin666/dsh-web-ui-all'
+    ])
+  })
+
+  it('returns false when package.json does not exist', async () => {
+    const success = await uninstallPluginFromProfile(join(testDir, 'nonexistent'), 'some-plugin')
+    expect(success).toBe(false)
+  })
+
+  it('returns false when plugin is not in package.json', async () => {
+    const pkgPath = profilePackageJsonPath(testDir)
+    await writeFile(
+      pkgPath,
+      JSON.stringify({
+        dependencies: {
+          dshmarket: '1.9.0'
+        },
+        dsh: {
+          profile: {
+            bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', 'dshmarket']
+          }
+        }
+      })
+    )
+
+    const success = await uninstallPluginFromProfile(testDir, 'non-existent-plugin')
+    expect(success).toBe(false)
+  })
+
+  it('resets plugin profile by cleaning up specific failing plugin and related packages', async () => {
+    const pkgPath = profilePackageJsonPath(testDir)
+    const originalPkg = {
+      name: 'dsh-profile-web',
+      dependencies: {
+        '@linxin666/dsh-web-ui-all': '^0.2.2',
+        dshmarket: '1.9.0'
+      },
+      dsh: {
+        profile: {
+          bundles: [
+            '@deepseek-ai/dsh-base',
+            '@deepseek-ai/dsh-web-app',
+            'dshmarket',
+            '@linxin666/dsh-web-ui-all'
+          ]
+        }
+      }
+    }
+    await writeFile(pkgPath, JSON.stringify(originalPkg, null, 2))
+
+    const success = await resetPluginProfile(testDir, '@linxin666/dsh-client-ui-web-ui-settings')
+    expect(success).toBe(true)
+
+    const updatedPkg = JSON.parse(await readFile(pkgPath, 'utf8'))
+    expect(updatedPkg.dependencies).toEqual({
+      dshmarket: '1.9.0'
+    })
+    expect(updatedPkg.dsh.profile.bundles).toEqual([
+      '@deepseek-ai/dsh-base',
+      '@deepseek-ai/dsh-web-app',
+      'dshmarket'
+    ])
+  })
+})

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -4,6 +4,7 @@ import {
   buildHarnessSpawnOptions,
   buildNodeArguments,
   extractFailureCause,
+  extractOffendingPlugin,
   formatExitCode
 } from '../src/main/runtime/harness-runtime'
 import { canGrantWindowPermission, isTrustedAppUrl } from '../src/main/security-policy'
@@ -159,6 +160,51 @@ describe('harness failure cause extraction', () => {
       '[stderr] short error message',
     ]
     expect(extractFailureCause(logs)).toBe('short error message')
+  })
+})
+
+describe('offending plugin extraction', () => {
+  it('extracts plugin name from loader entry failure in stderr', () => {
+    const logs = [
+      '[stderr] [harness-node] DSH entry failed: Error: dsh: plugin tree failed to load: failed to apply loader entry web-ui-better-sidebar (dsh-better-sidebar): webserver: duplicate prefix route "/sidebar/api"',
+      '[stderr] Error: webserver: duplicate prefix route "/sidebar/api"'
+    ]
+    expect(extractOffendingPlugin(logs)).toBe('dsh-better-sidebar')
+  })
+
+  it('extracts scoped plugin name from loader entry failure', () => {
+    const logs = [
+      '[stderr] [harness-node] DSH entry failed: Error: dsh: plugin tree failed to load: failed to apply loader entry abc (@linxin666/dsh-web-ui-all): error message'
+    ]
+    expect(extractOffendingPlugin(logs)).toBe('@linxin666/dsh-web-ui-all')
+  })
+
+  it('extracts plugin name from cannot resolve profile bundle error', () => {
+    const logs = [
+      '[stderr] [harness-node] DSH entry failed: Error: dsh: cannot resolve profile bundle "custom-broken-bundle" from the dsh installation'
+    ]
+    expect(extractOffendingPlugin(logs)).toBe('custom-broken-bundle')
+  })
+
+  it('extracts plugin name from declares no dsh.bundle error', () => {
+    const logs = [
+      '[stderr] [harness-node] DSH entry failed: Error: dsh: profile bundle "plain-npm-package" declares no dsh.bundle in its package.json'
+    ]
+    expect(extractOffendingPlugin(logs)).toBe('plain-npm-package')
+  })
+
+  it('ignores core deepseek packages as offending plugins', () => {
+    const logs = [
+      '[stderr] [harness-node] DSH entry failed: Error: dsh: plugin tree failed to load: failed to apply loader entry base (@deepseek-ai/dsh-base): some error'
+    ]
+    expect(extractOffendingPlugin(logs)).toBeUndefined()
+  })
+
+  it('returns undefined when no plugin error is matched', () => {
+    const logs = [
+      '[stderr] [harness-node] uncaught exception: ReferenceError: x is not defined'
+    ]
+    expect(extractOffendingPlugin(logs)).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## 变更背景
当用户安装的第三方插件在后端启动阶段发生路由冲突（如 `duplicate prefix route "/sidebar/api"`）或在前端渲染阶段缺失脚本（如 `Failed to load plugins: failed to import loader entry ...`）时，应用会发生崩溃或全屏报错，导致无法正常使用。

## 主要改动
1. **启动阶段冲突插件自动识别与一键卸载**（`src/main/runtime/harness-runtime.ts` & `src/main/state/plugin-recovery.ts`）：
   - 在 Harness 启动失败时，自动分析 stderr 日志精准提取引发冲突的插件名称。
   - 报错弹窗直接提供 **【卸载 "<插件名>" 并重试】** 选项，一键从 `package.json` 中剔除问题插件并保留其他所有正常安装的插件。
2. **全屏报错卡片自动注入【重启 Harness】按钮**（`src/preload/index.ts`）：
   - 当前端 React 渲染出全屏 `Failed to load plugins` 错误卡片时，DOM 监听器实时在卡片中央注入操作按钮 **【重启 Harness】**。
   - 用户点击后，后台自动清理该报错插件残余配置并重置 `cordis.patch.yml`，随后自动拉起服务并刷新页面。
3. **单元测试与验证**：
   - 新增 `test/plugin-recovery.test.ts` 与 `test/plugin-error-view.test.ts`，覆盖插件包名提取、配置精准剔除、残余重置等用例。
   - 全部 20 个测试套件（109 个单元测试）100% 通过。