### PR TITLE
fix(macos): prevent automatic window focus stealing

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,6 +43,10 @@ import {
   shouldLoadHarnessUrl
 } from './window-navigation'
 import {
+  raiseWindowWithoutStealingFocus,
+  type WindowFocusIntent
+} from './window-raise'
+import {
   checkForUpdates,
   registerUpdateHandlers,
   startUpdateManager,
@@ -453,7 +457,10 @@ function createWindow(): BrowserWindow {
   return window
 }
 
-async function openHarness(url: string): Promise<void> {
+async function openHarness(
+  url: string,
+  focusIntent: WindowFocusIntent = 'automatic'
+): Promise<void> {
   const window = mainWindow && !mainWindow.isDestroyed() ? mainWindow : createWindow()
   const rendererUrl = desktopHarnessUrl(url, process.platform)
   if (shouldLoadHarnessUrl(window.webContents.getURL(), url)) {
@@ -473,9 +480,12 @@ async function openHarness(url: string): Promise<void> {
   }
   if (runtime.snapshot().url !== url || window.isDestroyed()) return
   await syncNativeTheme(window)
-  if (window.isMinimized()) window.restore()
-  window.show()
-  window.focus()
+  raiseWindowWithoutStealingFocus(
+    window,
+    process.platform,
+    () => app.isActive(),
+    focusIntent
+  )
 }
 
 async function showSplash(): Promise<void> {
@@ -486,8 +496,7 @@ async function showSplash(): Promise<void> {
     query: { theme: nativeTheme.shouldUseDarkColors ? 'dark' : 'light' }
   })
   if (window.isDestroyed() || navigationVersion !== mainWindowNavigationVersion) return
-  window.show()
-  window.focus()
+  raiseWindowWithoutStealingFocus(window, process.platform, () => app.isActive())
 }
 
 /**
@@ -784,9 +793,7 @@ async function waitForPluginRecoveryAction(options: {
   }
 
   if (window.isDestroyed() || navigationVersion !== mainWindowNavigationVersion) return 'quit'
-  if (window.isMinimized()) window.restore()
-  window.show()
-  window.focus()
+  raiseWindowWithoutStealingFocus(window, process.platform, () => app.isActive())
   return actionPromise
 }
 
@@ -1015,9 +1022,7 @@ async function waitForSafeModeAction(options: {
   if (window.isDestroyed()) {
     return { type: 'quit' }
   }
-  if (window.isMinimized()) window.restore()
-  window.show()
-  window.focus()
+  raiseWindowWithoutStealingFocus(window, process.platform, () => app.isActive())
   return actionPromise
 }
 
@@ -1451,7 +1456,7 @@ if (!singleInstance) {
     }
     const snapshot = runtime?.snapshot()
     if (snapshot?.phase === 'ready' && snapshot.url) {
-      void openHarness(snapshot.url).catch(showUnexpectedError)
+      void openHarness(snapshot.url, 'user').catch(showUnexpectedError)
     }
   })
   app.whenReady().then(bootstrap).catch((error: unknown) => {
@@ -1466,7 +1471,7 @@ if (!singleInstance) {
     }
     const snapshot = runtime?.snapshot()
     if (snapshot?.phase === 'ready' && snapshot.url) {
-      void openHarness(snapshot.url).catch(showUnexpectedError)
+      void openHarness(snapshot.url, 'user').catch(showUnexpectedError)
     } else if (snapshot?.phase === 'idle') {
       void launchHarness().catch(showUnexpectedError)
     }

--- a/src/main/window-raise.ts
+++ b/src/main/window-raise.ts
@@ -1,0 +1,35 @@
+interface RaiseableWindow {
+  isDestroyed(): boolean
+  isMinimized(): boolean
+  restore(): void
+  show(): void
+  showInactive(): void
+  focus(): void
+}
+
+export type WindowFocusIntent = 'automatic' | 'user'
+
+/**
+ * Surface a window without letting an automatic macOS transition activate the
+ * application over whichever app the user is currently using.
+ *
+ * BrowserWindow.show() itself focuses the window, so omitting a later focus()
+ * call is not sufficient. showInactive() is the macOS path that preserves the
+ * current foreground application. Explicit user actions retain the ordinary
+ * restore/show/focus behavior, as do all non-macOS platforms.
+ */
+export function raiseWindowWithoutStealingFocus(
+  window: RaiseableWindow,
+  platform: NodeJS.Platform,
+  isAppActive: () => boolean,
+  intent: WindowFocusIntent = 'automatic'
+): void {
+  if (window.isDestroyed()) return
+  if (platform === 'darwin' && intent === 'automatic' && !isAppActive()) {
+    window.showInactive()
+    return
+  }
+  if (window.isMinimized()) window.restore()
+  window.show()
+  window.focus()
+}

--- a/test/window-raise.test.ts
+++ b/test/window-raise.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import { raiseWindowWithoutStealingFocus } from '../src/main/window-raise'
+
+interface WindowDouble {
+  isDestroyed: ReturnType<typeof vi.fn<() => boolean>>
+  isMinimized: ReturnType<typeof vi.fn<() => boolean>>
+  restore: ReturnType<typeof vi.fn<() => void>>
+  show: ReturnType<typeof vi.fn<() => void>>
+  showInactive: ReturnType<typeof vi.fn<() => void>>
+  focus: ReturnType<typeof vi.fn<() => void>>
+}
+
+function makeWindow(overrides: Partial<WindowDouble> = {}): WindowDouble {
+  return {
+    isDestroyed: overrides.isDestroyed ?? vi.fn(() => false),
+    isMinimized: overrides.isMinimized ?? vi.fn(() => false),
+    restore: overrides.restore ?? vi.fn(),
+    show: overrides.show ?? vi.fn(),
+    showInactive: overrides.showInactive ?? vi.fn(),
+    focus: overrides.focus ?? vi.fn()
+  }
+}
+
+describe('raiseWindowWithoutStealingFocus', () => {
+  it('uses showInactive for an automatic macOS transition while another app is active', () => {
+    const window = makeWindow({ isMinimized: vi.fn(() => true) })
+    const isAppActive = vi.fn(() => false)
+
+    raiseWindowWithoutStealingFocus(window, 'darwin', isAppActive)
+
+    expect(isAppActive).toHaveBeenCalledTimes(1)
+    expect(window.showInactive).toHaveBeenCalledTimes(1)
+    expect(window.restore).not.toHaveBeenCalled()
+    expect(window.show).not.toHaveBeenCalled()
+    expect(window.focus).not.toHaveBeenCalled()
+  })
+
+  it('restores and focuses an automatic macOS transition when the app is already active', () => {
+    const window = makeWindow({ isMinimized: vi.fn(() => true) })
+
+    raiseWindowWithoutStealingFocus(window, 'darwin', () => true)
+
+    expect(window.restore).toHaveBeenCalledTimes(1)
+    expect(window.show).toHaveBeenCalledTimes(1)
+    expect(window.focus).toHaveBeenCalledTimes(1)
+    expect(window.showInactive).not.toHaveBeenCalled()
+  })
+
+  it('focuses an explicit user action on macOS even if the app is not active yet', () => {
+    const window = makeWindow()
+    const isAppActive = vi.fn(() => false)
+
+    raiseWindowWithoutStealingFocus(window, 'darwin', isAppActive, 'user')
+
+    expect(isAppActive).not.toHaveBeenCalled()
+    expect(window.show).toHaveBeenCalledTimes(1)
+    expect(window.focus).toHaveBeenCalledTimes(1)
+    expect(window.showInactive).not.toHaveBeenCalled()
+  })
+
+  it('preserves focus behavior and avoids macOS-only APIs on Windows', () => {
+    const window = makeWindow({ isMinimized: vi.fn(() => true) })
+    const isAppActive = vi.fn(() => {
+      throw new Error('macOS-only API must not be called')
+    })
+
+    raiseWindowWithoutStealingFocus(window, 'win32', isAppActive)
+
+    expect(isAppActive).not.toHaveBeenCalled()
+    expect(window.restore).toHaveBeenCalledTimes(1)
+    expect(window.show).toHaveBeenCalledTimes(1)
+    expect(window.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing after the window is destroyed', () => {
+    const window = makeWindow({ isDestroyed: vi.fn(() => true) })
+    const isAppActive = vi.fn(() => true)
+
+    raiseWindowWithoutStealingFocus(window, 'darwin', isAppActive)
+
+    expect(isAppActive).not.toHaveBeenCalled()
+    expect(window.showInactive).not.toHaveBeenCalled()
+    expect(window.show).not.toHaveBeenCalled()
+    expect(window.focus).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Prevents automatic DSH Desktop window transitions from taking focus from another macOS application.

When Harness becomes ready, the splash changes, or a recovery page is presented while DSH Desktop is in the background, Desktop now uses Electron's `showInactive()` API. User-driven activation continues to restore and focus the window normally, and Windows/Linux behavior is unchanged.

Refs #157

## Root cause

`BrowserWindow.show()` itself shows **and focuses** a window. Merely removing or conditionally calling a later `window.focus()` does not prevent focus stealing.

Desktop called `show()` during automatic Harness-ready and recovery transitions, so those transitions could activate DSH Desktop while the user was working in another macOS application.

## Changes

- Add a small window-raise helper that uses `showInactive()` only when:
  - the platform is macOS;
  - the transition is automatic; and
  - DSH Desktop is not already active.
- Preserve restore/show/focus behavior for Windows and Linux without calling the macOS-only `app.isActive()` API.
- Mark Dock/app activation and second-instance launches as explicit user actions so they still focus the main window.
- Apply the automatic protection to Harness-ready, splash, plugin-recovery, and Safe Mode recovery transitions.
- Keep the user-invoked mobile pairing window unchanged.

## Scope

This PR deliberately does not change `process.execPath`, Harness runtime identity, or plugin environment variables. Persistent services such as Doctor LaunchAgents must select and persist their Node runtime in the plugin/service implementation; Desktop does not provide plugin-specific runtime rewriting here.

## Validation

- `npm test` — 44 files, 303 tests passed.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- `git diff --check` — passed.
