### PR TITLE
fix: center Windows startup content

### DIFF
--- a/build/splash.html
+++ b/build/splash.html
@@ -4,12 +4,27 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title></title>
+    <script>
+      if (navigator.platform.toLowerCase().startsWith('win')) {
+        document.documentElement.dataset.platform = 'windows'
+      }
+    </script>
     <style>
       :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
       * { box-sizing: border-box; }
       html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
-      body { display: grid; place-items: center; color: #17181a; background: #f8f8f6; }
-      main { display: grid; justify-items: center; gap: 12px; padding: 32px; text-align: center; }
+      body { color: #17181a; background: #f8f8f6; }
+      main {
+        position: fixed;
+        inset: 0;
+        display: grid;
+        align-content: center;
+        justify-items: center;
+        gap: 12px;
+        padding: 32px;
+        text-align: center;
+      }
+      html[data-platform="windows"] main { padding-top: 70px; }
       .mark { width: 196px; height: auto; image-rendering: pixelated; }
       .title { margin: 0; font-size: 23px; font-weight: 650; letter-spacing: -0.02em; }
       .status { margin: -4px 0 0; color: #777a80; font-size: 13px; }

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -114,6 +114,8 @@ describe('GitHub release contract', () => {
     expect(splash).toContain('Starting DSH Desktop')
     expect(splash).toContain('src="dsh-loader.gif"')
     expect(splash).not.toContain('class="track"')
+    expect(splash).toContain('position: fixed;')
+    expect(splash).toContain('html[data-platform="windows"] main { padding-top: 70px; }')
     expect(patch).not.toMatch(/id:\s*directory-picker/)
     expect(patch).not.toContain("name: '@deepseek-ai/dsh-host-directory-picker-native'")
     expect(patch).not.toContain("name: '@deepseek-ai/dsh-client-ui-directory-picker-native'")


### PR DESCRIPTION
## Summary

- center the splash content against the full startup window
- compensate for the Windows title-bar area without affecting macOS
- add release-contract assertions for the platform-specific layout

## Verification

- npm run typecheck
- npx vitest run test/release.test.ts (13 passed)