### PR TITLE
fix: restore preset package imports

### DIFF
--- a/patches/@deepseek-ai+dsh-host-apiproxy+0.1.1-rc.2.patch
+++ b/patches/@deepseek-ai+dsh-host-apiproxy+0.1.1-rc.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@deepseek-ai/dsh-host-apiproxy/lib/index.js b/node_modules/@deepseek-ai/dsh-host-apiproxy/lib/index.js
-index 5075798..fb882a8 100644
+index 5075798..e493cb2 100644
 --- a/node_modules/@deepseek-ai/dsh-host-apiproxy/lib/index.js
 +++ b/node_modules/@deepseek-ai/dsh-host-apiproxy/lib/index.js
 @@ -1,9 +1,9 @@
@@ -170,7 +170,7 @@ index 5075798..fb882a8 100644
  				if (capability.kind !== "browse") return err(request, {
  					code: "directory-picker-unavailable",
  					message: `host.createDirectory needs the browse capability; the composed picker serves "${capability.kind}"`,
-@@ -3231,6 +3342,145 @@ function createApiProxy(ctx, defaults) {
+@@ -3231,6 +3342,147 @@ function createApiProxy(ctx, defaults) {
  			}
  		},
  		agentPresets: {
@@ -276,10 +276,12 @@ index 5075798..fb882a8 100644
 +					});
 +				}
 +				if (conflict) return presetArchiveFailure(`A preset named "${targetId}" already exists. Choose a different name or remove the existing preset first.`, 409);
-+				const root = writableRoot();
-+				const target = resolve(root, targetId);
-+				const imported = await mkdtemp(resolve(root, `.${targetId}-import-`));
++				let imported;
 +				try {
++					const root = writableRoot(presets.roots);
++					await mkdir(root, { recursive: true });
++					const target = resolve(root, targetId);
++					imported = await mkdtemp(resolve(root, `.${targetId}-import-`));
 +					signal?.throwIfAborted();
 +					for (const [relPath, bytes] of Object.entries(files)) {
 +						const fullPath = resolve(imported, relPath);
@@ -299,7 +301,7 @@ index 5075798..fb882a8 100644
 +					signal?.throwIfAborted();
 +					await rename(imported, target);
 +				} catch (error) {
-+					await rm(imported, { recursive: true, force: true }).catch(() => {});
++					if (imported !== void 0) await rm(imported, { recursive: true, force: true }).catch(() => {});
 +					if (signal?.aborted) return presetArchiveFailure("Preset import was cancelled.", 499);
 +					return presetArchiveFailure(error instanceof Error ? error.message : "Failed to install preset files.");
 +				}
@@ -316,7 +318,7 @@ index 5075798..fb882a8 100644
  			async list(request) {
  				const presets = ctx.get("agentPresets");
  				if (presets === void 0) return ok(request, {
-@@ -4920,6 +5170,34 @@ function toFetchHandler(api) {
+@@ -4920,6 +5172,34 @@ function toFetchHandler(api) {
  			rpcId: RpcId(randomUUID()),
  			payload: {}
  		}, req.signal));
@@ -351,7 +353,7 @@ index 5075798..fb882a8 100644
  		if (path === "/api/session.export" && (req.method === "GET" || req.method === "HEAD")) {
  			const parsed = sessionLogQuerySchema.safeParse(Object.fromEntries(url.searchParams));
  			if (!parsed.success) return new Response("missing or invalid sessionId query parameter", { status: 400 });
-@@ -5519,7 +5797,6 @@ var ApiProxyService = class extends Service {
+@@ -5519,7 +5799,6 @@ var ApiProxyService = class extends Service {
  		"agentDefaultModel",
  		"agents",
  		"attachments",

--- a/test/preset-transfer-patch.test.ts
+++ b/test/preset-transfer-patch.test.ts
@@ -75,6 +75,20 @@ describe('agent preset package transfer', () => {
     expect(patch).toContain('absolute-paths')
   })
 
+  it('creates and resolves the writable preset root inside the structured import failure boundary', async () => {
+    const patch = await readFile(
+      patchPath('@deepseek-ai/dsh-host-apiproxy'),
+      'utf8'
+    )
+
+    expect(patch).toContain('const root = writableRoot(presets.roots)')
+    expect(patch).not.toContain('const root = writableRoot();')
+    expect(patch).toContain('await mkdir(root, { recursive: true })')
+    expect(patch).toContain('let imported;')
+    expect(patch).toContain('imported = await mkdtemp')
+    expect(patch).toContain('if (imported !== void 0) await rm(imported')
+  })
+
   it('adds import preview, conflict rename, trust warning, and custom-card export controls', async () => {
     const patch = await readFile(
       patchPath('@deepseek-ai/dsh-client-ui-agent-preset'),


### PR DESCRIPTION
## Summary

- pass the resolved preset roster roots to `writableRoot`
- create the user preset root before allocating the atomic import directory, including on a clean profile
- keep root resolution and temporary-directory setup inside the structured import failure boundary
- clean up the temporary directory only after it has been created
- add regression coverage for the writable-root contract and failure boundary

## Root cause

The desktop-only preset archive patch called `writableRoot()` without its required `roots` argument. That throws before the existing `try/catch`, so the host web server collapses the error into an empty HTTP 400 response.

The user preset root is also intentionally absent until the first authored preset. Creating it before `mkdtemp` ensures imports work on clean profiles rather than returning a filesystem error after the argument bug is fixed.

## Verification

- `npm ci` (all patch-package patches apply cleanly)
- `npx vitest run test/preset-transfer-patch.test.ts` (6 passed)
- `npx vitest run --exclude test/lan-mobile-bridge.test.ts` (261 passed)
- `npm run typecheck`
- `npm run build`

Full `npm test` reached 268 passing tests; four existing LAN bridge tests fail on this host because it currently exposes no RFC1918 interface, so no pairing URL is generated. The modified files are limited to the preset transfer patch and its regression test.

## Compatibility

PR #152 renames this patch for Harness rc.2. If it lands first, this change needs to be replayed onto the rc.2 patch during rebase.

Fixes #160
Related: #149
