### PR TITLE
chore: ignore local project artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ dist-dev/
 .DS_Store
 *.log
 coverage/
+/doc/
+/deliverables/
 build/icon.iconset/
 build/app-icon.iconset/
 build/icon-1024.png


### PR DESCRIPTION
## Summary

- ignore the local doc workspace
- ignore locally generated deliverables and archives
- keep generated artifacts out of repository status without deleting local files

## Verification

- git diff --check
- confirmed the branch changes only .gitignore