### PR TITLE
fix: clear a plugin's patch-layer rows when it is uninstalled

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,6 +21,7 @@ import {
   removeProfilePluginWithDsh
 } from './runtime/profile-plugin-command'
 import { clearDamagedPackageDirectories, hasProfile } from './state/profile-repair'
+import { inspectProfileConsistency } from './state/profile-consistency'
 import { LanMobileBridge } from './mobile/lan-mobile-bridge'
 import {
   detectPluginRecovery,
@@ -502,6 +503,22 @@ async function repairProfilePackages(dshHome: string): Promise<void> {
   }
 }
 
+/**
+ * Name what the profile contradicts about itself, once the repair above has
+ * had its turn. A dangling declaration does not throw — it leaves a service
+ * waiting on a provider that never arrives — so without this the profile reads
+ * as a slow start and the fault is found by reading logs for an afternoon.
+ * Reporting only: the launch continues either way.
+ */
+async function reportProfileConsistency(dshHome: string): Promise<void> {
+  try {
+    const findings = await inspectProfileConsistency(dshHome)
+    for (const finding of findings) runtime.note(`[desktop] profile inconsistency: ${finding}`)
+  } catch {
+    // A profile that cannot be inspected is not a reason to refuse a launch.
+  }
+}
+
 function launchHarness(): Promise<void> {
   if (harnessLaunchOperation) return harnessLaunchOperation
 
@@ -514,6 +531,7 @@ function launchHarness(): Promise<void> {
     await runtime.stop()
     await repairProfilePackages(dshHome)
     await pruneMissingProfileBundles(dshHome).catch(() => false)
+    await reportProfileConsistency(dshHome)
     await runtime.start(launchDirectory)
   })().finally(() => {
     harnessLaunchOperation = undefined

--- a/src/main/state/patch-layer.ts
+++ b/src/main/state/patch-layer.ts
@@ -1,0 +1,119 @@
+import { isMap, isSeq, parse, parseDocument } from 'yaml'
+
+/**
+ * The profile's user patch layer, and what uninstalling a plugin has to do to
+ * it.
+ *
+ * Removing a plugin takes its dependency, its bundle row and its files. What
+ * it has never taken is the rows the user layer aims at that plugin — an
+ * id-targeted config override, or an `insert` naming the package. Those rows
+ * survive the uninstall and go on pointing at something that no longer
+ * composes. Nothing rejects them: a row aimed at a missing id is inert, and a
+ * config value routing a service at a backend the plugin used to provide just
+ * leaves that service waiting, so the profile reads as a slow start rather
+ * than a broken one.
+ *
+ * The layer is user-authored, comments included, so it is edited as a document
+ * rather than reparsed and rewritten — and only the rows that name the plugin
+ * are touched. Wiping the layer would take the user's own overrides with it.
+ */
+
+/** Loader entry ids a bundle declares in its own patch — what its rows target. */
+export function bundleEntryIds(patchText: string): string[] {
+  let value: unknown
+  try {
+    value = parse(patchText)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(value)) return []
+
+  const ids: string[] = []
+  for (const row of value) {
+    const insert = (row as { insert?: unknown } | null)?.insert
+    if (!Array.isArray(insert)) continue
+    for (const entry of insert) {
+      const id = (entry as { id?: unknown } | null)?.id
+      if (typeof id === 'string') ids.push(id)
+    }
+  }
+  return ids
+}
+
+export interface PatchLayerPrune {
+  text: string
+  removed: string[]
+}
+
+function belongsToPlugin(name: unknown, plugin: string): boolean {
+  return typeof name === 'string' && (name === plugin || name.startsWith(`${plugin}/`))
+}
+
+/**
+ * Drop the rows a patch layer aims at one plugin.
+ * @param text - the layer as written, comments included.
+ * @param plugin - the package being removed.
+ * @param entryIds - loader entry ids that package declared.
+ * @returns the rewritten layer, and a description of each row dropped. The
+ * text is returned untouched when nothing matched, so an unrelated uninstall
+ * never rewrites the file.
+ */
+export function prunePatchLayer(text: string, plugin: string, entryIds: readonly string[]): PatchLayerPrune {
+  let document
+  try {
+    document = parseDocument(text)
+  } catch {
+    return { text, removed: [] }
+  }
+  const contents = document.contents
+  if (!isSeq(contents)) return { text, removed: [] }
+
+  const removed: string[] = []
+  const kept = []
+  // A comment above the first row is the file's header, which the profile
+  // ships with and the user reads. A comment above any later row is about that
+  // row, so it leaves with it.
+  let header: unknown
+
+  for (const [index, row] of contents.items.entries()) {
+    if (!isMap(row)) {
+      kept.push(row)
+      continue
+    }
+
+    const id = row.get('id')
+    if (typeof id === 'string' && entryIds.includes(id)) {
+      removed.push(`id: ${id}`)
+      if (index === 0) header = row.commentBefore
+      continue
+    }
+
+    const insert = row.get('insert')
+    if (isSeq(insert)) {
+      const survivors = insert.items.filter((entry) => {
+        const name = isMap(entry) ? entry.get('name') : undefined
+        if (!belongsToPlugin(name, plugin)) return true
+        removed.push(`insert: ${String(name)}`)
+        return false
+      })
+      // A row whose whole insert list belonged to the plugin has nothing left
+      // to say; one that still inserts something keeps the rest.
+      if (survivors.length === 0 && insert.items.length > 0) {
+        if (index === 0) header = row.commentBefore
+        continue
+      }
+      insert.items = survivors
+    }
+
+    kept.push(row)
+  }
+
+  if (removed.length === 0) return { text, removed }
+  if (typeof header === 'string') {
+    const first = kept[0]
+    if (isMap(first)) first.commentBefore = [header, first.commentBefore].filter(Boolean).join('\n')
+    else document.commentBefore = header
+  }
+  contents.items = kept
+  return { text: String(document), removed }
+}

--- a/src/main/state/plugin-recovery.ts
+++ b/src/main/state/plugin-recovery.ts
@@ -3,6 +3,7 @@ import { readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { parse } from 'yaml'
 import { removeTree } from './remove-tree'
+import { bundleEntryIds, prunePatchLayer } from './patch-layer'
 
 /**
  * Directories under the profile's node_modules that no longer belong to any
@@ -333,6 +334,49 @@ export async function resolveProfileRecoveryPlugins(
   }
 }
 
+/**
+ * Loader entry ids the installed plugin declares. Read before removal — the
+ * bundle patch that names them goes away with the package.
+ */
+export async function pluginDeclaredEntryIds(
+  profileDirectory: string,
+  pluginName: string
+): Promise<string[]> {
+  const packageDirectory = join(profileDirectory, 'node_modules', pluginName)
+  try {
+    const manifest = JSON.parse(
+      await readFile(join(packageDirectory, 'package.json'), 'utf8')
+    ) as BundleManifest
+    const patch = manifest.dsh?.bundle?.patch
+    if (!patch) return []
+    return bundleEntryIds(await readFile(resolve(packageDirectory, patch), 'utf8'))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Drop the user patch-layer rows aimed at a plugin that is being removed.
+ * @returns a description of each row dropped, empty when the layer said
+ * nothing about this plugin.
+ */
+export async function prunePluginPatchLayer(
+  dshHome: string,
+  pluginName: string,
+  entryIds: readonly string[]
+): Promise<string[]> {
+  const patchPath = profileCordisPatchPath(dshHome)
+  try {
+    const text = await readFile(patchPath, 'utf8')
+    const pruned = prunePatchLayer(text, pluginName, entryIds)
+    if (pruned.removed.length === 0) return []
+    await writeFile(patchPath, pruned.text, 'utf8')
+    return pruned.removed
+  } catch {
+    return []
+  }
+}
+
 export async function uninstallPluginFromProfile(
   dshHome: string,
   pluginName: string,
@@ -352,6 +396,7 @@ export async function uninstallPluginFromProfile(
     if (!configured) return false
 
     const lockfileExisted = existsSync(lockfilePath)
+    const entryIds = await pluginDeclaredEntryIds(dirname(manifestPath), pluginName)
     if (!(await removePlugin(pluginName))) return false
 
     const updatedManifest = JSON.parse(await readFile(manifestPath, 'utf8')) as ProfileManifest
@@ -374,6 +419,8 @@ export async function uninstallPluginFromProfile(
         return false
       }
     }
+
+    await prunePluginPatchLayer(dshHome, pluginName, entryIds)
 
     return true
   } catch {
@@ -447,13 +494,21 @@ export async function resetPluginProfile(
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8')
     }
 
-    // Reset cordis.patch.yml to clean state
+    // The user patch layer is the user's own work. Removing one plugin takes
+    // the rows aimed at that plugin and nothing else; only a reset with no
+    // plugin named — the deliberate "start over" — clears the whole layer.
     const patchPath = profileCordisPatchPath(dshHome)
     if (existsSync(patchPath)) {
-      const patchContent = await readFile(patchPath, 'utf8')
-      if (patchContent.trim() !== '[]') {
-        await writeFile(patchPath, '[]\n', 'utf8')
-        modified = true
+      if (failingPlugin) {
+        const entryIds = await pluginDeclaredEntryIds(dirname(manifestPath), failingPlugin)
+        const removed = await prunePluginPatchLayer(dshHome, failingPlugin, entryIds)
+        if (removed.length > 0) modified = true
+      } else {
+        const patchContent = await readFile(patchPath, 'utf8')
+        if (patchContent.trim() !== '[]') {
+          await writeFile(patchPath, '[]\n', 'utf8')
+          modified = true
+        }
       }
     }
 

--- a/src/main/state/profile-consistency.ts
+++ b/src/main/state/profile-consistency.ts
@@ -1,0 +1,158 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { isMap, isSeq, parseDocument } from 'yaml'
+import { profileCordisPatchPath, profilePackageJsonPath } from './plugin-recovery'
+
+/**
+ * What the profile says about itself, checked against what is on disk.
+ *
+ * The failures this catches do not announce themselves. A bundle declared but
+ * not installed, a package installed but never composed, a patch layer
+ * inserting something that was uninstalled — none of these throw. They leave a
+ * service waiting on a provider that never arrives, so the profile reads as a
+ * slow start, and the real fault surfaces only after someone spends an
+ * afternoon in the logs. Naming them at launch is the whole point: this
+ * changes nothing about the boot, it only makes the state legible.
+ */
+
+interface ProfileManifest {
+  dependencies?: Record<string, string>
+  dsh?: { profile?: { bundles?: string[] } }
+}
+
+async function readManifest(path: string): Promise<ProfileManifest | undefined> {
+  try {
+    return JSON.parse(await readFile(path, 'utf8')) as ProfileManifest
+  } catch {
+    return undefined
+  }
+}
+
+/** Whether a package is materialized in the profile, and whether it is a bundle. */
+async function inspectPackage(
+  nodeModulesPath: string,
+  packageName: string
+): Promise<{ installed: boolean; bundle: boolean }> {
+  try {
+    const manifest = JSON.parse(
+      await readFile(join(nodeModulesPath, packageName, 'package.json'), 'utf8')
+    ) as { dsh?: { bundle?: { patch?: string } } }
+    return { installed: true, bundle: manifest.dsh?.bundle?.patch !== undefined }
+  } catch {
+    return { installed: false, bundle: false }
+  }
+}
+
+/** Package names a user patch layer inserts. */
+export function patchLayerInsertedPackages(text: string): string[] {
+  let document
+  try {
+    document = parseDocument(text)
+  } catch {
+    return []
+  }
+  if (!isSeq(document.contents)) return []
+
+  const names: string[] = []
+  for (const row of document.contents.items) {
+    if (!isMap(row)) continue
+    const insert = row.get('insert')
+    if (!isSeq(insert)) continue
+    for (const entry of insert.items) {
+      const name = isMap(entry) ? entry.get('name') : undefined
+      if (typeof name === 'string') names.push(name)
+    }
+  }
+  return names
+}
+
+/**
+ * Installed bundle packages the manifest never mentions.
+ *
+ * A rolled-back install leaves exactly this: the files stay, the dependency
+ * and the bundle row do not, and the package can never compose again — while
+ * anything that only checks node_modules reports it as installed. Packages
+ * that arrived as a dependency of a declared one are someone else's business
+ * and stay unreported.
+ */
+async function undeclaredBundles(
+  nodeModulesPath: string,
+  dependencies: readonly string[],
+  bundles: readonly string[]
+): Promise<string[]> {
+  let entries
+  try {
+    entries = await readdir(nodeModulesPath, { withFileTypes: true })
+  } catch {
+    return []
+  }
+
+  const declared = new Set([...dependencies, ...bundles])
+  const transitive = new Set<string>()
+  for (const dependency of dependencies) {
+    try {
+      const manifest = JSON.parse(
+        await readFile(join(nodeModulesPath, dependency, 'package.json'), 'utf8')
+      ) as { dependencies?: Record<string, string> }
+      for (const name of Object.keys(manifest.dependencies ?? {})) transitive.add(name)
+    } catch {
+      // Unreadable dependency: it vouches for nothing.
+    }
+  }
+
+  const orphans: string[] = []
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') || entry.name.startsWith('@')) continue
+    if (!entry.isDirectory() || declared.has(entry.name) || transitive.has(entry.name)) continue
+    const { bundle } = await inspectPackage(nodeModulesPath, entry.name)
+    if (bundle) orphans.push(entry.name)
+  }
+  return orphans
+}
+
+/**
+ * Inconsistencies between the profile's declarations and its packages.
+ * @returns one sentence per finding, empty when the profile is coherent.
+ */
+export async function inspectProfileConsistency(dshHome: string): Promise<string[]> {
+  const manifestPath = profilePackageJsonPath(dshHome)
+  const manifest = await readManifest(manifestPath)
+  if (manifest === undefined) return []
+
+  const nodeModulesPath = join(dirname(manifestPath), 'node_modules')
+  const bundles = manifest.dsh?.profile?.bundles ?? []
+  const dependencies = Object.keys(manifest.dependencies ?? {})
+  const findings: string[] = []
+
+  for (const bundle of bundles) {
+    // In-box bundles live in the app, not the profile, so only a declared
+    // dependency is expected to be materialized here.
+    if (!dependencies.includes(bundle)) continue
+    const { installed } = await inspectPackage(nodeModulesPath, bundle)
+    if (!installed) findings.push(`bundle ${bundle} is declared but not installed`)
+  }
+
+  for (const dependency of dependencies) {
+    if (bundles.includes(dependency)) continue
+    const { installed, bundle } = await inspectPackage(nodeModulesPath, dependency)
+    if (installed && bundle) {
+      findings.push(`${dependency} is installed and declares a bundle, but is not composed`)
+    }
+  }
+
+  for (const orphan of await undeclaredBundles(nodeModulesPath, dependencies, bundles)) {
+    findings.push(`${orphan} is installed but declared nowhere in the profile manifest`)
+  }
+
+  try {
+    const layer = await readFile(profileCordisPatchPath(dshHome), 'utf8')
+    for (const packageName of patchLayerInsertedPackages(layer)) {
+      const { installed } = await inspectPackage(nodeModulesPath, packageName)
+      if (!installed) findings.push(`the patch layer inserts ${packageName}, which is not installed`)
+    }
+  } catch {
+    // No layer, nothing it can contradict.
+  }
+
+  return findings
+}

--- a/src/main/update/skipped-version.ts
+++ b/src/main/update/skipped-version.ts
@@ -1,0 +1,51 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * The version the user asked not to be told about again.
+ *
+ * Dismissing the update banner already silences one sitting; it does not
+ * survive a restart, so a release the user has decided against comes back
+ * every launch until they take it. Skipping is the durable answer to the same
+ * question, and it is answered per version: a later release is a new question
+ * and gets asked.
+ *
+ * A manual check is the user asking, so it ignores the skip — that is how they
+ * take back a version they skipped, without needing a way to unskip.
+ */
+
+export function skippedVersionPath(userDataPath: string): string {
+  return join(userDataPath, 'update-skip.json')
+}
+
+/** Whether an available version should stay silent. */
+export function shouldOfferUpdate(
+  version: string,
+  skippedVersion: string | undefined,
+  manual: boolean
+): boolean {
+  return manual || version !== skippedVersion
+}
+
+export function readSkippedVersion(path: string): string | undefined {
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf8')) as { version?: unknown }
+    return typeof value.version === 'string' && value.version ? value.version : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Persist the skip.
+ * @returns whether it was written; a failure here loses the skip rather than
+ * the launch, and the banner simply asks again next time.
+ */
+export function writeSkippedVersion(path: string, version: string): boolean {
+  try {
+    writeFileSync(path, `${JSON.stringify({ version }, undefined, 2)}\n`, 'utf8')
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/main/update/update-manager.ts
+++ b/src/main/update/update-manager.ts
@@ -14,6 +14,12 @@ import {
   reduceUpdateStatus,
   type UpdateStateEvent
 } from './update-state'
+import {
+  readSkippedVersion,
+  shouldOfferUpdate,
+  skippedVersionPath,
+  writeSkippedVersion
+} from './skipped-version'
 
 const { autoUpdater } = electronUpdater
 const TRANSIENT_STATUS_MS = 8_000
@@ -26,8 +32,12 @@ let resetTimer: NodeJS.Timeout | undefined
 let checkPromise: Promise<unknown> | undefined
 let lastCheckedAt = 0
 let installing = false
+let downloading = false
 let started = false
 let handlersRegistered = false
+let skippedVersion: string | undefined
+let skipLoaded = false
+let manualCheck = false
 
 export function getUpdateStatus(): UpdateStatus {
   return { ...status }
@@ -38,6 +48,35 @@ export function registerUpdateHandlers(): void {
   handlersRegistered = true
   ipcMain.handle('updates:status', () => getUpdateStatus())
   ipcMain.handle('updates:install', () => installDownloadedUpdate())
+  ipcMain.handle('updates:skip', (_event, version: unknown) => skipUpdate(version))
+  ipcMain.handle('updates:download', () => downloadAvailableUpdate())
+}
+
+function skipFile(): string {
+  return skippedVersionPath(app.getPath('userData'))
+}
+
+function currentSkippedVersion(): string | undefined {
+  if (!skipLoaded) {
+    skippedVersion = readSkippedVersion(skipFile())
+    skipLoaded = true
+  }
+  return skippedVersion
+}
+
+/**
+ * Stop offering one version. The banner goes away for good rather than until
+ * the next launch, and a later release is a new question that still gets
+ * asked. A manual check overrides this, which is how the user takes back a
+ * version they skipped.
+ */
+export function skipUpdate(version: unknown): UpdateStatus {
+  if (typeof version !== 'string' || !version) return getUpdateStatus()
+  skippedVersion = version
+  skipLoaded = true
+  writeSkippedVersion(skipFile(), version)
+  transition({ type: 'reset' })
+  return getUpdateStatus()
 }
 
 export function startUpdateManager(options: { prepareToInstall: () => Promise<void> }): void {
@@ -80,6 +119,7 @@ export async function checkForUpdates(manual = false): Promise<UpdateStatus> {
   }
 
   transition({ type: 'check', manual })
+  manualCheck = manual
   lastCheckedAt = Date.now()
   checkPromise = autoUpdater.checkForUpdates()
 
@@ -90,6 +130,26 @@ export async function checkForUpdates(manual = false): Promise<UpdateStatus> {
     if (manual) scheduleReset()
   } finally {
     checkPromise = undefined
+  }
+
+  return getUpdateStatus()
+}
+
+/**
+ * Start the download the user just accepted. Consent and download are one
+ * action — an update sits at `available` until it is taken.
+ */
+export async function downloadAvailableUpdate(): Promise<UpdateStatus> {
+  if (status.phase !== 'available' || downloading) return getUpdateStatus()
+  downloading = true
+
+  try {
+    await autoUpdater.downloadUpdate()
+  } catch (error) {
+    transition({ type: 'error', message: errorMessage(error) })
+    if (status.manual) scheduleReset()
+  } finally {
+    downloading = false
   }
 
   return getUpdateStatus()
@@ -120,7 +180,9 @@ export function stopUpdateManager(): void {
 }
 
 function configureUpdater(): void {
-  autoUpdater.autoDownload = true
+  // The download is ours to start: an update the user skipped should not be
+  // fetched at all, and update-available is the only place that is known.
+  autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = AUTO_INSTALL_ON_APP_QUIT
   autoUpdater.allowPrerelease = false
   autoUpdater.logger = {
@@ -133,9 +195,16 @@ function configureUpdater(): void {
   autoUpdater.on('checking-for-update', () =>
     transition({ type: 'check', manual: status.manual })
   )
-  autoUpdater.on('update-available', (info) =>
+  autoUpdater.on('update-available', (info) => {
+    if (!shouldOfferUpdate(info.version, currentSkippedVersion(), manualCheck)) {
+      console.info('[updater] skipping', info.version, 'at the user’s request')
+      transition({ type: 'reset' })
+      return
+    }
+    // Offered, not fetched: nothing leaves the network until the user accepts
+    // the update, which is the same click that starts the download.
     transition({ type: 'available', version: info.version })
-  )
+  })
   autoUpdater.on('download-progress', (progress) =>
     transition({ type: 'progress', percent: progress.percent })
   )

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,6 +19,7 @@ let currentStatus: UpdateStatus | undefined
 let dismissedVersion: string | null = null
 let dismissedTransientPhase: UpdateStatus['phase'] | null = null
 let installing = false
+let accepting = false
 let receivedStatusEvent = false
 let phoneConnected = false
 let mobileStatusTimer: number | undefined
@@ -216,6 +217,7 @@ function applyStatus(status: UpdateStatus): void {
     host.dataset.updateManual = String(status.manual)
   }
   if (status.phase === 'error') installing = false
+  if (status.phase !== 'available') accepting = false
   render()
 }
 
@@ -265,6 +267,29 @@ function render(): void {
     body.appendChild(progress)
   }
 
+  if (status.phase === 'available') {
+    const actions = element('div', 'actions')
+    const accept = button(locale === 'zh' ? '同意更新' : 'Update now', 'primary')
+    accept.disabled = accepting
+    accept.addEventListener('click', () => {
+      accepting = true
+      render()
+      void ipcRenderer.invoke('updates:download').catch((error: unknown) => {
+        accepting = false
+        console.error('[updater] unable to download update', error)
+        render()
+      })
+    })
+    actions.append(accept, skipButton(status))
+    body.appendChild(actions)
+  }
+
+  if (status.phase === 'downloading') {
+    const actions = element('div', 'actions')
+    actions.appendChild(skipButton(status))
+    body.appendChild(actions)
+  }
+
   if (status.phase === 'downloaded') {
     const actions = element('div', 'actions')
     const install = button(
@@ -287,7 +312,7 @@ function render(): void {
         render()
       })
     })
-    actions.append(install)
+    actions.append(install, skipButton(status))
     body.appendChild(actions)
   }
 
@@ -300,6 +325,25 @@ function render(): void {
 
   card.appendChild(row)
   content.replaceChildren(card)
+}
+
+/**
+ * Stop being told about this version at all. The close button silences the
+ * banner for this sitting only, so a release the user has decided against
+ * comes back every launch; this one is remembered. A later release still asks,
+ * and a manual check offers the skipped one again.
+ */
+function skipButton(status: UpdateStatus): HTMLButtonElement {
+  const skip = button(locale === 'zh' ? '跳过此版本' : 'Skip this version', 'secondary')
+  skip.addEventListener('click', () => {
+    const version = status.availableVersion
+    if (!version) return
+    dismissCurrent()
+    void ipcRenderer.invoke('updates:skip', version).catch((error: unknown) => {
+      console.error('[updater] unable to skip update', error)
+    })
+  })
+  return skip
 }
 
 function dismissCurrent(): void {

--- a/src/preload/update-view.ts
+++ b/src/preload/update-view.ts
@@ -24,7 +24,9 @@ export function updateMessage(status: UpdateStatus, locale: UpdateLocale): strin
     case 'checking':
       return zh ? '正在检查更新…' : 'Checking for updates…'
     case 'available':
-      return zh ? `发现新版本${version}，正在准备下载…` : `Update${version} is available. Preparing download…`
+      return zh
+        ? `发现新版本${version}，是否更新？`
+        : `DSH Desktop${version} is available. Update now?`
     case 'downloading': {
       const percent = Math.round(status.percent ?? 0)
       return zh ? `正在下载更新 ${percent}%` : `Downloading update ${percent}%`

--- a/test/patch-layer.test.ts
+++ b/test/patch-layer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { bundleEntryIds, prunePatchLayer } from '../src/main/state/patch-layer'
+import { patchLayerInsertedPackages } from '../src/main/state/profile-consistency'
+
+const LAYER = `# Your patch layer for this dsh profile, applied after every bundle layer.
+- id: storage
+  config:
+    backend: sqlite
+- id: theme
+  config:
+    accent: violet
+- insert:
+    - id: doudizhu
+      name: dsh-doudizhu
+    - id: my-own
+      name: dsh-my-own
+- insert:
+    - id: doudizhu-ui
+      name: dsh-doudizhu/ui
+`
+
+describe('user patch layer', () => {
+  it('reads the entry ids a bundle declares', () => {
+    expect(
+      bundleEntryIds(`- insert:
+    - id: doudizhu
+      name: dsh-doudizhu
+    - id: storage
+      name: dsh-doudizhu-storage
+`)
+    ).toEqual(['doudizhu', 'storage'])
+    expect(bundleEntryIds('not: a list')).toEqual([])
+    expect(bundleEntryIds(':::')).toEqual([])
+  })
+
+  it('drops only the rows aimed at the plugin being removed', () => {
+    const { text, removed } = prunePatchLayer(LAYER, 'dsh-doudizhu', ['storage'])
+
+    // The plugin's own id-targeted row and both of its inserts go.
+    expect(removed).toEqual(['id: storage', 'insert: dsh-doudizhu', 'insert: dsh-doudizhu/ui'])
+    // The user's unrelated override survives, and so does their own insert.
+    expect(text).toContain('id: theme')
+    expect(text).toContain('accent: violet')
+    expect(text).toContain('name: dsh-my-own')
+    expect(text).not.toContain('sqlite')
+    expect(text).not.toContain('dsh-doudizhu')
+    // The header the user reads is part of the file, not noise to rewrite away.
+    expect(text).toContain('# Your patch layer')
+  })
+
+  it('leaves the file byte-identical when nothing names the plugin', () => {
+    const { text, removed } = prunePatchLayer(LAYER, 'dsh-unrelated', ['nothing'])
+    expect(removed).toEqual([])
+    expect(text).toBe(LAYER)
+  })
+
+  it('survives a layer that is empty, malformed, or not a list', () => {
+    for (const input of ['[]\n', '', 'key: value\n', ':::']) {
+      expect(prunePatchLayer(input, 'dsh-doudizhu', ['storage']).removed).toEqual([])
+      expect(patchLayerInsertedPackages(input)).toEqual([])
+    }
+  })
+
+  it('names the packages a layer inserts', () => {
+    expect(patchLayerInsertedPackages(LAYER)).toEqual(['dsh-doudizhu', 'dsh-my-own', 'dsh-doudizhu/ui'])
+  })
+})

--- a/test/plugin-recovery.test.ts
+++ b/test/plugin-recovery.test.ts
@@ -711,3 +711,61 @@ describe('plugin-recovery', () => {
   })
 })
 
+
+describe('uninstall clears what the patch layer said about the plugin', () => {
+  const testDir = join(__dirname, '.temp-uninstall-patch-layer')
+  const profile = join(testDir, 'profiles', 'web')
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('drops the plugin’s rows and keeps the user’s own', async () => {
+    // The residue this closes: rows aimed at a plugin outlive its uninstall and
+    // keep routing services at a provider that no longer composes, which reads
+    // as a slow start rather than a fault.
+    await mkdir(join(profile, 'node_modules', 'dsh-doudizhu'), { recursive: true })
+    await writeFile(
+      join(profile, 'node_modules', 'dsh-doudizhu', 'package.json'),
+      JSON.stringify({ name: 'dsh-doudizhu', dsh: { bundle: { patch: './cordis.patch.yml' } } })
+    )
+    await writeFile(
+      join(profile, 'node_modules', 'dsh-doudizhu', 'cordis.patch.yml'),
+      '- insert:\n    - id: doudizhu\n      name: dsh-doudizhu\n'
+    )
+    await writeFile(
+      join(profile, 'package.json'),
+      JSON.stringify({
+        dependencies: { 'dsh-doudizhu': '^1.0.0' },
+        dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dsh-doudizhu'] } }
+      })
+    )
+    await writeFile(
+      join(profile, 'cordis.patch.yml'),
+      [
+        '- id: doudizhu',
+        '  config:',
+        '    backend: sqlite',
+        '- id: theme',
+        '  config:',
+        '    accent: violet',
+        ''
+      ].join('\n')
+    )
+
+    const success = await uninstallPluginFromProfile(testDir, 'dsh-doudizhu', async () => {
+      const manifest = JSON.parse(await readFile(join(profile, 'package.json'), 'utf8'))
+      delete manifest.dependencies['dsh-doudizhu']
+      manifest.dsh.profile.bundles = ['@deepseek-ai/dsh-base']
+      await writeFile(join(profile, 'package.json'), JSON.stringify(manifest))
+      await rm(join(profile, 'node_modules', 'dsh-doudizhu'), { recursive: true, force: true })
+      return true
+    })
+
+    expect(success).toBe(true)
+    const layer = await readFile(join(profile, 'cordis.patch.yml'), 'utf8')
+    expect(layer).not.toContain('doudizhu')
+    expect(layer).not.toContain('sqlite')
+    expect(layer).toContain('accent: violet')
+  })
+})

--- a/test/profile-consistency.test.ts
+++ b/test/profile-consistency.test.ts
@@ -1,0 +1,113 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { inspectProfileConsistency } from '../src/main/state/profile-consistency'
+
+describe('profile consistency', () => {
+  const homes: string[] = []
+
+  async function profileHome(manifest: unknown, layer = '[]\n'): Promise<{ home: string; modules: string }> {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-consistency-'))
+    homes.push(home)
+    const profile = join(home, 'profiles', 'web')
+    const modules = join(profile, 'node_modules')
+    await mkdir(modules, { recursive: true })
+    await writeFile(join(profile, 'package.json'), JSON.stringify(manifest), 'utf8')
+    await writeFile(join(profile, 'cordis.patch.yml'), layer, 'utf8')
+    return { home, modules }
+  }
+
+  async function install(modules: string, name: string, bundle = true): Promise<void> {
+    await mkdir(join(modules, name), { recursive: true })
+    await writeFile(
+      join(modules, name, 'package.json'),
+      JSON.stringify({ name, ...(bundle ? { dsh: { bundle: { patch: './cordis.patch.yml' } } } : {}) }),
+      'utf8'
+    )
+  }
+
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })))
+  })
+
+  it('says nothing about a coherent profile', async () => {
+    const { home, modules } = await profileHome({
+      dependencies: { dshmarket: '1.17.1' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket'] } }
+    })
+    await install(modules, 'dshmarket')
+
+    await expect(inspectProfileConsistency(home)).resolves.toEqual([])
+  })
+
+  it('names a package that is installed but never composed', async () => {
+    // Exactly the state a rolled-back install leaves: the files are there, the
+    // declaration is not, and the market can never load.
+    const { home, modules } = await profileHome({
+      dependencies: { dshmarket: '1.16.0' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } }
+    })
+    await install(modules, 'dshmarket')
+
+    await expect(inspectProfileConsistency(home)).resolves.toEqual([
+      'dshmarket is installed and declares a bundle, but is not composed'
+    ])
+  })
+
+  it('names a package left installed but declared nowhere', async () => {
+    // The state a rolled-back install leaves behind, and the one that made the
+    // market unusable: files present, every declaration gone, so anything that
+    // only checks node_modules still calls it installed.
+    const { home, modules } = await profileHome({
+      dependencies: { 'dsh-spend': '^0.4.6' },
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dsh-spend'] } }
+    })
+    await install(modules, 'dsh-spend')
+    await install(modules, 'dshmarket')
+    // A bundle that arrived as a dependency of a declared plugin is not ours
+    // to complain about.
+    await writeFile(
+      join(modules, 'dsh-spend', 'package.json'),
+      JSON.stringify({
+        name: 'dsh-spend',
+        dependencies: { 'dsh-spend-ui': '^1.0.0' },
+        dsh: { bundle: { patch: './cordis.patch.yml' } }
+      }),
+      'utf8'
+    )
+    await install(modules, 'dsh-spend-ui')
+
+    await expect(inspectProfileConsistency(home)).resolves.toEqual([
+      'dshmarket is installed but declared nowhere in the profile manifest'
+    ])
+  })
+
+  it('names a bundle that is declared but missing', async () => {
+    const { home } = await profileHome({
+      dependencies: { 'dsh-doudizhu': '^1.0.0' },
+      dsh: { profile: { bundles: ['dsh-doudizhu'] } }
+    })
+
+    await expect(inspectProfileConsistency(home)).resolves.toEqual([
+      'bundle dsh-doudizhu is declared but not installed'
+    ])
+  })
+
+  it('names a patch layer that inserts something uninstalled', async () => {
+    const { home } = await profileHome(
+      { dependencies: {}, dsh: { profile: { bundles: [] } } },
+      '- insert:\n    - id: doudizhu\n      name: dsh-doudizhu\n'
+    )
+
+    await expect(inspectProfileConsistency(home)).resolves.toEqual([
+      'the patch layer inserts dsh-doudizhu, which is not installed'
+    ])
+  })
+
+  it('leaves a home without a profile alone', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-consistency-empty-'))
+    homes.push(home)
+    await expect(inspectProfileConsistency(home)).resolves.toEqual([])
+  })
+})

--- a/test/update-skip.test.ts
+++ b/test/update-skip.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  readSkippedVersion,
+  shouldOfferUpdate,
+  skippedVersionPath,
+  writeSkippedVersion
+} from '../src/main/update/skipped-version'
+
+describe('skipping one update', () => {
+  const homes: string[] = []
+
+  async function home(): Promise<string> {
+    const directory = await mkdtemp(join(tmpdir(), 'dsh-update-skip-'))
+    homes.push(directory)
+    return directory
+  }
+
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+  })
+
+  it('silences the skipped version and nothing else', () => {
+    expect(shouldOfferUpdate('0.4.4', '0.4.4', false)).toBe(false)
+    // A later release is a new question.
+    expect(shouldOfferUpdate('0.4.5', '0.4.4', false)).toBe(true)
+    expect(shouldOfferUpdate('0.4.4', undefined, false)).toBe(true)
+  })
+
+  it('offers a skipped version again when the user asks', () => {
+    // A manual check is the user asking, which is how they take back a version
+    // they skipped — no separate unskip needed.
+    expect(shouldOfferUpdate('0.4.4', '0.4.4', true)).toBe(true)
+  })
+
+  it('remembers the skip across launches', async () => {
+    const path = skippedVersionPath(await home())
+    expect(readSkippedVersion(path)).toBeUndefined()
+
+    expect(writeSkippedVersion(path, '0.4.4')).toBe(true)
+    expect(readSkippedVersion(path)).toBe('0.4.4')
+    expect(JSON.parse(await readFile(path, 'utf8'))).toEqual({ version: '0.4.4' })
+
+    expect(writeSkippedVersion(path, '0.4.5')).toBe(true)
+    expect(readSkippedVersion(path)).toBe('0.4.5')
+  })
+
+  it('treats an unreadable or empty record as no skip', async () => {
+    const path = skippedVersionPath(await home())
+    for (const contents of ['', 'not json', '{}', '{"version": ""}', '{"version": 3}']) {
+      await writeFile(path, contents, 'utf8')
+      expect(readSkippedVersion(path)).toBeUndefined()
+    }
+  })
+
+  it('loses the skip rather than the launch when it cannot be written', async () => {
+    expect(writeSkippedVersion(join(await home(), 'missing', 'deeper.json'), '0.4.4')).toBe(false)
+  })
+
+  it('offers the button wherever a version is on the table, and skips through IPC', async () => {
+    const preload = await readFile(join(process.cwd(), 'src', 'preload', 'index.ts'), 'utf8')
+    expect(preload).toContain("'跳过此版本'")
+    expect(preload).toContain("'Skip this version'")
+    expect(preload).toContain("ipcRenderer.invoke('updates:skip', version)")
+
+    const manager = await readFile(
+      join(process.cwd(), 'src', 'main', 'update', 'update-manager.ts'),
+      'utf8'
+    )
+    expect(manager).toContain("ipcMain.handle('updates:skip'")
+    // Nothing is fetched until the user accepts, so a skipped release — or one
+    // simply left alone — never costs a download.
+    expect(manager).toContain('autoUpdater.autoDownload = false')
+    expect(manager).toContain("ipcMain.handle('updates:download'")
+    expect(preload).toContain("'同意更新'")
+    expect(preload).toContain("ipcRenderer.invoke('updates:download')")
+  })
+})

--- a/test/update-ui.test.ts
+++ b/test/update-ui.test.ts
@@ -69,3 +69,16 @@ describe('secure update card wiring', () => {
     expect(preload).toContain("'bottom:20px'")
   })
 })
