### PR TITLE
fix: keep rc.6 UI plugins compatible with keyed settings slots (rc.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "agent"
   ],
   "scripts": {
-    "postinstall": "patch-package && node scripts/install-brand-assets.mjs && install-electron --no",
+    "postinstall": "patch-package && node scripts/install-plugin-compatibility.mjs && node scripts/install-brand-assets.mjs && install-electron --no",
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "icons:generate": "node scripts/generate-app-icons.mjs",

--- a/scripts/install-plugin-compatibility.mjs
+++ b/scripts/install-plugin-compatibility.mjs
@@ -1,0 +1,52 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const frontendDirectory = path.join(
+  projectRoot,
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-web-frontend',
+  'dist'
+)
+const indexPath = path.join(frontendDirectory, 'index.html')
+
+// rc.6 plugins registered `settings.plugin.item` as a list slot using `id`.
+// rc.7+ made it a keyed slot that requires `options.key`, so legacy bundles
+// fail to load with "keyed slot \"settings.plugin.item\" requires options.key".
+// DSH Desktop cannot ship a fork of the Harness frontend, so we shim the
+// minified SlotCore served to the browser: when the slot is `settings.plugin.item`
+// and the registrant only has `id`, copy `id` into `key`. All other keyed
+// slots stay strict.
+const original = 'const u=l.spec,c=n.priority??0'
+const compatible =
+  'const u=l.spec;n.name==="settings.plugin.item"&&u.kind==="keyed"&&n.key===void 0&&n.id!==void 0&&(n={...n,key:n.id});const c=n.priority??0'
+
+const index = await readFile(indexPath, 'utf8')
+const assetUrl = index.match(/src="\/(assets\/index-[^"]+\.js)"/)?.[1]
+if (assetUrl === undefined) {
+  throw new Error(
+    'Could not install plugin compatibility: DSH frontend asset was not found in dist/index.html'
+  )
+}
+
+const assetPath = path.join(frontendDirectory, assetUrl)
+const asset = await readFile(assetPath, 'utf8')
+
+if (asset.includes(compatible)) {
+  console.log(
+    `Legacy plugin compatibility already installed: ${path.relative(projectRoot, assetPath)}`
+  )
+} else {
+  const occurrences = asset.split(original).length - 1
+  if (occurrences !== 1) {
+    throw new Error(
+      `Could not install plugin compatibility in ${path.relative(projectRoot, assetPath)}: expected exactly one SlotCore registration site, found ${occurrences}. The DSH frontend bundle shape has changed; update scripts/install-plugin-compatibility.mjs.`
+    )
+  }
+  await writeFile(assetPath, asset.replace(original, compatible))
+  console.log(
+    `Installed legacy plugin compatibility: ${path.relative(projectRoot, assetPath)}`
+  )
+}

--- a/test/plugin-slot-compatibility.test.ts
+++ b/test/plugin-slot-compatibility.test.ts
@@ -1,0 +1,46 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = path.resolve(import.meta.dirname, '..')
+
+const SHIM_FRAGMENT =
+  'n.name==="settings.plugin.item"&&u.kind==="keyed"&&n.key===void 0&&n.id!==void 0&&(n={...n,key:n.id})'
+
+const FRONTEND_DIST = path.join(
+  projectRoot,
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-web-frontend',
+  'dist'
+)
+
+describe('legacy plugin settings slot compatibility', () => {
+  it('runs the postinstall shim and ships the new step in package.json', async () => {
+    const packageJson = JSON.parse(
+      await readFile(path.join(projectRoot, 'package.json'), 'utf8')
+    ) as { scripts: { postinstall: string } }
+    const installer = await readFile(
+      path.join(projectRoot, 'scripts', 'install-plugin-compatibility.mjs'),
+      'utf8'
+    )
+
+    expect(packageJson.scripts.postinstall).toContain(
+      'node scripts/install-plugin-compatibility.mjs'
+    )
+    expect(installer).toContain(
+      'const u=l.spec;n.name==="settings.plugin.item"&&u.kind==="keyed"&&n.key===void 0&&n.id!==void 0&&(n={...n,key:n.id});const c=n.priority??0'
+    )
+    expect(installer).toContain('const u=l.spec,c=n.priority??0')
+  })
+
+  it('patches the SlotCore bundle actually served by the desktop app', async () => {
+    const indexHtml = await readFile(path.join(FRONTEND_DIST, 'index.html'), 'utf8')
+    const asset = indexHtml.match(/src="\/(assets\/index-[^"]+\.js)"/)?.[1]
+    expect(asset).toBeDefined()
+
+    const servedAsset = await readFile(path.join(FRONTEND_DIST, asset ?? ''), 'utf8')
+    expect(servedAsset).toContain(SHIM_FRAGMENT)
+    expect(servedAsset).not.toContain('const u=l.spec,c=n.priority??0')
+  })
+})


### PR DESCRIPTION
## Summary

- shim the minified SlotCore served to the desktop window so an rc.6-style `id` is accepted as the `key` for the `settings.plugin.item` keyed slot, while keeping explicit keys authoritative
- install the same narrow patch at `postinstall` time against `dsh-web-frontend/dist/assets/index-*.js`, with idempotence and a fail-loud vendor-drift check
- add regression coverage for the postinstall wiring and the served frontend asset

## Root cause

Harness rc.6 exposed `settings.plugin.item` as a list slot, so existing third-party bundles register an `id`. rc.7 made that slot keyed and now requires `options.key`, causing those bundles to fail during UI startup before the desktop can render:

```
failed to apply loader entry 98f85676 (@linxin666/dsh-client-ui-web-ui-settings): keyed slot "settings.plugin.item" requires options.key
```

The browser shell bundles its own SlotCore inside `@deepseek-ai/dsh-web-frontend/dist`, so the fix has to be applied to the served minified asset, not just the module the unit tests import.

## Why this differs from PR #75

PR #75 targets `0.1.0-rc.7` and patches `@deepseek-ai/dsh-client-ui-slots` plus `@deepseek-ai/dsh-client-ui-settings-plugins`. Current `main` is on `0.1.0-rc.8`, where `@deepseek-ai/dsh-client-ui-slots` no longer exists as a separate package and the slot shim has to live in the served minified bundle. This PR re-aims the same compatibility shim at the rc.8 layout and is intentionally scoped to the slot registration; if the configurable-plugins tab also needs a downstream patch, that should be a follow-up once we can repro the missing-card symptom.

## Verification

- `node scripts/install-plugin-compatibility.mjs` (twice — confirms idempotence)
- `node --check` on the served frontend asset
- `npm test` — 32 files, 197 tests passed
- `npm run typecheck`
- `npm run build`

## Limitations

A packaged Electron visual launch was not performed because the Electron binary was intentionally not downloaded in this environment. The frontend rewrite deliberately fails installation if a future Harness asset no longer matches the pinned rc.8 shape, so an upgrade cannot silently omit the compatibility shim.

Fixes #74.