### PR TITLE
fix: inherit user login shell environment for Harness subprocess

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,7 +14,7 @@ import {
   type IpcMainInvokeEvent,
   type MessageBoxOptions
 } from 'electron'
-import { extractFailureCause, HarnessRuntime } from './runtime/harness-runtime'
+import { extractFailureCause, HarnessRuntime, resolveShellEnvironment } from './runtime/harness-runtime'
 import { launchDisclaimedUtilityProcess } from './runtime/disclaimed-utility-process'
 import {
   installProfileDependenciesWithDsh,
@@ -793,7 +793,7 @@ async function showPluginRecovery(options?: {
                 nodeExecutablePath: bundledNodePath(),
                 pnpmEntryPath: bundledPnpmEntryPath(),
                 pnpmRunnerPath: bundledPnpmRunnerPath(),
-                environment: process.env
+                environment: resolveShellEnvironment()
               },
               pluginName
             )

--- a/src/main/runtime/harness-runtime.ts
+++ b/src/main/runtime/harness-runtime.ts
@@ -1,4 +1,4 @@
-import type { SpawnOptionsWithoutStdio } from 'node:child_process'
+import { execFileSync, type SpawnOptionsWithoutStdio } from 'node:child_process'
 import type { EventEmitter } from 'node:events'
 import { createWriteStream, existsSync, mkdirSync, type WriteStream } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
@@ -27,6 +27,86 @@ export interface HarnessChildProcess extends EventEmitter {
   readonly stderr: NodeJS.ReadableStream
   readonly exitCode: number | null
   kill(signal?: NodeJS.Signals): boolean
+}
+
+/**
+ * Resolve the user's interactive login shell environment.
+ *
+ * Electron apps launched from macOS Finder/Spotlight inherit a minimal
+ * environment from launchd that never sources the user's shell profile
+ * (~/.zshenv, ~/.zprofile, ~/.zshrc). This leaves PATH without Homebrew,
+ * mise shims, ~/.local/bin, etc., so CLIs like bun, lark-cli, and docker
+ * are invisible to the Harness process and every subprocess it spawns.
+ *
+ * On Windows the same gap exists when tools are added via a PowerShell
+ * profile ($PROFILE) rather than the user-level registry environment —
+ * `cmd /c set` only sees registry vars, so we use PowerShell with the
+ * profile loaded to capture the full set.
+ *
+ * This function shells out once to capture the full environment the user
+ * would have in a terminal, and returns it for use as the Harness spawn
+ * base. On any failure it falls back to `process.env` to preserve the
+ * current behavior.
+ *
+ * The result is memoised for the process lifetime.
+ */
+let resolvedShellEnvironment: NodeJS.ProcessEnv | undefined
+
+export function resolveShellEnvironment(): NodeJS.ProcessEnv {
+  if (resolvedShellEnvironment !== undefined) return resolvedShellEnvironment
+
+  try {
+    if (process.platform === 'win32') {
+      // PowerShell with the user profile loaded captures both registry
+      // environment variables and any PATH additions sourced in $PROFILE
+      // (e.g. conda activate, nvm use, scoop shim).  -OutputFormat Text
+      // avoids BOM/XML wrapping.
+      const output = execFileSync(
+        'powershell',
+        [
+          '-NoLogo',
+          '-NonInteractive',
+          '-OutputFormat', 'Text',
+          '-Command',
+          // Dot-source the profile (suppress errors if it doesn't exist),
+          // then emit NAME=VALUE for every environment variable.
+          '. $PROFILE 2>$null; Get-ChildItem Env: | ForEach-Object { "$($_.Name)=$($_.Value)" }'
+        ],
+        {
+          encoding: 'utf8',
+          timeout: 15_000,
+          stdio: ['ignore', 'pipe', 'ignore']
+        }
+      )
+      resolvedShellEnvironment = parseEnvOutput(output, /\r?\n/)
+    } else {
+      // macOS / Linux: run a login + interactive shell so both .zprofile
+      // (Homebrew, OrbStack) and .zshrc (mise shims, ~/.local/bin, cargo,
+      // go, etc.) are sourced.  stderr is ignored to suppress prompt noise.
+      const shell = process.env.SHELL ?? '/bin/sh'
+      const output = execFileSync(shell, ['-l', '-i', '-c', 'env'], {
+        encoding: 'utf8',
+        timeout: 10_000,
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+      resolvedShellEnvironment = parseEnvOutput(output, /\n/)
+    }
+  } catch {
+    // Shell capture failed — stay silent and keep the inherited environment.
+    resolvedShellEnvironment = process.env
+  }
+
+  return resolvedShellEnvironment
+}
+
+function parseEnvOutput(output: string, lineSeparator: RegExp): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {}
+  for (const line of output.split(lineSeparator)) {
+    const eq = line.indexOf('=')
+    if (eq <= 0) continue
+    env[line.slice(0, eq)] = line.slice(eq + 1)
+  }
+  return env
 }
 
 export function buildHarnessArguments(port: number, patchPath?: string): string[] {
@@ -172,7 +252,12 @@ export class HarnessRuntime {
       child = this.options.launchProcess(
         this.options.nodeExecutablePath,
         args,
-        buildHarnessSpawnOptions(launchDirectory, this.options.dshHome)
+        buildHarnessSpawnOptions(
+          launchDirectory,
+          this.options.dshHome,
+          process.platform,
+          resolveShellEnvironment()
+        )
       )
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -12,6 +12,7 @@ import {
   extractPluginFailureReferences,
   extractSlotConflictName,
   formatExitCode,
+  resolveShellEnvironment,
   updateReadyStability
 } from '../src/main/runtime/harness-runtime'
 import { canGrantWindowPermission, isTrustedAppUrl } from '../src/main/security-policy'
@@ -201,7 +202,27 @@ describe('Harness launch contract', () => {
   })
 })
 
+describe('shell environment resolution', () => {
+  it('resolves a non-empty environment from the user login shell', () => {
+    const env = resolveShellEnvironment()
+    expect(env).toBeDefined()
+    // PATH must always be present in a valid shell environment.
+    expect(env.PATH).toBeTruthy()
+  })
 
+  it('memoises the result across calls', () => {
+    const first = resolveShellEnvironment()
+    const second = resolveShellEnvironment()
+    // Same object reference — the result is cached for the process lifetime.
+    expect(second).toBe(first)
+  })
+
+  it('produces a PATH that includes standard system directories', () => {
+    const env = resolveShellEnvironment()
+    // /usr/bin is present on every macOS and Linux installation.
+    expect(env.PATH).toContain('/usr/bin')
+  })
+})
 
 describe('harness failure cause extraction', () => {
   it('extracts the DSH entry failure message from stderr', () => {


### PR DESCRIPTION
## Problem

Electron apps launched from macOS Finder/Spotlight inherit a minimal environment from launchd that never sources the user's shell profile (`~/.zshenv`, `~/.zprofile`, `~/.zshrc`). This leaves PATH without Homebrew, mise shims, `~/.local/bin`, etc., so CLIs like `bun`, `lark-cli`, `docker`, and `cua-driver` are invisible to the Harness process and every subprocess it spawns (bash tool, MCP servers).

On Windows the same gap exists when tools are added via a PowerShell profile (``) rather than the user-level registry environment.

## Root Cause

`buildHarnessSpawnOptions` in `src/main/runtime/harness-runtime.ts` defaults its `environment` parameter to `process.env` — the Electron app's minimal launchd environment. The Harness subprocess inherits this, and `scrubbedParentEnv()` in DSH core has no way to recover the missing entries.

```typescript
// Before: uses Electron's minimal process.env
buildHarnessSpawnOptions(launchDirectory, this.options.dshHome)
```

## Fix

Resolve the user's interactive login shell environment once at startup and pass it as the base environment:

- **macOS/Linux**: `/bin/zsh -l -i -c env` — sources both `.zprofile` (Homebrew, OrbStack) and `.zshrc` (mise shims, `~/.local/bin`, cargo, go, etc.)
- **Windows**: PowerShell with `` loaded, then enumerate `Env:` — captures both registry vars and profile-sourced PATH additions (conda, nvm, scoop)

```typescript
// After: resolves the user's full shell environment
buildHarnessSpawnOptions(
  launchDirectory,
  this.options.dshHome,
  process.platform,
  resolveShellEnvironment()
)
```

The result is memoised for the process lifetime. On any failure (shell not found, timeout, etc.) it falls back to `process.env` to preserve the current behavior.

The same fix is applied to profile plugin commands (`environment: resolveShellEnvironment()` in `src/main/index.ts`).

## Verification

Tested on macOS (arm64) with the packaged app:

| Tool | Before | After |
|------|:------:|:------:|
| `bun` | ❌ | ✅ `mise/installs/bun/1.3.14/bin/bun` |
| `lark-cli` | ❌ | ✅ `mise/installs/node/26.3.0/bin/lark-cli` |
| `cua-driver` | ❌ | ✅ `~/.local/bin/cua-driver` |
| `docker` | ❌ | ✅ `~/.local/bin/docker` |
| `codex` | ❌ | ✅ `mise/installs/node/26.3.0/bin/codex` |
| `python3` | ❌ (system fallback) | ✅ homebrew version |
| `git` | ❌ (system fallback) | ✅ `/opt/homebrew/bin/git` |
| `HOMEBREW_PREFIX` | ❌ | ✅ `/opt/homebrew` |
| `JAVA_HOME` | ❌ | ✅ mise java |

API keys (`KEY`/`TOKEN`/`SECRET` pattern) remain scrubbed by DSH core's `scrubbedParentEnv()` — this is by design; LLM credentials are managed by DSH's credential system.

## Tests

- All 274 existing tests pass
- 3 new tests for `resolveShellEnvironment`: non-empty result, memoisation, PATH includes `/usr/bin`
- TypeScript typecheck passes