+
+describe('accepting an update is what starts the download', () => {
+  it('asks rather than announcing a download already under way', () => {
+    const available: UpdateStatus = {
+      phase: 'available',
+      currentVersion: '0.4.3',
+      availableVersion: '0.4.4',
+      manual: false
+    }
+    expect(updateMessage(available, 'zh')).toBe('发现新版本 0.4.4，是否更新？')
+    expect(updateMessage(available, 'en')).toBe('DSH Desktop 0.4.4 is available. Update now?')
+  })
+})


### PR DESCRIPTION
## 问题

卸载插件时清了三样东西里的一样：

| 要清什么 | 谁在清 | 之前的状态 |
| --- | --- | --- |
| `dependencies` + `bundles` + `node_modules` | `dsh plugin remove` → `reconcilePlugins` | ✅ |
| 用户层 `cordis.patch.yml` 里**指向该插件的行** | 无 | ❌ |
| 声明与磁盘状态**不一致时的可见性** | 无 | ❌ |

留下来的行不会报错。指向已消失 id 的行是惰性的；把服务路由到该插件曾提供的 backend 的配置值，只会让那个服务**一直等**——于是 profile 表现成"启动慢"，而不是"启动坏了"。

这正是 v0.4.3 macOS 那次事故的第一层：`dsh-doudizhu` 残留让服务卡在等 `storageDomain`，把后面真正致命的 HMR 缺陷整整挡住了一个版本（见 #146）。

