### PR TITLE
fix: pin the profile's pnpm store, and restyle the update card

### DIFF
--- a/patches/@deepseek-ai+dsh+0.1.1-rc.1.patch
+++ b/patches/@deepseek-ai+dsh+0.1.1-rc.1.patch
@@ -1,11 +1,12 @@
 diff --git a/node_modules/@deepseek-ai/dsh/package.json b/node_modules/@deepseek-ai/dsh/package.json
-index 881bb2a..adc3a2a 100644
+index 881bb2a..e355fb5 100644
 --- a/node_modules/@deepseek-ai/dsh/package.json
 +++ b/node_modules/@deepseek-ai/dsh/package.json
-@@ -20,6 +20,7 @@
+@@ -20,6 +20,8 @@
    ],
    "license": "MIT",
    "dependencies": {
++    "dsh-desktop-hmr-fallback": "0.1.0",
 +    "dsh-desktop-market-installer": "0.1.0",
      "commander": "^15.0.0",
      "js-yaml": "^4.2.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -807,7 +807,12 @@ async function showPluginRecovery(options?: {
           if (removed) {
             if (!removedPlugins.includes(plugin)) removedPlugins.push(plugin)
           } else {
-            failedPlugins.push(plugin)
+            const fallbackRemoved = await resetPluginProfile(dshHome, plugin)
+            if (fallbackRemoved) {
+              if (!removedPlugins.includes(plugin)) removedPlugins.push(plugin)
+            } else {
+              failedPlugins.push(plugin)
+            }
           }
         }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,7 @@ import {
 } from './runtime/profile-plugin-command'
 import { clearDamagedPackageDirectories, hasProfile } from './state/profile-repair'
 import { inspectProfileConsistency } from './state/profile-consistency'
+import { ensureStoreDirPinned, inspectStoreConsistency } from './state/profile-store'
 import { LanMobileBridge } from './mobile/lan-mobile-bridge'
 import {
   detectPluginRecovery,
@@ -513,6 +514,8 @@ async function repairProfilePackages(dshHome: string): Promise<void> {
 async function reportProfileConsistency(dshHome: string): Promise<void> {
   try {
     const findings = await inspectProfileConsistency(dshHome)
+    const store = await inspectStoreConsistency(dshHome)
+    if (store) findings.push(store)
     for (const finding of findings) runtime.note(`[desktop] profile inconsistency: ${finding}`)
   } catch {
     // A profile that cannot be inspected is not a reason to refuse a launch.
@@ -529,6 +532,10 @@ function launchHarness(): Promise<void> {
     // previous one running: start() stops it, but that is after the repair.
     // Stopping here is what makes the window this launch path assumes.
     await runtime.stop()
+    // Before anything else runs pnpm: a store the profile does not pin makes
+    // every package operation fail, repairs included.
+    const pinned = await ensureStoreDirPinned(dshHome).catch(() => undefined)
+    if (pinned) runtime.note(`[desktop] pinned the profile's pnpm store: ${pinned}`)
     await repairProfilePackages(dshHome)
     await pruneMissingProfileBundles(dshHome).catch(() => false)
     await reportProfileConsistency(dshHome)

--- a/src/main/state/plugin-recovery.ts
+++ b/src/main/state/plugin-recovery.ts
@@ -167,7 +167,7 @@ async function pluginMatchesSlot(
     try {
       const content = await readFile(join(packageDir, file), 'utf8')
       if (content.includes(slotName)) return true
-    } catch {}
+    } catch { }
   }
   return false
 }
@@ -193,10 +193,10 @@ async function packagesProvidingSlot(
             providers.push(packageName)
             break
           }
-        } catch {}
+        } catch { }
       }
     }
-  } catch {}
+  } catch { }
 
   return providers
 }
