### PR TITLE
fix(windows-titlebar): extend drag region to full titlebar height

### DIFF
--- a/src/preload/windows-titlebar.ts
+++ b/src/preload/windows-titlebar.ts
@@ -362,7 +362,7 @@ const titlebarStyles = `
     position: absolute;
     top: 0;
     right: 44px;
-    height: 5px;
+    height: ${WINDOWS_TITLEBAR_HEIGHT}px;
     left: var(${SIDEBAR_WIDTH_PROPERTY}, 280px);
     pointer-events: auto;
     -webkit-app-region: drag;

--- a/test/windows-titlebar.test.ts
+++ b/test/windows-titlebar.test.ts
@@ -33,7 +33,7 @@ describe('Windows titlebar menu', () => {
     expect(preload).toContain("document.documentElement.style.setProperty(SIDEBAR_WIDTH_PROPERTY")
     expect(preload).toContain('background: transparent')
     expect(preload).toContain('.safeArea::before')
-    expect(preload).toContain('height: 5px')
+    expect(preload).toContain('height: ${WINDOWS_TITLEBAR_HEIGHT}px')
     expect(preload).toContain('body.dsh-desktop-windows-titlebar-layout > #root')
     expect(preload).toContain('-webkit-app-region: drag')
     expect(preload).toContain('-webkit-app-region: no-drag')


### PR DESCRIPTION
## Summary

Fix the Windows titlebar drag region so the visible top strip becomes draggable again.

The injected `.safeArea::before` drag region was only 5px tall while the titlebar overlay is 36px tall, leaving the visible top strip non-draggable on Windows. This PR changes it to use the shared `WINDOWS_TITLEBAR_HEIGHT` constant so the drag region matches the overlay.

## Root cause

`src/preload/windows-titlebar.ts:365` set the height of the drag region to a hard-coded `5px`. The rest of the 36px title-bar strip was `no-drag`, so the visible header area could not be used to move the window. (Note: this only affected Windows; the macOS path injects a 24px drag region separately.)

## Changes

- `src/preload/windows-titlebar.ts` — set `.safeArea::before` height to `WINDOWS_TITLEBAR_HEIGHT` (36px), matching the titlebar overlay.
- `test/windows-titlebar.test.ts` — update the corresponding assertion.

## Verification

- `npm test -- test/windows-titlebar.test.ts` — 5/5 passing.
- Full `npm test` suite: 160 passing; 11 failing tests are unrelated `*patch.test.ts` tests that require `patch-package` to populate vendored module sources (skipped here because I installed with `--ignore-scripts` to avoid running native postinstall steps). They do not touch this change.

## Related

Fixes #121