### PR TITLE
fix: avoid plugin recovery from conversation text

### DIFF
--- a/src/preload/boot-failure.ts
+++ b/src/preload/boot-failure.ts
@@ -1,0 +1,32 @@
+export const BOOT_FAILURE_ROOT_SELECTOR = '[data-dsh-boot]'
+
+const BOOT_FAILURE_TITLE = 'Failed to load plugins'
+
+export interface BootFailureElement {
+  innerText?: string
+  textContent?: string | null
+}
+
+/**
+ * Returns a normalized boot failure diagnostic only from Harness's dedicated
+ * boot screen. Callers must pass the `[data-dsh-boot]` root, rather than a
+ * document-wide container: conversations may legitimately quote this title.
+ */
+export function extractBootFailureText(root: BootFailureElement | null): string | undefined {
+  if (!root) return undefined
+
+  const text = root.innerText || root.textContent
+  if (!text?.includes(BOOT_FAILURE_TITLE)) return undefined
+
+  return text
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .join('\n')
+}
+
+export function findBootFailureText(document: Document): string | undefined {
+  return extractBootFailureText(
+    document.querySelector<HTMLElement>(BOOT_FAILURE_ROOT_SELECTOR)
+  )
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,7 @@ import {
   type UpdateLocale
 } from './update-view'
 import { isPluginLoadError } from './plugin-error-view'
+import { findBootFailureText } from './boot-failure'
 import { mountWindowsTitlebar } from './windows-titlebar'
 
 const ROOT_ID = 'dsh-desktop-update-root'
@@ -30,20 +31,10 @@ const pendingBootFailureMessages: string[] = []
 const BOOT_FAILURE_SETTLE_MS = 400
 
 function currentBootFailureText(): string | undefined {
-  const root = document.body || document.documentElement
-  if (!root) return undefined
-
-  // The package list and loader detail are rendered in separate sibling
-  // containers on Harness's boot-failure page. Reading only the title's
-  // parent drops exactly the evidence Desktop needs to identify the second
-  // conflicting plugin, so capture the full failure page instead.
-  const text = document.body?.innerText || root.textContent
-  if (!text?.includes('Failed to load plugins')) return undefined
-  return text
-    ?.split(/\r?\n/)
-    .map((value) => value.trim())
-    .filter(Boolean)
-    .join('\n')
+  // Harness removes this root once the application starts. Scoping the check
+  // to it prevents a quoted error in a conversation from being mistaken for a
+  // startup failure by the document-wide mutation observer.
+  return findBootFailureText(document)
 }
 
 function addBootFailureMessage(message: string | undefined): void {

--- a/test/plugin-error-view.test.ts
+++ b/test/plugin-error-view.test.ts
@@ -5,6 +5,10 @@ import {
   isPluginLoadError,
   pluginErrorMessage
 } from '../src/preload/plugin-error-view'
+import {
+  BOOT_FAILURE_ROOT_SELECTOR,
+  findBootFailureText
+} from '../src/preload/boot-failure'
 
 const sampleLoaderError =
   'failed to import loader entry 516a3af0 (@linxin666/dsh-client-ui-web-ui-settings): client-modules: bundle script /plugins/@linxin666/dsh-client-ui-web-ui-settings/client.js?rev=54840dfe7860 failed to load'
@@ -59,7 +63,41 @@ describe('preload wiring for plugin error handling', () => {
     expect(preload).toContain('checkBootFailureInDom')
     expect(preload).toContain('queueBootFailure(errorText)')
     expect(preload).toContain('pendingBootFailureMessages.join')
-    expect(preload).toContain("document.body?.innerText")
-    expect(preload).toContain("text?.includes('Failed to load plugins')")
+    expect(preload).toContain('findBootFailureText(document)')
+    expect(preload).not.toContain('document.body?.innerText')
+  })
+})
+
+describe('boot failure page detection', () => {
+  it('only accepts the dedicated boot page and preserves its diagnostics', () => {
+    let queriedSelector: string | undefined
+    const bootFailure = findBootFailureText({
+      querySelector: (selector: string) => {
+        queriedSelector = selector
+        return { innerText: 'Failed to load plugins' }
+      }
+    } as unknown as Document)
+
+    expect(queriedSelector).toBe(BOOT_FAILURE_ROOT_SELECTOR)
+    expect(bootFailure).toBe(
+      'Failed to load plugins'
+    )
+    expect(findBootFailureText({
+      querySelector: () => ({
+        innerText:
+          'Failed to load plugins\n@deepseek-ai/dsh-client-ui-example\nweb boot: 1 entry did not activate'
+      })
+    } as unknown as Document)).toBe(
+      'Failed to load plugins\n@deepseek-ai/dsh-client-ui-example\nweb boot: 1 entry did not activate'
+    )
+  })
+
+  it('does not inspect ordinary document text such as a conversation', () => {
+    const conversationOnlyDocument = {
+      body: { innerText: 'The screenshot says “Failed to load plugins”, but the app recovered.' },
+      querySelector: () => null
+    }
+
+    expect(findBootFailureText(conversationOnlyDocument as unknown as Document)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- Restrict DOM-based plugin boot-failure detection to Harness’s dedicated `[data-dsh-boot]` screen.
- Preserve the complete diagnostic text from a real boot-failure screen.
- Add regression coverage for a conversation that quotes `Failed to load plugins`.

## Context
A chat message or model response containing `Failed to load plugins` previously matched the preload’s document-wide observer and opened the recovery view even though Harness had started successfully.

The earlier environment / pnpm-store repair is already merged in main as #148, so this PR is intentionally the follow-up fix on top of that change.

## Verification
- `npm test`
- `npm run typecheck`