@@ -216,13 +216,13 @@ async function pluginReferencesPackage(
       ...Object.keys(manifest.optionalDependencies ?? {})
     ])
     if ([...packageNames].some((packageName) => declaredPackages.has(packageName))) return true
-  } catch {}
+  } catch { }
 
   for (const file of ['cordis.patch.yml', 'index.js', 'lib/index.js', 'dist/index.js']) {
     try {
       const content = await readFile(join(packageDirectory, file), 'utf8')
       if ([...packageNames].some((packageName) => content.includes(packageName))) return true
-    } catch {}
+    } catch { }
   }
   return false
 }
@@ -527,9 +527,17 @@ export async function resetPluginProfile(
               if (files.length === 0) {
                 await removeTree(scopeDir).catch(() => undefined)
               }
-            } catch {}
+            } catch { }
           }
         }
+      }
+    }
+
+    const packagesDir = join(dshHome, 'profiles', 'web', 'packages')
+    if (failingPlugin && existsSync(packagesDir)) {
+      const packageSourceDir = join(packagesDir, failingPlugin)
+      if (existsSync(packageSourceDir)) {
+        await removeTree(packageSourceDir).catch(() => undefined)
       }
     }
 

--- a/src/main/state/profile-store.ts
+++ b/src/main/state/profile-store.ts
@@ -1,0 +1,125 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { profilePackageJsonPath } from './plugin-recovery'
+
+/**
+ * Where the profile's packages are linked from, and why it has to be written
+ * down.
+ *
+ * pnpm records the store it materialized `node_modules` from in
+ * `.modules.yaml`, and refuses every later operation if the store it would use
+ * now is a different one — `ERR_PNPM_UNEXPECTED_STORE`. That refusal is total:
+ * not just installs, but uninstalls, updates and repairs, which is a plugin
+ * system locked shut from the outside. A profile whose store sits inside
+ * itself reaches that state the moment anything runs pnpm without saying so,
+ * because the default store lives under the user's home instead.
+ *
+ * The desktop already writes the profile's `.npmrc`. Pinning the recorded
+ * store there keeps the two accounts of the same fact from drifting apart.
+ */
+
+/** The store `node_modules` was linked from, as pnpm recorded it. */
+export async function recordedStoreDir(profileDirectory: string): Promise<string | undefined> {
+  try {
+    const raw = await readFile(join(profileDirectory, 'node_modules', '.modules.yaml'), 'utf8')
+    // pnpm writes this file as JSON-in-YAML, so the value arrives quoted and
+    // comma-terminated; older layouts write it bare.
+    const quoted = /^\s*"?storeDir"?\s*:\s*"([^"]+)"/mu.exec(raw)
+    const bare = /^\s*"?storeDir"?\s*:\s*([^"\s][^,\n]*?)\s*,?\s*$/mu.exec(raw)
+    const value = (quoted?.[1] ?? bare?.[1])?.trim()
+    return value ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** The store an `.npmrc` pins, if it pins one. */
+export function configuredStoreDir(npmrc: string): string | undefined {
+  const match = /^\s*store-dir\s*=\s*(.+?)\s*$/mu.exec(npmrc)
+  const value = match?.[1]
+  return value ? value : undefined
+}
+
+/**
+ * An `.npmrc` that pins the store pnpm actually used.
+ * @returns the text to write, or undefined when it already says so — callers
+ * leave the file alone rather than rewriting it on every launch.
+ */
+export function pinStoreDir(npmrc: string, storeDir: string): string | undefined {
+  const configured = configuredStoreDir(npmrc)
+  if (configured === storeDir) return undefined
+  // pnpm strips the trailing store version segment from what it records, so
+  // the pinned value is the directory that contains it.
+  const body = configured === undefined ? npmrc : npmrc.replace(/^\s*store-dir\s*=.*$\n?/mu, '')
+  const separator = body.length === 0 || body.endsWith('\n') ? '' : '\n'
+  return `${body}${separator}store-dir=${storeDir}\n`
+}
+
+/**
+ * pnpm records the store including its version segment (`…/v10`); the setting
+ * names the directory above it.
+ */
+export function storeDirSetting(recorded: string): string {
+  return /[/\\]v\d+$/u.test(recorded) ? dirname(recorded) : recorded
+}
+
+/**
+ * Write the recorded store into the profile's `.npmrc`, so the next pnpm run
+ * uses the store its `node_modules` was built from.
+ *
+ * Only what pnpm already recorded is written — this states an existing fact
+ * rather than choosing a new store, and a profile that never installed
+ * anything has nothing to state. Run before Harness starts, alongside the
+ * other repairs, so the operations that follow can actually run.
+ * @returns the pinned store, or undefined when nothing needed doing.
+ */
+export async function ensureStoreDirPinned(dshHome: string): Promise<string | undefined> {
+  const profileDirectory = dirname(profilePackageJsonPath(dshHome))
+  const recorded = await recordedStoreDir(profileDirectory)
+  if (recorded === undefined) return undefined
+
+  const npmrcPath = join(profileDirectory, '.npmrc')
+  let npmrc = ''
+  try {
+    npmrc = await readFile(npmrcPath, 'utf8')
+  } catch {
+    // A profile without an .npmrc still deserves the pin.
+  }
+
+  const expected = storeDirSetting(recorded)
+  const pinned = pinStoreDir(npmrc, expected)
+  if (pinned === undefined) return undefined
+
+  try {
+    await writeFile(npmrcPath, pinned, 'utf8')
+    return expected
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Whether a profile is about to meet ERR_PNPM_UNEXPECTED_STORE.
+ * @returns a sentence naming the mismatch, or undefined when the two agree —
+ * or when there is nothing recorded yet to disagree with.
+ */
+export async function inspectStoreConsistency(dshHome: string): Promise<string | undefined> {
+  const profileDirectory = dirname(profilePackageJsonPath(dshHome))
+  const recorded = await recordedStoreDir(profileDirectory)
+  if (recorded === undefined) return undefined
+
+  let npmrc = ''
+  try {
+    npmrc = await readFile(join(profileDirectory, '.npmrc'), 'utf8')
+  } catch {
+    // No .npmrc pins nothing, which is exactly the drift being reported.
+  }
+
+  const configured = configuredStoreDir(npmrc)
+  const expected = storeDirSetting(recorded)
+  if (configured === expected) return undefined
+
+  return configured === undefined
+    ? `node_modules was linked from ${recorded}, which no .npmrc pins — pnpm will refuse to run here`
+    : `node_modules was linked from ${recorded}, but .npmrc pins ${configured} — pnpm will refuse to run here`
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,7 +3,7 @@ import type { UpdateStatus } from '../shared/contracts'
 import {
   isUpdateDismissed,
   shouldShowUpdate,
-  updateMessage,
+  updateHeadline,
   type UpdateLocale
 } from './update-view'
 import { isPluginLoadError } from './plugin-error-view'
@@ -240,20 +240,23 @@ function render(): void {
   card.setAttribute('aria-label', locale === 'zh' ? 'DSH Desktop 更新' : 'DSH Desktop update')
 
   const row = element('div', 'row')
-  const indicator = element('span', isBusy(status) ? 'spinner' : 'dot')
-  indicator.setAttribute('aria-hidden', 'true')
-  row.appendChild(indicator)
+  const badge = element('span', status.phase === 'error' ? 'badge warning' : 'badge')
+  badge.setAttribute('aria-hidden', 'true')
+  if (isBusy(status)) badge.appendChild(element('span', 'spinner'))
+  else badge.innerHTML = updateIcon
+  row.appendChild(badge)
 
+  const headline = updateHeadline(status, locale)
   const body = element('div', 'body')
-  const message = element('p', 'message')
-  message.textContent = updateMessage(status, locale)
-  body.appendChild(message)
+  const title = element('p', 'title')
+  title.textContent = headline.title
+  body.appendChild(title)
 
-  if (status.phase === 'error' && status.message) {
-    const detail = element('p', 'detail')
-    detail.textContent = status.message
-    body.appendChild(detail)
-  }
+  // The failure's own words beat ours, when it has any.
+  const description = element('p', 'description')
+  description.textContent =
+    status.phase === 'error' && status.message ? status.message : headline.description
+  if (description.textContent) body.appendChild(description)
 
   if (status.phase === 'downloading') {
     const progress = element('div', 'progress')
@@ -390,43 +393,43 @@ const styles = `
   }
   .row { display: flex; align-items: flex-start; gap: 12px; }
   .body { min-width: 0; flex: 1; }
-  .message { margin: 0; font-size: 14px; font-weight: 600; line-height: 20px; }
-  .detail {
-    margin: 5px 0 0;
+  .title { margin: 0; font-size: 14px; font-weight: 650; line-height: 20px; letter-spacing: -0.1px; }
+  .description {
+    margin: 3px 0 0;
     color: var(--dsw-alias-label-secondary, #666b73);
-    font-size: 12px;
-    line-height: 17px;
+    font-size: 12.5px;
+    line-height: 18px;
     display: -webkit-box;
     overflow: hidden;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
   }
-  .dot {
-    width: 10px;
-    height: 10px;
-    margin-top: 5px;
+  .badge {
+    width: 34px;
+    height: 34px;
+    margin-top: -1px;
     flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border-radius: 999px;
-    background: #4d6bfe;
-    box-shadow: 0 0 0 4px rgba(77, 107, 254, 0.12);
+    color: #2ea043;
+    background: rgba(46, 160, 67, 0.14);
   }
-  .dot.warning {
-    background: #f59e0b;
-    box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.18);
-  }
+  .badge.warning { color: #d29922; background: rgba(210, 153, 34, 0.16); }
   .spinner {
-    width: 17px;
-    height: 17px;
-    margin-top: 1px;
+    width: 16px;
+    height: 16px;
     flex: none;
-    border: 2px solid rgba(77, 107, 254, 0.22);
-    border-top-color: #4d6bfe;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
     border-radius: 999px;
+    opacity: 0.85;
     animation: spin 0.75s linear infinite;
   }
   .progress {
-    height: 6px;
-    margin-top: 10px;
+    height: 5px;
+    margin-top: 11px;
     overflow: hidden;
     border-radius: 999px;
     background: var(--dsw-alias-bg-layer-2, rgba(32, 33, 36, 0.1));
@@ -435,10 +438,10 @@ const styles = `
     height: 100%;
     min-width: 2px;
     border-radius: inherit;
-    background: #4d6bfe;
+    background: #2ea043;
     transition: width 180ms ease;
   }
-  .actions { display: flex; gap: 8px; margin-top: 12px; }
+  .actions { display: flex; gap: 8px; margin-top: 13px; }
   button {
     appearance: none;
     border: 0;
@@ -448,19 +451,24 @@ const styles = `
   button:focus-visible { outline: 2px solid #4d6bfe; outline-offset: 2px; }
   button:disabled { cursor: default; opacity: 0.55; }
   .primary, .secondary {
-    min-height: 30px;
-    padding: 5px 11px;
-    border-radius: 8px;
-    font-size: 12px;
+    min-height: 32px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 12.5px;
     font-weight: 600;
   }
   .primary { color: #fff; background: #4d6bfe; }
   .primary:hover:not(:disabled) { background: #3e5de7; }
+  /* Ghosted, so the accepted action is the only filled thing on the card. */
   .secondary {
-    color: var(--dsw-alias-label-primary, #202124);
-    background: var(--dsw-alias-bg-layer-2, rgba(32, 33, 36, 0.08));
+    color: var(--dsw-alias-label-secondary, #666b73);
+    background: transparent;
+    border: 1px solid var(--dsw-alias-border-l2, rgba(32, 33, 36, 0.16));
   }
-  .secondary:hover { background: var(--dsw-alias-interactive-bg-hover, rgba(32, 33, 36, 0.13)); }
+  .secondary:hover {
+    color: var(--dsw-alias-label-primary, #202124);
+    background: var(--dsw-alias-interactive-bg-hover, rgba(32, 33, 36, 0.06));
+  }
   .close {
     width: 24px;
     height: 24px;
@@ -481,14 +489,22 @@ const styles = `
       border-color: var(--dsw-alias-border-l2, rgba(255, 255, 255, 0.14));
       box-shadow: 0 16px 42px rgba(0, 0, 0, 0.42), 0 2px 8px rgba(0, 0, 0, 0.25);
     }
-    .detail { color: var(--dsw-alias-label-secondary, #a9adb5); }
-    .secondary { color: var(--dsw-alias-label-primary, #f3f4f6); background: rgba(255, 255, 255, 0.1); }
+    .description { color: var(--dsw-alias-label-secondary, #a9adb5); }
+    .badge { color: #3fb950; background: rgba(63, 185, 80, 0.16); }
+    .badge.warning { color: #e3b341; background: rgba(227, 179, 65, 0.18); }
+    .secondary {
+      color: var(--dsw-alias-label-secondary, #a9adb5);
+      border-color: var(--dsw-alias-border-l2, rgba(255, 255, 255, 0.18));
+    }
+    .secondary:hover { color: var(--dsw-alias-label-primary, #f3f4f6); background: rgba(255, 255, 255, 0.08); }
   }
   @media (prefers-reduced-motion: reduce) {
     .spinner { animation: none; }
     .progressValue { transition: none; }
   }
 `
+
+const updateIcon = `<svg viewBox="0 0 24 24" width="18" height="18" fill="none" aria-hidden="true"><path d="M4.6 12a7.4 7.4 0 0 1 12.6-5.2" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/><path d="M19.4 12a7.4 7.4 0 0 1-12.6 5.2" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/><path d="M17.6 3.5v3.4h-3.4M6.4 20.5v-3.4h3.4" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/></svg>`
 
 const phoneIcon = `<svg viewBox="0 0 24 24" width="19" height="19" fill="none" aria-hidden="true"><rect x="7" y="2.75" width="10" height="18.5" rx="2.25" stroke="currentColor" stroke-width="1.7"/><path d="M10.2 5.5h3.6M10.5 18.35h3" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>`
 

--- a/src/preload/update-view.ts
+++ b/src/preload/update-view.ts
@@ -16,6 +16,67 @@ export function isUpdateDismissed(
   return status.phase === dismissedTransientPhase
 }
 
+export interface UpdateHeadline {
+  title: string
+  description: string
+}
+
+/**
+ * The card's two lines: what happened, then what it means for the user.
+ *
+ * The version belongs in the second line rather than the first — a release
+ * number answers "which one", not "what now", and reading the state should not
+ * require parsing a version string out of a sentence.
+ */
+export function updateHeadline(status: UpdateStatus, locale: UpdateLocale): UpdateHeadline {
+  const zh = locale === 'zh'
+  const version = status.availableVersion ? `v${status.availableVersion}` : ''
+
+  switch (status.phase) {
+    case 'checking':
+      return {
+        title: zh ? '正在检查更新' : 'Checking for updates',
+        description: zh ? `当前 v${status.currentVersion}` : `Currently on v${status.currentVersion}`
+      }
+    case 'available':
+      return {
+        title: zh ? '有可用更新' : 'Update available',
+        description: zh
+          ? `${version} 已发布，同意后开始下载。`
+          : `${version} is ready to download.`
+      }
+    case 'downloading':
+      return {
+        title: zh ? '正在下载更新' : 'Downloading update',
+        description: zh ? `${version} · ${Math.round(status.percent ?? 0)}%` : `${version} · ${Math.round(status.percent ?? 0)}%`
+      }
+    case 'downloaded':
+      return {
+        title: zh ? '更新已就绪' : 'Update ready',
+        description: zh
+          ? `${version} 将在重启后生效。`
+          : `${version} will be applied on next launch.`
+      }
+    case 'up-to-date':
+      return {
+        title: zh ? '已是最新版本' : 'Up to date',
+        description: zh ? `当前 v${status.currentVersion}` : `Currently on v${status.currentVersion}`
+      }
+    case 'unsupported':
+      return {
+        title: zh ? '此版本不支持自动更新' : 'Automatic updates unavailable',
+        description: zh ? '请从官网下载新版本。' : 'Download new versions from the website.'
+      }
+    case 'error':
+      return {
+        title: zh ? '更新失败' : 'Update failed',
+        description: zh ? '无法检查或下载更新。' : 'Unable to check for or download updates.'
+      }
+    case 'idle':
+      return { title: '', description: '' }
+  }
+}
+
 export function updateMessage(status: UpdateStatus, locale: UpdateLocale): string {
   const zh = locale === 'zh'
   const version = status.availableVersion ? ` ${status.availableVersion}` : ''

--- a/test/hmr-fallback.test.js
+++ b/test/hmr-fallback.test.js
@@ -51,6 +51,12 @@ describe('desktop HMR fallback', () => {
     expect(manifest.dependencies['dsh-desktop-hmr-fallback']).toBe(
       'file:packages/dsh-desktop-hmr-fallback'
     )
+
+    const dshPatch = await readFile(
+      join(process.cwd(), 'patches', '@deepseek-ai+dsh+0.1.1-rc.1.patch'),
+      'utf8'
+    )
+    expect(dshPatch).toContain('"dsh-desktop-hmr-fallback": "0.1.0"')
   })
 
   it('refreshes on a change to the watched config, and not on its neighbours', async () => {

--- a/test/plugin-recovery.test.ts
+++ b/test/plugin-recovery.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -311,6 +312,33 @@ describe('plugin-recovery', () => {
       '@deepseek-ai/dsh-web-app',
       'dshmarket'
     ])
+  })
+
+  it('removes workspace packages and stale lockfile when resetting a plugin', async () => {
+    const pkgPath = profilePackageJsonPath(testDir)
+    const profileDir = join(testDir, 'profiles', 'web')
+    const workspacePkgDir = join(profileDir, 'packages', 'dsh-doudizhu')
+    const nodeModulesPkgDir = join(profileDir, 'node_modules', 'dsh-doudizhu')
+    const lockfilePath = join(profileDir, 'pnpm-lock.yaml')
+
+    await mkdir(workspacePkgDir, { recursive: true })
+    await mkdir(nodeModulesPkgDir, { recursive: true })
+    await writeFile(join(workspacePkgDir, 'package.json'), '{"name":"dsh-doudizhu"}')
+    await writeFile(join(nodeModulesPkgDir, 'package.json'), '{"name":"dsh-doudizhu"}')
+    await writeFile(lockfilePath, 'lockfileVersion: 9.0')
+    await writeFile(
+      pkgPath,
+      JSON.stringify({
+        dependencies: { 'dsh-doudizhu': 'workspace:^' },
+        dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dsh-doudizhu'] } }
+      })
+    )
+
+    const success = await resetPluginProfile(testDir, 'dsh-doudizhu')
+    expect(success).toBe(true)
+    expect(existsSync(workspacePkgDir)).toBe(false)
+    expect(existsSync(nodeModulesPkgDir)).toBe(false)
+    expect(existsSync(lockfilePath)).toBe(false)
   })
 
   it('resolves root package when a scoped sub-module fails', async () => {

--- a/test/profile-store.test.ts
+++ b/test/profile-store.test.ts
@@ -1,0 +1,102 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  configuredStoreDir,
+  ensureStoreDirPinned,
+  inspectStoreConsistency,
+  pinStoreDir,
+  recordedStoreDir,
+  storeDirSetting
+} from '../src/main/state/profile-store'
+
+const NPMRC = 'package-import-method=clone-or-copy\nchild-concurrency=1\n'
+
+describe('the profile’s pnpm store', () => {
+  const homes: string[] = []
+
+  async function profileHome(options: { recorded?: string; npmrc?: string } = {}): Promise<{
+    home: string
+    profile: string
+  }> {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-store-'))
+    homes.push(home)
+    const profile = join(home, 'profiles', 'web')
+    await mkdir(join(profile, 'node_modules'), { recursive: true })
+    await writeFile(join(profile, 'package.json'), '{}', 'utf8')
+    if (options.recorded !== undefined) {
+      await writeFile(
+        join(profile, 'node_modules', '.modules.yaml'),
+        `  "nodeLinker": "hoisted",\n  "storeDir": "${options.recorded}",\n  "virtualStoreDir": ".pnpm",\n`,
+        'utf8'
+      )
+    }
+    if (options.npmrc !== undefined) await writeFile(join(profile, '.npmrc'), options.npmrc, 'utf8')
+    return { home, profile }
+  }
+
+  afterEach(async () => {
+    await Promise.all(homes.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+  })
+
+  it('reads what pnpm recorded and what the config pins', async () => {
+    const { profile } = await profileHome({ recorded: '/p/web/.pnpm-store/v10' })
+    await expect(recordedStoreDir(profile)).resolves.toBe('/p/web/.pnpm-store/v10')
+    expect(configuredStoreDir(`${NPMRC}store-dir=/p/web/.pnpm-store\n`)).toBe('/p/web/.pnpm-store')
+    expect(configuredStoreDir(NPMRC)).toBeUndefined()
+  })
+
+  it('pins the directory above the store’s version segment', () => {
+    // pnpm records …/v10 but the setting names its parent.
+    expect(storeDirSetting('/p/web/.pnpm-store/v10')).toBe('/p/web/.pnpm-store')
+    expect(storeDirSetting('/p/web/.pnpm-store')).toBe('/p/web/.pnpm-store')
+  })
+
+  it('adds, replaces, or leaves the pin alone', () => {
+    expect(pinStoreDir(NPMRC, '/store')).toBe(`${NPMRC}store-dir=/store\n`)
+    expect(pinStoreDir(`${NPMRC}store-dir=/old\n`, '/store')).toBe(`${NPMRC}store-dir=/store\n`)
+    // Already correct: the file is not rewritten on every launch.
+    expect(pinStoreDir(`${NPMRC}store-dir=/store\n`, '/store')).toBeUndefined()
+    expect(pinStoreDir('', '/store')).toBe('store-dir=/store\n')
+  })
+
+  it('states the recorded store in the profile’s config', async () => {
+    const { home, profile } = await profileHome({
+      recorded: '/p/web/.pnpm-store/v10',
+      npmrc: NPMRC
+    })
+
+    await expect(ensureStoreDirPinned(home)).resolves.toBe('/p/web/.pnpm-store')
+    expect(await readFile(join(profile, '.npmrc'), 'utf8')).toBe(
+      `${NPMRC}store-dir=/p/web/.pnpm-store\n`
+    )
+    // Second launch has nothing left to do.
+    await expect(ensureStoreDirPinned(home)).resolves.toBeUndefined()
+  })
+
+  it('has nothing to state for a profile that never installed anything', async () => {
+    const { home } = await profileHome({ npmrc: NPMRC })
+    await expect(ensureStoreDirPinned(home)).resolves.toBeUndefined()
+    await expect(inspectStoreConsistency(home)).resolves.toBeUndefined()
+  })
+
+  it('names the mismatch that makes every pnpm operation fail', async () => {
+    // ERR_PNPM_UNEXPECTED_STORE refuses installs, uninstalls, updates and
+    // repairs alike, and the UI can only say "unable to change plugins".
+    const unpinned = await profileHome({ recorded: '/p/web/.pnpm-store/v10', npmrc: NPMRC })
+    await expect(inspectStoreConsistency(unpinned.home)).resolves.toContain('no .npmrc pins')
+
+    const wrong = await profileHome({
+      recorded: '/p/web/.pnpm-store/v10',
+      npmrc: `${NPMRC}store-dir=/elsewhere\n`
+    })
+    await expect(inspectStoreConsistency(wrong.home)).resolves.toContain('/elsewhere')
+
+    const pinned = await profileHome({
+      recorded: '/p/web/.pnpm-store/v10',
+      npmrc: `${NPMRC}store-dir=/p/web/.pnpm-store\n`
+    })
+    await expect(inspectStoreConsistency(pinned.home)).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
接在 #147 之后，同一轮排查里剩下的两件事及后续修复。

## 一、固定 profile 的 pnpm store（P0）

一个 profile 的 `node_modules` 如果是从某个 store 链过来的，而 pnpm 下次不会再选中那个 store，整个插件系统就被从外面锁死：`ERR_PNPM_UNEXPECTED_STORE` 拒绝的不只是安装，**卸载、更新、修复一并拒绝**，而用户看到的只有一句"未能修改插件配置"。

实际发生的情形：某个 profile 内部有一个 487 MB 的 store（`<profile>/.pnpm-store/v10`），`.modules.yaml` 记着它，但 `.npmrc` 没有 `store-dir`——于是 pnpm 默认去用 `~/Library/pnpm/store/v10`，两边对不上。结果是一个会导致启动失败的插件**没法从界面卸载**，必须手工改配置才能救回来。

修法：启动路径在**任何 pnpm 运行之前**，把 pnpm 自己记录过的 store 写进 profile 的 `.npmrc`。

- **只写既成事实**：值来自 `node_modules/.modules.yaml` 的 `storeDir`，不是替用户挑一个 store；从没装过东西的 profile 没有可写的东西。
- 已经一致时不重写文件，不会每次启动都动它。
- 写不进去（只读等）时，把真相报进日志，而不是让下一次操作以那句笼统的失败收场。

时序上放在 `runtime.stop()` 之后、`repairProfilePackages()` 之前——修复本身也要跑 pnpm。

## 二、更新卡片样式

第二行是新的：第一行说发生了什么，第二行说这对用户意味着什么，版本号落在第二行（版本号回答"哪一个"，不回答"现在怎样"）。图标变成承载状态的圆形徽章，卡片上只有被接受的那个动作是实心按钮，其余是间距。

按钮的文案和行为没变——同意更新、跳过此版本、重新启动并安装。

## 三、补全 dsh 补丁依赖并完善插件卸载恢复降级

1. **补全 `dsh-desktop-hmr-fallback` 依赖声明**：在 `patches/@deepseek-ai+dsh+0.1.1-rc.1.patch` 中声明该依赖，使全新 profile 启动时 `healProfilesModuleFallback` 正确软链该包，解决 CI Windows 冒烟测试失败问题。
2. **卸载失败自动降级重置**：主进程恢复弹窗点击"移除插件"时，若常规 pnpm 移除因依赖冲突/损坏报错，自动降级调用 `resetPluginProfile` 进行安全清理（清理 `package.json`、`cordis.patch.yml`、`node_modules/<pkg>`、`packages/<pkg>` 及脏 lockfile），避免卸载失败死锁。

## 验证

- `npm run typecheck` 通过；`npm test` 40 文件 **271** 测试全绿。
- CI Windows / macOS 打包冒烟测试重新触发运行中。