### PR TITLE
fix(darwin): boot the packaged Harness without Node's internal loader

### DIFF
--- a/build/dsh-desktop.patch.yml
+++ b/build/dsh-desktop.patch.yml
@@ -17,3 +17,13 @@
   config:
     profile: web
     allowRestart: false
+
+# Harness creates the full Cordis HMR service after boot when no `hmr` service
+# exists, and that service throws without Node's internal module loader —
+# which a packaged Electron app cannot provide, so every signed macOS launch
+# failed profile boot at that step. This row supplies the config-watching
+# subset `watchUserPatches` actually needs; where the internals are reachable
+# it stands aside and the real service loads unchanged.
+- insert:
+    - id: dsh-desktop-hmr-fallback
+      name: dsh-desktop-hmr-fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@deepseek-ai/dsh-subprocess": "0.1.1-rc.1",
         "@deepseek-ai/dsh-timeout": "0.1.1-rc.1",
         "@deepseek-ai/dsh-workflow": "0.1.1-rc.1",
+        "dsh-desktop-hmr-fallback": "file:packages/dsh-desktop-hmr-fallback",
         "dsh-desktop-market-installer": "file:packages/dsh-desktop-market-installer",
         "electron-updater": "^6.8.9",
         "node": "24.9.0",
@@ -8454,6 +8455,10 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dsh-desktop-hmr-fallback": {
+      "resolved": "packages/dsh-desktop-hmr-fallback",
+      "link": true
+    },
     "node_modules/dsh-desktop-market-installer": {
       "resolved": "packages/dsh-desktop-market-installer",
       "link": true
@@ -13181,6 +13186,13 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "packages/dsh-desktop-hmr-fallback": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1"
       }
     },
     "packages/dsh-desktop-market-installer": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@deepseek-ai/dsh-subprocess": "0.1.1-rc.1",
     "@deepseek-ai/dsh-timeout": "0.1.1-rc.1",
     "@deepseek-ai/dsh-workflow": "0.1.1-rc.1",
+    "dsh-desktop-hmr-fallback": "file:packages/dsh-desktop-hmr-fallback",
     "dsh-desktop-market-installer": "file:packages/dsh-desktop-market-installer",
     "electron-updater": "^6.8.9",
     "node": "24.9.0",

--- a/packages/dsh-desktop-hmr-fallback/index.js
+++ b/packages/dsh-desktop-hmr-fallback/index.js
@@ -1,0 +1,95 @@
+import { watch } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { Service } from '@deepseek-ai/cordis'
+
+/**
+ * The `hmr` service Harness needs, for hosts that cannot give it Node's
+ * internal module loader.
+ *
+ * `runProfile` creates the full Cordis HMR service after boot whenever no
+ * `hmr` service exists, and that service throws on construction without
+ * `ctx.loader.internal` — taking the rest of profile boot with it, user
+ * patch-layer watching included. A packaged Electron app is such a host: the
+ * macOS Harness runs in a utility process, and `--expose-internals` reaches
+ * its `execArgv` without reaching Node's option parser, so the internal
+ * loader is absent no matter what the command line says. The
+ * `node-addon-require-builtin` fallback the loader tries next is built for
+ * plain Node and reports `Unsupported/no-realm` under Electron.
+ *
+ * Module-level hot replacement genuinely needs those internals and is not
+ * reproduced here. Watching the user patch layer does not — that is a file
+ * watcher and a callback — and it is the capability profile boot actually
+ * asks for. The desktop already owns a full Harness restart for everything
+ * else.
+ */
+export const name = 'dsh-desktop-hmr-fallback'
+export const inject = ['loader']
+
+const DEBOUNCE_MS = 100
+
+export class ConfigWatchHmr extends Service {
+  constructor(ctx) {
+    super(ctx, 'hmr')
+  }
+
+  /**
+   * Watch one exact config path and refresh on change — the subset of the
+   * Cordis HMR contract `watchUserPatches` uses.
+   * @param filename - config path to watch.
+   * @param refresh - callback run serially on add, change, or unlink.
+   * @returns a disposer, matching the service this stands in for.
+   */
+  async registerConfig(filename, refresh) {
+    const target = resolve(filename)
+    let signature = await stamp(target)
+    let pending
+    let queue = Promise.resolve()
+
+    const check = () => {
+      // Directory events do not reliably name the file that changed — macOS
+      // omits it often enough that trusting the name refreshes on every
+      // neighbour. The file's own mtime and size do say.
+      queue = queue
+        .then(async () => {
+          const next = await stamp(target)
+          if (next === signature) return
+          signature = next
+          // Serially, like the service this replaces: a refresh overlapping
+          // itself would compose the patch layer against a half-applied tree.
+          await refresh()
+        })
+        .catch((error) => this.ctx.logger?.warn?.(error))
+    }
+    const watcher = watch(dirname(target), { persistent: false }, () => {
+      clearTimeout(pending)
+      pending = setTimeout(check, DEBOUNCE_MS)
+      pending.unref?.()
+    })
+    watcher.on('error', () => undefined)
+
+    return async () => {
+      clearTimeout(pending)
+      watcher.close()
+      await queue.catch(() => undefined)
+    }
+  }
+}
+
+/** A file's identity for change detection: empty while it does not exist. */
+async function stamp(path) {
+  try {
+    const info = await stat(path)
+    return `${info.mtimeMs}:${info.size}`
+  } catch {
+    return ''
+  }
+}
+
+export function apply(ctx) {
+  // A host that can reach Node's internals keeps the real thing, module-level
+  // hot replacement included: development runs and the bundled-Node platforms
+  // are unaffected by this package's presence.
+  if (ctx.loader.internal !== undefined) return
+  ctx.plugin(ConfigWatchHmr)
+}

