### PR TITLE
fix: keep the stock `directoryPicker` seam active in the desktop composition

### DIFF
--- a/build/dsh-desktop.patch.yml
+++ b/build/dsh-desktop.patch.yml
@@ -1,13 +1,8 @@
-# DSH Desktop delegates directory selection to Electron's system dialog. Keep
-# the renderless client surface, but do not load the Koffi-based Host worker:
-# on Windows it can exit before reporting a result inside packaged Electron.
-- id: directory-picker
-  disabled: true
-
+# Keep the stock directory-picker (auto) row active: the native backend
+# serves ctx.directoryPicker, so host-side consumers (host.pickDirectory,
+# plugins reading the seam) work unmodified. The client surface keeps its
+# Electron-dialog bridge via the client-ui patch in patches/.
 - insert:
-    - id: directory-picker-electron-desktop-surface
-      name: '@deepseek-ai/dsh-client-ui-directory-picker-native'
-
     # DSH Desktop owns the fixed-target dsh-market installer and its lightweight
     # settings entry. After dshmarket is installed and Harness restarts, the
     # community plugin replaces the placeholder with its complete market UI.

--- a/test/directory-picker.test.ts
+++ b/test/directory-picker.test.ts
@@ -26,11 +26,12 @@ describe('desktop Electron directory picker', () => {
     )
   })
 
-  it('keeps only the client surface and removes the crashing Host worker', async () => {
+  it('keeps the stock picker composition: the seam comes from the stock auto row', async () => {
     const desktopPatch = await readFile('build/dsh-desktop.patch.yml', 'utf8')
 
-    expect(desktopPatch).toContain("name: '@deepseek-ai/dsh-client-ui-directory-picker-native'")
-    expect(desktopPatch).not.toContain("name: '@deepseek-ai/dsh-host-directory-picker-native'")
+    // No picker rows at all - the stock auto row mounts the native backend.
+    expect(desktopPatch).not.toMatch(/id:\s*directory-picker/)
+    expect(desktopPatch).not.toContain('dsh-client-ui-directory-picker-native')
   })
 
   it('captures the client bridge as a reproducible dependency patch', async () => {

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -114,9 +114,9 @@ describe('GitHub release contract', () => {
     expect(splash).toContain('Starting DSH Desktop')
     expect(splash).toContain('src="dsh-loader.gif"')
     expect(splash).not.toContain('class="track"')
-    expect(patch).toMatch(/id: directory-picker\r?\n  disabled: true/)
+    expect(patch).not.toMatch(/id:\s*directory-picker/)
     expect(patch).not.toContain("name: '@deepseek-ai/dsh-host-directory-picker-native'")
-    expect(patch).toContain("name: '@deepseek-ai/dsh-client-ui-directory-picker-native'")
+    expect(patch).not.toContain("name: '@deepseek-ai/dsh-client-ui-directory-picker-native'")
   })
 
   it('routes manual restarts through the active plugin recovery flow', async () => {


### PR DESCRIPTION
Closes #111 · Branch `feat/electron-directory-picker-seam` · Follow-up to #55

## What & why

#55 disabled the stock `directory-picker` (auto) row on the belief that the Koffi dialog worker can fail inside packaged Electron, inserting a standalone client surface instead. That removed `ctx.directoryPicker` from the host, so every host-side consumer broke: `host.pickDirectory` → `directory-picker-unavailable`, and plugins reading the seam threw (observed with `dsh-remote` 0.5.10: `cannot get property "directoryPicker" without inject`).

**The premise does not hold.** Verified on a packaged Windows v0.3.0 build from inside the Harness child: `pickNativeDirectory()` spawns the worker, a real selection resolves the path, and an abort cleanly closes the dialog.

## Change

`build/dsh-desktop.patch.yml`: drop the disable row and the client-surface insert. The stock auto row from dsh-web-app mounts the native backend — **`ctx.directoryPicker`, `host.pickDirectory`, and the entire seam work for every plugin, unmodified, on dsh's original pick channel.**

The preload bridge and the client-ui patch are untouched: the client surface keeps the parented Electron dialog.

**3 files, +10/−14. No new transport, no new wire surface, no env flags, no dependency-patch changes, no main-process changes.** (The rc.8 dependency-patch set is untouched — the fix carries over unchanged across the rc.7 → rc.8 upgrade.)

## Verification

- Rebased onto current `main` (rc.8): `npm test` — **168 passing**; `npm run typecheck`, `npm run build` — clean
- Live proof on an installed v0.3.0 build, from inside the Harness child: a real `pickNativeDirectory()` call resolved the selected path; abort produced a clean rejection
- End-to-end with an unmodified third-party plugin: reverted the installed `dsh-remote` to stock **0.5.10** — with this composition change its local-pick flow works through the stock seam with **zero changes to dsh-remote**
- Note for maintainers: my verification is Windows-only; the disable comment cited Windows specifically, but a macOS re-check before release would confirm the same
