### PR TITLE
fix(market): pass ELECTRON_RUN_AS_NODE to the pnpm child environment

### DIFF
--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -277,10 +277,14 @@ export function buildPnpmEnvironment(
   environment = process.env,
   executablePath = process.execPath
 ) {
+  // The child is spawned as `process.execPath`, which on macOS is the Electron
+  // helper binary: it only runs the dsh CLI as Node when ELECTRON_RUN_AS_NODE
+  // is set. The harness entry (harness-node-entry.mjs) declares that flag in
+  // its own environment so that children spawned here inherit Node mode —
+  // deleting it here makes the helper exit 0 without ever running the CLI,
+  // which the market then mistakes for a successful pnpm run. Pass it through;
+  // the bundled-Node hosts (Windows, Linux) never set it and are unaffected.
   const result = { ...environment }
-  for (const key of Object.keys(result)) {
-    if (key.toUpperCase() === 'ELECTRON_RUN_AS_NODE') delete result[key]
-  }
 
   const seen = new Set()
   const paths = [binDirectory, dirname(executablePath), ...processPath(environment).split(delimiter)]

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -167,7 +167,7 @@ describe('desktop plugin market installer', () => {
     await writeFile(
       fakeDshEntry,
       [
-        "process.stdout.write(JSON.stringify({ args: process.argv.slice(2), cwd: process.cwd(), path: process.env.PATH }))",
+        "process.stdout.write(JSON.stringify({ args: process.argv.slice(2), cwd: process.cwd(), path: process.env.PATH, runAsNode: process.env.ELECTRON_RUN_AS_NODE }))",
         "await new Promise((resolve) => setTimeout(resolve, Number(process.env.DSH_DESKTOP_TEST_DELAY_MS ?? '0')))"
       ].join('\n'),
       'utf8'
@@ -206,8 +206,15 @@ describe('desktop plugin market installer', () => {
     expect(invocation.path.split(process.platform === 'win32' ? ';' : ':')[0]).toBe(
       binDirectory
     )
+    // The macOS helper binary only runs the dsh CLI as Node when the child
+    // environment carries ELECTRON_RUN_AS_NODE, so the spawn must not strip it.
+    expect(invocation.runAsNode).toBe('1')
     const pnpmEnv = buildPnpmEnvironment(binDirectory, environment)
-    expect(pnpmEnv).not.toHaveProperty('ELECTRON_RUN_AS_NODE')
+    // On macOS the child is spawned as the Electron helper binary, which only
+    // runs the dsh CLI as Node when ELECTRON_RUN_AS_NODE is set; the harness
+    // entry declares it for its children, so the environment must pass it
+    // through rather than stripping it.
+    expect(pnpmEnv.ELECTRON_RUN_AS_NODE).toBe('1')
     expect(pnpmEnv.PNPM_MAX_WORKERS).toBe('1')
     expect(pnpmEnv.npm_config_child_concurrency).toBe('1')
     expect(pnpmEnv.npm_config_package_import_method).toBe('clone-or-copy')


### PR DESCRIPTION
## 问题

macOS 上点击安装 dsh-market 报错 **"pnpm completed, but dshmarket was not found in the web profile."**,且安装从未真正执行(issue #140)。

## 根因

market 安装器运行在 harness 进程里,`createDesktopPnpmService` 直接以 `process.execPath` 拉起 `dsh plugin --profile web add dshmarket@latest`。在 macOS 上 `process.execPath` 是 Electron Helper 二进制,它只有在环境变量 `ELECTRON_RUN_AS_NODE` 存在时才以 Node 模式执行脚本。

`harness-node-entry.mjs` 正是为此在 harness 进程内声明了 `process.env.ELECTRON_RUN_AS_NODE = '1'`,让 harness 的子进程继承 Node 模式(见 `test/runtime.test.ts` 中 "declares Node mode for Harness children" 的测试说明)。但 `buildPnpmEnvironment` 把该变量从子进程环境里删掉了,导致 Helper 进程**立即以退出码 0 退出、从未执行 dsh CLI**,安装器误以为 pnpm 成功,检查 profile 后发现没有 dshmarket,于是抛出上述错误。Windows/Linux 使用打包的真实 Node 运行时,不受影响。

## 修复

`buildPnpmEnvironment` 不再删除 `ELECTRON_RUN_AS_NODE`,让 harness 入口声明的 Node 模式传递给子进程;Windows/Linux 从不设置该变量,不受影响。

## 验证

- 更新 `test/market-installer.test.js`:断言 `buildPnpmEnvironment` 透传该变量,并让 fake entry 打印子进程实际收到的 `ELECTRON_RUN_AS_NODE`,验证真实 spawn 路径。
- `test/market-installer.test.js` 12 个测试全部通过;`runtime.test.ts`、`profile-plugin-command.test.ts`、`pnpm-runner.test.js` 等关联测试通过。
- 在本机已用修复后的命令(`ELECTRON_RUN_AS_NODE=1` 的等价链路)验证 dshmarket@1.17.1 可正常安装到 web profile。