--- a/packages/dsh-desktop-hmr-fallback/package.json
+++ b/packages/dsh-desktop-hmr-fallback/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dsh-desktop-hmr-fallback",
+  "version": "0.1.0",
+  "description": "Config-watch HMR service for hosts where Node's internal module loader is unavailable.",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1"
+  }
+}

--- a/test/hmr-fallback.test.js
+++ b/test/hmr-fallback.test.js
@@ -1,0 +1,75 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ConfigWatchHmr,
+  apply,
+  inject,
+  name
+} from '../packages/dsh-desktop-hmr-fallback/index.js'
+
+/**
+ * The plugin registers a Cordis service, which needs a real context to
+ * construct. These cover the two decisions that do not: whether the fallback
+ * engages at all, and that the desktop patch actually loads it.
+ */
+function fakeContext(internal) {
+  const plugins = []
+  return {
+    loader: { internal },
+    plugin: (value) => plugins.push(value),
+    plugins
+  }
+}
+
+describe('desktop HMR fallback', () => {
+  it('stands aside wherever Node’s internal loader is reachable', () => {
+    // Development runs and the bundled-Node platforms keep the real service,
+    // module-level hot replacement included.
+    const ctx = fakeContext({})
+    apply(ctx)
+    expect(ctx.plugins).toHaveLength(0)
+  })
+
+  it('provides the service where the internals are absent', () => {
+    // A packaged Electron app: --expose-internals reaches execArgv without
+    // reaching Node's option parser, so Harness would create the full HMR
+    // service after boot and that service throws on construction.
+    const ctx = fakeContext(undefined)
+    apply(ctx)
+    expect(ctx.plugins).toHaveLength(1)
+    expect(name).toBe('dsh-desktop-hmr-fallback')
+    expect(inject).toContain('loader')
+  })
+
+  it('is composed into the desktop profile', async () => {
+    const patch = await readFile(join(process.cwd(), 'build', 'dsh-desktop.patch.yml'), 'utf8')
+    expect(patch).toContain('name: dsh-desktop-hmr-fallback')
+
+    const manifest = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8'))
+    expect(manifest.dependencies['dsh-desktop-hmr-fallback']).toBe(
+      'file:packages/dsh-desktop-hmr-fallback'
+    )
+  })
+
+  it('refreshes on a change to the watched config, and not on its neighbours', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dsh-hmr-fallback-'))
+    const watched = join(directory, 'cordis.patch.yml')
+    await writeFile(watched, '[]\n', 'utf8')
+    const refresh = vi.fn(async () => undefined)
+
+    const service = Object.create(ConfigWatchHmr.prototype)
+    service.ctx = { logger: { warn: () => undefined } }
+    const dispose = await service.registerConfig(watched, refresh)
+
+    await writeFile(join(directory, 'unrelated.yml'), 'x\n', 'utf8')
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    expect(refresh).not.toHaveBeenCalled()
+
+    await writeFile(watched, '- id: x\n', 'utf8')
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalled(), { timeout: 2000 })
+
+    await dispose()
+  })
+})