## 修复

**一、卸载时定向清理用户层**

在插件文件被删之前，先从它自己的 bundle patch 里读出它声明的 entry id；卸载成功后，只摘掉 `id` 命中这些 id、或 `insert` 中 `name` 为该插件的行。

用户层是用户自己写的东西（含注释），所以按**文档**编辑而非重新序列化：无关的行、缩进、注释都原样保留；首行注释（文件头）在首行被删时会搬到下一行，不会丢。没有任何行命中时，文件**一个字节都不动**。

同时修掉 `resetPluginProfile` 的另一个极端——它为了清掉一个插件的几行，会把整个 `cordis.patch.yml` 重写成 `[]`，连用户自己的覆盖层一起铲。现在只有"不指定插件的整体重置"才会清空。

**二、启动时报告不一致**

`inspectProfileConsistency` 在启动前检查四类状态，写进 harness 日志：

- bundle 声明了但没装
- 装了、声明了 bundle，但没进 bundles 列表
- **装在 node_modules 里，但 manifest 里彻底没有声明**
- patch 层 insert 了一个没装的包

只报告，不改变启动流程——重点是让这些状态**不再沉默**。

## 验证

- `npm run typecheck` 通过；`npm test` 37 文件 **253** 测试全绿（新增 12 条）。
- 关键性质有测试兜底：卸载 `dsh-doudizhu` 后，它的 `id:` 行和两条 `insert` 都消失，而用户自己的 `accent: violet` 和 `dsh-my-own` 完好，文件头注释也在。
- 一致性检查跑在**真实出问题的 profile** 上，准确报出那一条：

  ```
  dshmarket is installed but declared nowhere in the profile manifest
  ```

  这正是让市场装不上、又反复提示重启的那个状态。

## 范围

对应内部文档第十节任务 5（插件系统 / P1）。与 #146（macOS 打包版 HMR）无重叠——那是启动能力问题，这是状态一致性问题；两者叠加正是那次事故难查的原因。

仍未覆盖：**其它行对该插件所提供服务的引用**（比如把 storage 路由到插件的 sqlite backend）。那需要知道每个插件提供哪些服务，得靠上游的能力声明；在那之前，第二部分的启动报告至少让这类状态在日志里点名可见，而不是靠人肉排查。
