### PR TITLE
AND-262: require confirmation before installing updates

### DIFF
--- a/src/main/update/update-manager.ts
+++ b/src/main/update/update-manager.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, powerMonitor } from 'electron'
 import electronUpdater from 'electron-updater'
 import type { UpdateStatus } from '../../shared/contracts'
 import {
+  AUTO_INSTALL_ON_APP_QUIT,
   shouldCheckAfterResume,
   supportsAutoUpdates,
   UPDATE_CHECK_INTERVAL_MS,
@@ -120,7 +121,7 @@ export function stopUpdateManager(): void {
 
 function configureUpdater(): void {
   autoUpdater.autoDownload = true
-  autoUpdater.autoInstallOnAppQuit = true
+  autoUpdater.autoInstallOnAppQuit = AUTO_INSTALL_ON_APP_QUIT
   autoUpdater.allowPrerelease = false
   autoUpdater.logger = {
     info: (...args: unknown[]) => console.info('[updater]', ...args),

--- a/src/main/update/update-policy.ts
+++ b/src/main/update/update-policy.ts
@@ -1,6 +1,7 @@
 export const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1_000
 export const UPDATE_STARTUP_DELAY_MS = 15_000
 export const UPDATE_STARTUP_JITTER_MS = 15_000
+export const AUTO_INSTALL_ON_APP_QUIT = false
 
 export function supportsAutoUpdates(isPackaged: boolean, platform: NodeJS.Platform): boolean {
   return isPackaged && (platform === 'darwin' || platform === 'win32')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -287,9 +287,7 @@ function render(): void {
         render()
       })
     })
-    const later = button(locale === 'zh' ? '稍后' : 'Later', 'secondary')
-    later.addEventListener('click', dismissCurrent)
-    actions.append(install, later)
+    actions.append(install)
     body.appendChild(actions)
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -293,12 +293,10 @@ function render(): void {
 
   row.appendChild(body)
 
-  if (status.phase !== 'downloaded') {
-    const close = button('×', 'close')
-    close.setAttribute('aria-label', locale === 'zh' ? '关闭' : 'Close')
-    close.addEventListener('click', dismissCurrent)
-    row.appendChild(close)
-  }
+  const close = button('×', 'close')
+  close.setAttribute('aria-label', locale === 'zh' ? '关闭' : 'Close')
+  close.addEventListener('click', dismissCurrent)
+  row.appendChild(close)
 
   card.appendChild(row)
   content.replaceChildren(card)

--- a/src/preload/update-view.ts
+++ b/src/preload/update-view.ts
@@ -12,6 +12,7 @@ export function isUpdateDismissed(
   dismissedVersion: string | null,
   dismissedTransientPhase: UpdateStatus['phase'] | null = null
 ): boolean {
+  if (status.phase === 'downloaded') return false
   if (status.availableVersion) return status.availableVersion === dismissedVersion
   return status.phase === dismissedTransientPhase
 }

--- a/src/preload/update-view.ts
+++ b/src/preload/update-view.ts
@@ -12,7 +12,6 @@ export function isUpdateDismissed(
   dismissedVersion: string | null,
   dismissedTransientPhase: UpdateStatus['phase'] | null = null
 ): boolean {
-  if (status.phase === 'downloaded') return false
   if (status.availableVersion) return status.availableVersion === dismissedVersion
   return status.phase === dismissedTransientPhase
 }

--- a/test/update-ui.test.ts
+++ b/test/update-ui.test.ts
@@ -15,6 +15,13 @@ const downloading: UpdateStatus = {
   manual: false
 }
 
+const downloaded: UpdateStatus = {
+  phase: 'downloaded',
+  currentVersion: '1.0.0',
+  availableVersion: '1.1.0',
+  manual: false
+}
+
 describe('desktop update card visibility', () => {
   it('shows automatic downloads but keeps automatic background checks quiet', () => {
     expect(shouldShowUpdate(downloading)).toBe(true)
@@ -31,6 +38,10 @@ describe('desktop update card visibility', () => {
     expect(isUpdateDismissed({ ...downloading, availableVersion: '1.2.0' }, '1.1.0')).toBe(
       false
     )
+  })
+
+  it('keeps a downloaded update visible until the user installs it', () => {
+    expect(isUpdateDismissed(downloaded, '1.1.0')).toBe(false)
   })
 
   it('formats localized progress copy', () => {

--- a/test/update-ui.test.ts
+++ b/test/update-ui.test.ts
@@ -40,8 +40,10 @@ describe('desktop update card visibility', () => {
     )
   })
 
-  it('keeps a downloaded update visible until the user installs it', () => {
-    expect(isUpdateDismissed(downloaded, '1.1.0')).toBe(false)
+  it('dismisses a downloaded update when the user closes the card', () => {
+    expect(isUpdateDismissed(downloaded, null)).toBe(false)
+    expect(isUpdateDismissed(downloaded, '1.0.0')).toBe(false)
+    expect(isUpdateDismissed(downloaded, '1.1.0')).toBe(true)
   })
 
   it('formats localized progress copy', () => {

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -6,6 +6,7 @@ import { promisify } from 'node:util'
 import { afterEach, describe, expect, it } from 'vitest'
 import { parse, stringify } from 'yaml'
 import {
+  AUTO_INSTALL_ON_APP_QUIT,
   shouldCheckAfterResume,
   supportsAutoUpdates,
   UPDATE_CHECK_INTERVAL_MS
@@ -20,6 +21,10 @@ afterEach(async () => {
 })
 
 describe('desktop update policy', () => {
+  it('only installs a downloaded update after explicit user confirmation', () => {
+    expect(AUTO_INSTALL_ON_APP_QUIT).toBe(false)
+  })
+
   it('only enables updates for installed macOS and Windows builds', () => {
     expect(supportsAutoUpdates(true, 'darwin')).toBe(true)
     expect(supportsAutoUpdates(true, 'win32')).toBe(true)


### PR DESCRIPTION
## Summary

- disable electron-updater's automatic install on ordinary app quit
- keep the downloaded-update card visible until the user explicitly restarts to install
- cover the install policy and persistent ready state with regression tests

## Verification

- `npm test -- --run test/update.test.ts test/update-ui.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test -- --run` (190 tests)

Fixes #119
Closes AND-262