### PR DESCRIPTION
## 问题

签名打包的 macOS 正式版**每次启动**都在 profile boot 的同一步失败（0.4.3 用户日志 8/8）：

```text
DSH entry failed: failed to apply loader entry (@deepseek-ai/cordis-plugin-hmr):
--expose-internals is required for HMR service
```

对应内部文档《DSH Desktop v0.4.3 macOS 正式版启动失败：Utility Process 与 HMR 集成问题》的第二个问题（第一个是插件残留，与本 PR 无关）。

## 根因

`runProfile` 在 boot 之后发现没有 `hmr` 服务时会**自己创建**一个完整的 Cordis HMR（日志里那个随机 id 就是它），而该服务在缺少 `ctx.loader.internal` 时构造即抛，把 boot 的后半段一起带走——包括用户 patch 层的监听。

打包版拿不到这个 internal loader，两条路都断：

- `--expose-internals` 进得了 utility process 的 `execArgv`，但进不了 Node 的选项解析器；
- loader 的备选路径 `node-addon-require-builtin` 是按 plain Node 构建的，在 Electron 下直接报 `Unsupported/no-realm`。

补上文档建议 1 要求的最小复现（直接验证 internal loader 对象，而非只看 `process.execArgv`），四组组合结果如下：

| 构建形态 | `disclaim` | internal loader |
| --- | --- | --- |
| 开发运行 | `false` | ✅ 可用 |
| 开发运行 | `true` | ✅ 可用 |
| 签名打包 | `false` | ❌ `MODULE_NOT_FOUND` |
| 签名打包 | `true` | ❌ `MODULE_NOT_FOUND` |

**分水岭是打包，不是 `disclaim`。** 这修正了文档"最可能的解释"，也意味着 #107 的 macOS TCC 责任隔离**不需要动**。

另外确认：在 profile 层把 `hmr` 行 `disabled: true` 关掉**没有用**——那只会让 `runProfile` 换个 id 再创建一个，照样抛错。

## 修复

`watchUserPatches` 对 HMR 的全部要求就是 `registerConfig(filename, refresh)`——一个文件监听加一个回调，不需要 internals。本 PR 新增一个桌面端自有的 `hmr` 服务，只提供这个子集，且**仅在 internals 不可达时**生效：

- 能拿到 internals 的宿主（开发运行、Windows/Linux 的打包 Node）保持原样，完整 HMR 与模块级热替换不受影响；
- 拿不到的宿主（签名打包的 macOS）由它顶上，boot 得以走完，用户 patch 仍然实时生效。

变更点：`packages/dsh-desktop-hmr-fallback/`（新包）、`build/dsh-desktop.patch.yml`（插入该行）、`package.json`（file: 依赖）。

## 验证

在**签名的 `--dir` 构建**上验证（文档建议 4 要求的正式打包态，非 dev build）：

- 连续两次冷启动都到达 `DSH entry loaded`，`grep -c 'expose-internals'` 为 **0**；同一构建去掉本改动则两次都失败；
- Harness endpoint 持续返回 **200**；
- 修改 profile 的 `cordis.patch.yml` 后 Harness 继续正常服务，监听未打挂；
- `npm run typecheck` 通过；`npm test` 36 文件 245 测试全绿（新增 4 条）。

## 与 #145 的关系

不重叠。#145 修的是 `buildPnpmEnvironment` 删掉 `ELECTRON_RUN_AS_NODE` 导致市场安装报 "pnpm completed, but dshmarket was not found"（issue #140）；本 PR 修的是 Harness 启动本身。两者都只在 macOS 上出现，但根因和代码路径都不同。

## 遗留

- 文档建议 3（推动 Harness 官方提供 config-only watcher / graceful fallback）仍值得推进：本 PR 是宿主侧的兜底，上游若解耦，这个包可以删掉。
- 文档建议 4 的签名构建 smoke test 尚未进 CI，建议单开。
