### PR TITLE
ci: add Windows UKey signing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,12 +424,13 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/v')
         with:
-          name: windows-x64
+          name: windows-x64-unsigned
           path: |
             dist/dsh-desktop-windows-x64-setup.exe
             dist/dsh-desktop-windows-x64-setup.exe.blockmap
             dist/latest.yml
           if-no-files-found: error
+          retention-days: 1
       - uses: actions/upload-artifact@v4
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         with:
@@ -440,6 +441,102 @@ jobs:
             dist-dev/latest.yml
           if-no-files-found: error
 
+  sign-windows:
+    name: Sign Windows package locally with UKey
+    needs: windows-x64
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.windows-x64.result == 'success'
+    runs-on: [self-hosted, macOS, ARM64]
+    env:
+      CI: 'true'
+      JSIGN_VERSION: '7.5'
+      JSIGN_SHA256: '602a51c3545a6dc4fb99bd2ea7152b26d1345916d0c93ddfbd5936cb735af91c'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Install release tooling
+        run: npm ci --ignore-scripts
+      - name: Prepare unsigned Windows package
+        run: |
+          work_dir="$RUNNER_TEMP/dsh-windows-${{ github.run_id }}"
+          mkdir -p "$work_dir/release"
+          echo "WINDOWS_SIGNING_WORK_DIR=$work_dir" >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-x64-unsigned
+          path: ${{ runner.temp }}/dsh-windows-${{ github.run_id }}/release
+      - name: Download and verify Jsign
+        run: |
+          jsign_jar="$WINDOWS_SIGNING_WORK_DIR/jsign-${JSIGN_VERSION}.jar"
+          curl --fail --location --retry 3 \
+            --output "$jsign_jar" \
+            "https://github.com/ebourg/jsign/releases/download/${JSIGN_VERSION}/jsign-${JSIGN_VERSION}.jar"
+          printf '%s  %s\n' "$JSIGN_SHA256" "$jsign_jar" | shasum -a 256 --check
+          java -jar "$jsign_jar" --version
+          echo "JSIGN_JAR=$jsign_jar" >> "$GITHUB_ENV"
+      - name: Sign Windows installer with SafeNet UKey
+        env:
+          WINDOWS_SIGNING_PIN: ${{ secrets.DESKTOP_WINDOWS_SIGNING_PIN }}
+        run: |
+          test -r /usr/local/lib/libeTPkcs11.dylib
+          test -n "$WINDOWS_SIGNING_PIN" || { echo "::error::Missing required secret: DESKTOP_WINDOWS_SIGNING_PIN"; exit 1; }
+          installer_count="$(find "$WINDOWS_SIGNING_WORK_DIR/release" -maxdepth 1 -type f -name '*.exe' | wc -l | tr -d ' ')"
+          test "$installer_count" = '1'
+          installer="$(find "$WINDOWS_SIGNING_WORK_DIR/release" -maxdepth 1 -type f -name '*.exe' -print -quit)"
+          pin_file="$(mktemp "$WINDOWS_SIGNING_WORK_DIR/jsign-pin.XXXXXX")"
+          trap 'rm -f "$pin_file"' EXIT
+          chmod 600 "$pin_file"
+          printf '%s' "$WINDOWS_SIGNING_PIN" > "$pin_file"
+          unset WINDOWS_SIGNING_PIN
+          java -jar "$JSIGN_JAR" \
+            --storetype ETOKEN \
+            --storepass "file:$pin_file" \
+            --alg SHA-256 \
+            --tsaurl http://timestamp.digicert.com \
+            --tsmode RFC3161 \
+            --tsretries 3 \
+            --tsretrywait 10 \
+            --name 'DSH Desktop' \
+            --url https://www.dshdesktop.com \
+            --verbose \
+            "$installer"
+          java -jar "$JSIGN_JAR" extract --format DER "$installer"
+          test -s "$installer.sig"
+          rm -f "$installer.sig"
+      - name: Rebuild Windows update metadata
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          node scripts/finalize-windows-release.mjs \
+            "$WINDOWS_SIGNING_WORK_DIR/release" \
+            "$version"
+          test -f "$WINDOWS_SIGNING_WORK_DIR/release/latest.yml"
+          test -f "$WINDOWS_SIGNING_WORK_DIR"/release/*.exe.blockmap
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-x64
+          path: |
+            ${{ runner.temp }}/dsh-windows-${{ github.run_id }}/release/dsh-desktop-windows-x64-setup.exe
+            ${{ runner.temp }}/dsh-windows-${{ github.run_id }}/release/dsh-desktop-windows-x64-setup.exe.blockmap
+            ${{ runner.temp }}/dsh-windows-${{ github.run_id }}/release/latest.yml
+          if-no-files-found: error
+      - name: Remove local signing files
+        if: always()
+        run: |
+          case "$WINDOWS_SIGNING_WORK_DIR" in
+            "$RUNNER_TEMP"/dsh-windows-*) rm -rf "$WINDOWS_SIGNING_WORK_DIR" ;;
+            '') ;;
+            *) echo "Refusing to remove unexpected signing path: $WINDOWS_SIGNING_WORK_DIR"; exit 1 ;;
+          esac
+
   publish:
     name: Publish GitHub Release
     if: >-
@@ -447,11 +544,11 @@ jobs:
       startsWith(github.ref, 'refs/tags/v') &&
       needs.macos-apple-silicon.result == 'success' &&
       needs.macos-intel.result == 'success' &&
-      needs.windows-x64.result == 'success'
+      needs.sign-windows.result == 'success'
     needs:
       - macos-apple-silicon
       - macos-intel
-      - windows-x64
+      - sign-windows
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -464,8 +561,13 @@ jobs:
       - run: npm ci --ignore-scripts
       - uses: actions/download-artifact@v4
         with:
+          pattern: macos-*
           path: release-assets
           merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-x64
+          path: release-assets
       - name: Merge macOS update metadata
         run: |
           node scripts/merge-mac-update-metadata.mjs \
@@ -570,4 +672,3 @@ jobs:
             --tag "$RELEASE_TAG" \
             --notes .github/release-artifacts/feishu-release-notes.md \
             --webhook "$FEISHU_RELEASE_WEBHOOK"
-

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,17 @@
+# Desktop release runbook
+
+## Local Windows UKey signing runner
+
+Windows packaging and signing run as separate jobs. The GitHub-hosted Windows runner builds an unsigned NSIS installer and uploads a short-lived workflow artifact. A local macOS ARM64 runner downloads it, signs the installer with Jsign and the SafeNet UKey, regenerates the blockmap and `latest.yml`, and uploads the signed release set. The GitHub Release job cannot start unless signing succeeds.
+
+Prepare the local runner once:
+
+1. Register it with the `self-hosted`, `macOS`, and `ARM64` labels.
+2. Install SafeNet Authentication Client and confirm `/usr/local/lib/libeTPkcs11.dylib` is readable.
+3. Connect the UKey before pushing a release tag.
+4. In the GitHub repository, open **Settings → Secrets and variables → Actions** and create a repository secret named `DESKTOP_WINDOWS_SIGNING_PIN` containing the UKey PIN. For stronger release controls, use an environment secret and add the matching `environment` to the `sign-windows` job.
+5. Restrict release tag creation and workflow changes to trusted maintainers. A self-hosted runner can access any secret injected into its job.
+
+The workflow pins Jsign 7.5 by SHA-256 and uses the SafeNet `ETOKEN` store, SHA-256 signing, and a DigiCert RFC 3161 timestamp. GitHub injects the PIN only into the signing step. The step copies it to a mode-`600` temporary file, removes it from the shell environment, and deletes the file when the step exits. The workflow never prints the PIN or passes it as a command-line argument.
+
+After a tag release succeeds, verify that the Windows installer shows the expected publisher and a valid RFC 3161 timestamp in its Digital Signatures properties. Never reuse a published tag; fix the issue and release a new version.

--- a/scripts/finalize-windows-release.mjs
+++ b/scripts/finalize-windows-release.mjs
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto'
+import { readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { basename, join, resolve } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const { buildBlockMap } = require('app-builder-lib/out/targets/blockmap/blockmap')
+
+async function findInstaller(releaseDir) {
+  const entries = await readdir(releaseDir, { withFileTypes: true })
+  const installers = entries
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.exe'))
+    .map((entry) => join(releaseDir, entry.name))
+  if (installers.length !== 1) {
+    throw new Error(`Expected exactly one Windows installer, found ${installers.length}.`)
+  }
+  return installers[0]
+}
+
+async function sha512(file) {
+  return createHash('sha512').update(await readFile(file)).digest('base64')
+}
+
+async function finalizeRelease(releaseDir, version) {
+  const installer = await findInstaller(releaseDir)
+  const blockmap = `${installer}.blockmap`
+  await rm(blockmap, { force: true })
+  const updateInfo = await buildBlockMap(installer, 'gzip', blockmap)
+  const fileStat = await stat(installer)
+  const digest = await sha512(installer)
+  if (updateInfo.size !== fileStat.size || updateInfo.sha512 !== digest) {
+    throw new Error('Generated update metadata does not match the signed installer.')
+  }
+
+  const filename = basename(installer)
+  const metadata = [
+    `version: ${version}`,
+    'files:',
+    `  - url: ${JSON.stringify(filename)}`,
+    `    sha512: ${digest}`,
+    `    size: ${fileStat.size}`,
+    `path: ${JSON.stringify(filename)}`,
+    `sha512: ${digest}`,
+    `releaseDate: ${JSON.stringify(new Date().toISOString())}`,
+    ''
+  ].join('\n')
+  await writeFile(join(releaseDir, 'latest.yml'), metadata, 'utf8')
+  return { installer, blockmap }
+}
+
+const [releaseDirArg, version] = process.argv.slice(2)
+if (!releaseDirArg || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version ?? '')) {
+  throw new Error('Usage: finalize-windows-release.mjs <release-dir> <semver>')
+}
+
+const result = await finalizeRelease(resolve(releaseDirArg), version)
+console.log(`Finalized signed installer metadata for ${basename(result.installer)}.`)

--- a/test/finalize-windows-release.test.ts
+++ b/test/finalize-windows-release.test.ts
@@ -1,0 +1,37 @@
+import { createHash } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('signed Windows release finalizer', () => {
+  it('rebuilds the blockmap and updater metadata after signing', async () => {
+    const releaseDir = await mkdtemp(path.join(tmpdir(), 'dsh-windows-release-'))
+    try {
+      const installerName = 'dsh-desktop-windows-x64-setup.exe'
+      const installer = path.join(releaseDir, installerName)
+      const content = Buffer.from('signed Windows installer fixture')
+      await writeFile(installer, content)
+      await writeFile(`${installer}.blockmap`, 'stale blockmap')
+      await writeFile(path.join(releaseDir, 'latest.yml'), 'stale metadata')
+
+      const result = spawnSync(
+        process.execPath,
+        [path.join(process.cwd(), 'scripts', 'finalize-windows-release.mjs'), releaseDir, '1.2.3'],
+        { encoding: 'utf8' }
+      )
+      expect(result.status, result.stderr).toBe(0)
+
+      const digest = createHash('sha512').update(content).digest('base64')
+      const metadata = await readFile(path.join(releaseDir, 'latest.yml'), 'utf8')
+      expect(metadata).toContain('version: 1.2.3')
+      expect(metadata).toContain(`url: "${installerName}"`)
+      expect(metadata).toContain(`sha512: ${digest}`)
+      expect(metadata).toContain(`size: ${content.length}`)
+      expect((await stat(`${installer}.blockmap`)).size).toBeGreaterThan(0)
+    } finally {
+      await rm(releaseDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -288,6 +288,31 @@ describe('GitHub release contract', () => {
     )
   })
 
+  it('signs Windows installers on the local UKey runner before publishing', async () => {
+    const workflow = await readFile(
+      path.join(projectRoot, '.github', 'workflows', 'release.yml'),
+      'utf8'
+    )
+
+    expect(workflow).toContain('name: windows-x64-unsigned')
+    expect(workflow).toContain('Sign Windows package locally with UKey')
+    expect(workflow).toContain('runs-on: [self-hosted, macOS, ARM64]')
+    expect(workflow).toContain('--storetype ETOKEN')
+    expect(workflow).toContain('--storepass "file:$pin_file"')
+    expect(workflow).toContain('--tsmode RFC3161')
+    expect(workflow).toContain('secrets.DESKTOP_WINDOWS_SIGNING_PIN')
+    expect(workflow).toContain(`printf '%s' "$WINDOWS_SIGNING_PIN" > "$pin_file"`)
+    expect(workflow).toContain('unset WINDOWS_SIGNING_PIN')
+    expect(workflow).not.toContain('security find-generic-password')
+    expect(workflow).not.toContain('WINDOWS_SIGNING_KEYCHAIN_SERVICE')
+    expect(workflow).toContain('finalize-windows-release.mjs')
+    expect(workflow).toContain('version="${GITHUB_REF_NAME#v}"')
+    expect(workflow).toContain('pattern: macos-*')
+    expect(workflow).toMatch(
+      /publish:[\s\S]*?needs\.sign-windows\.result == 'success'[\s\S]*?- sign-windows/
+    )
+  })
+
   it('routes the published download through the official website', async () => {
     const readmes = await Promise.all(
       ['README.md', 'README.zh.md'].map((file) =>


### PR DESCRIPTION
## Summary

- split Windows packaging and UKey signing across hosted Windows and self-hosted macOS ARM64 runners
- sign the NSIS installer with Jsign/SafeNet ETOKEN using `DESKTOP_WINDOWS_SIGNING_PIN`
- rebuild the blockmap and `latest.yml` after signing and publish only signed Windows artifacts
- document runner and GitHub Secret setup

## Validation

- `npx vitest run test/finalize-windows-release.test.ts test/release.test.ts` (15 tests passed)
- `npm run typecheck`
- release workflow YAML parse
- `git diff --check`

## Release prerequisite

Add the Actions secret `DESKTOP_WINDOWS_SIGNING_PIN` and keep the SafeNet UKey connected to the `[self-hosted, macOS, ARM64]` runner.