### PR TITLE
fix(macos): remove the legacy doctor LaunchAgent on launch

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,7 @@ import {
 } from 'electron'
 import { extractFailureCause, HarnessRuntime } from './runtime/harness-runtime'
 import { launchDisclaimedUtilityProcess } from './runtime/disclaimed-utility-process'
+import { cleanupDoctorLaunchAgent } from './runtime/doctor-launchagent-cleanup'
 import {
   installProfileDependenciesWithDsh,
   removeProfilePluginWithDsh
@@ -1031,6 +1032,23 @@ async function showMobilePairing(): Promise<void> {
 async function bootstrap(): Promise<void> {
   if (process.platform === 'darwin') app.dock?.setIcon(desktopIconPath())
   launchDirectory = await ensureLaunchRoot(app.getPath('userData'))
+  // The DSH Doctor plugin (@linxin666/dsh-doctor <= 0.3.3) writes a
+  // macOS LaunchAgent that points the service at the Electron Helper
+  // without `ELECTRON_RUN_AS_NODE=1`, which makes launchd start the
+  // Helper in Electron mode and crash with `EXC_BREAKPOINT` roughly
+  // every ten seconds. The repeated launches are the launchd half of
+  // the focus stealing reported in #157. PR #174 only covers the
+  // desktop's own `BrowserWindow.focus()` calls, so an affected
+  // machine keeps yanking focus until the bad plist is gone. Removing
+  // it before any window is shown is the safe moment to do it.
+  const doctorCleanup = cleanupDoctorLaunchAgent({
+    log: (message) => console.log(message)
+  })
+  if (doctorCleanup.removed) {
+    console.log(
+      `[desktop] cleared the legacy com.dsh.doctor LaunchAgent (unregistered=${doctorCleanup.unregistered})`
+    )
+  }
   registerUpdateHandlers()
   createWindow()
   runtime = new HarnessRuntime({

--- a/src/main/runtime/doctor-launchagent-cleanup.ts
+++ b/src/main/runtime/doctor-launchagent-cleanup.ts
@@ -1,0 +1,107 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, unlinkSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const DOCTOR_LAUNCH_AGENT_LABEL = 'com.dsh.doctor'
+const DOCTOR_LAUNCH_AGENT_PLIST = `${DOCTOR_LAUNCH_AGENT_LABEL}.plist`
+const ELECTRON_NODE_MODE_KEY = 'ELECTRON_RUN_AS_NODE'
+const HELPER_EXECUTABLE_HINT = 'Helper'
+
+export interface DoctorLaunchAgentCleanupOptions {
+  homeDirectory?: string
+  uid?: number | null
+  launchctlPath?: string
+  runLaunchctl?: (
+    command: string,
+    args: readonly string[]
+  ) => { status: number | null; error?: Error }
+  log?: (message: string) => void
+}
+
+export interface DoctorLaunchAgentCleanupResult {
+  plistFound: boolean
+  affected: boolean
+  removed: boolean
+  unregistered: boolean
+}
+
+export function doctorLaunchAgentPlistPath(homeDirectory: string = homedir()): string {
+  return join(homeDirectory, 'Library', 'LaunchAgents', DOCTOR_LAUNCH_AGENT_PLIST)
+}
+
+function defaultRunLaunchctl(
+  command: string,
+  args: readonly string[]
+): { status: number | null; error?: Error } {
+  const result = spawnSync(command, [...args], { stdio: 'ignore' })
+  return { status: result.status, error: result.error ?? undefined }
+}
+
+export function cleanupDoctorLaunchAgent(
+  options: DoctorLaunchAgentCleanupOptions = {}
+): DoctorLaunchAgentCleanupResult {
+  if (process.platform !== 'darwin') {
+    return { plistFound: false, affected: false, removed: false, unregistered: false }
+  }
+
+  const plistPath = doctorLaunchAgentPlistPath(options.homeDirectory)
+  if (!existsSync(plistPath)) {
+    return { plistFound: false, affected: false, removed: false, unregistered: false }
+  }
+
+  let content: string
+  try {
+    content = readFileSync(plistPath, 'utf8')
+  } catch (error) {
+    options.log?.(
+      `[desktop] failed to read doctor plist at ${plistPath}: ${error instanceof Error ? error.message : String(error)}`
+    )
+    return { plistFound: true, affected: false, removed: false, unregistered: false }
+  }
+
+  if (!content.includes(HELPER_EXECUTABLE_HINT)) {
+    return { plistFound: true, affected: false, removed: false, unregistered: false }
+  }
+  if (content.includes(ELECTRON_NODE_MODE_KEY)) {
+    return { plistFound: true, affected: false, removed: false, unregistered: false }
+  }
+
+  const uid = options.uid ?? process.getuid?.() ?? null
+  const launchctl = options.launchctlPath ?? 'launchctl'
+  const runLaunchctl = options.runLaunchctl ?? defaultRunLaunchctl
+  let unregistered = false
+
+  if (typeof uid === 'number') {
+    const target = `gui/${uid}/${DOCTOR_LAUNCH_AGENT_LABEL}`
+    try {
+      const result = runLaunchctl(launchctl, ['bootout', target])
+      if (result.error) throw result.error
+      unregistered = result.status === 0
+    } catch (error) {
+      options.log?.(
+        `[desktop] failed to run launchctl bootout: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+
+  let removed = false
+  try {
+    unlinkSync(plistPath)
+    removed = true
+  } catch (error) {
+    options.log?.(
+      `[desktop] failed to remove doctor plist at ${plistPath}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+
+  if (removed) {
+    options.log?.(
+      unregistered
+        ? `[desktop] removed the legacy doctor LaunchAgent at ${plistPath} (label ${DOCTOR_LAUNCH_AGENT_LABEL})`
+        : `[desktop] removed the legacy doctor plist at ${plistPath}; launchctl bootout did not report success`
+    )
+  }
+
+  return { plistFound: true, affected: true, removed, unregistered }
+}

--- a/test/doctor-launchagent-cleanup.test.ts
+++ b/test/doctor-launchagent-cleanup.test.ts
@@ -1,0 +1,298 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  cleanupDoctorLaunchAgent,
+  doctorLaunchAgentPlistPath
+} from '../src/main/runtime/doctor-launchagent-cleanup'
+
+const HELPER_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.dsh.doctor</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/Applications/DSH Desktop.app/Contents/Frameworks/DSH Desktop Helper.app/Contents/MacOS/DSH Desktop Helper</string>
+      <string>/Users/u/.npm-global/lib/node_modules/@linxin666/dsh-doctor/lib/cli.mjs</string>
+      <string>supervisor</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>DSH_DOCTOR_HOME</key>
+      <string>/Users/u/.dsh-doctor</string>
+    </dict>
+    <key>KeepAlive</key>
+    <true/>
+  </dict>
+</plist>
+`
+
+const FIXED_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.dsh.doctor</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/Applications/DSH Desktop.app/Contents/Frameworks/DSH Desktop Helper.app/Contents/MacOS/DSH Desktop Helper</string>
+      <string>supervisor</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>DSH_DOCTOR_HOME</key>
+      <string>/Users/u/.dsh-doctor</string>
+      <key>ELECTRON_RUN_AS_NODE</key>
+      <string>1</string>
+    </dict>
+    <key>KeepAlive</key>
+    <true/>
+  </dict>
+</plist>
+`
+
+const REAL_NODE_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.dsh.doctor</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/bin/node</string>
+      <string>supervisor</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>DSH_DOCTOR_HOME</key>
+      <string>/Users/u/.dsh-doctor</string>
+    </dict>
+  </dict>
+</plist>
+`
+
+interface FakeRunnerOptions {
+  status?: number | null
+  error?: Error
+}
+
+interface FakeRunner {
+  calls: { command: string; args: readonly string[] }[]
+  run: (command: string, args: readonly string[]) => { status: number | null; error?: Error }
+}
+
+function fakeRunner(options: FakeRunnerOptions = {}): FakeRunner {
+  const calls: { command: string; args: readonly string[] }[] = []
+  const status = options.status === undefined ? 0 : options.status
+  return {
+    calls,
+    run(command, args) {
+      calls.push({ command, args: [...args] })
+      if (options.error) throw options.error
+      return { status }
+    }
+  }
+}
+
+describe('doctor-launchagent-cleanup', () => {
+  const originalPlatform = process.platform
+  const originalGetuid = process.getuid
+  let home: string
+  let plistPath: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'doctor-launchagent-cleanup-'))
+    plistPath = doctorLaunchAgentPlistPath(home)
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    if (originalGetuid) {
+      process.getuid = originalGetuid
+    } else {
+      delete (process as { getuid?: () => number }).getuid
+    }
+  })
+
+  function setPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', { value, configurable: true })
+  }
+
+  function setUid(uid: number | null): void {
+    if (uid === null) {
+      delete (process as { getuid?: () => number }).getuid
+    } else {
+      process.getuid = () => uid
+    }
+  }
+
+  function writePlist(content: string): void {
+    mkdirSync(join(home, 'Library', 'LaunchAgents'), { recursive: true })
+    writeFileSync(plistPath, content, 'utf8')
+  }
+
+  it('returns the plist path under Library/LaunchAgents for the home directory', () => {
+    expect(doctorLaunchAgentPlistPath('/Users/u')).toBe(
+      '/Users/u/Library/LaunchAgents/com.dsh.doctor.plist'
+    )
+  })
+
+  it('skips cleanup on non-darwin platforms', () => {
+    setPlatform('linux')
+    const result = cleanupDoctorLaunchAgent({ homeDirectory: home, uid: 501 })
+    expect(result).toEqual({ plistFound: false, affected: false, removed: false, unregistered: false })
+  })
+
+  it('skips cleanup when the plist is not present', () => {
+    setPlatform('darwin')
+    const result = cleanupDoctorLaunchAgent({ homeDirectory: home, uid: 501 })
+    expect(result).toEqual({ plistFound: false, affected: false, removed: false, unregistered: false })
+  })
+
+  it('removes the legacy Helper plist and unregisters the service', () => {
+    setPlatform('darwin')
+    setUid(501)
+    writePlist(HELPER_PLIST)
+    const runner = fakeRunner({ status: 0 })
+    const log: string[] = []
+
+    const result = cleanupDoctorLaunchAgent({
+      homeDirectory: home,
+      uid: 501,
+      runLaunchctl: runner.run,
+      log: (message) => log.push(message)
+    })
+
+    expect(result).toEqual({ plistFound: true, affected: true, removed: true, unregistered: true })
+    expect(existsSync(plistPath)).toBe(false)
+    expect(runner.calls).toEqual([
+      { command: 'launchctl', args: ['bootout', 'gui/501/com.dsh.doctor'] }
+    ])
+    expect(log).toHaveLength(1)
+    expect(log[0]).toContain('removed the legacy doctor LaunchAgent')
+  })
+
+  it('leaves a fixed plist that already declares ELECTRON_RUN_AS_NODE alone', () => {
+    setPlatform('darwin')
+    setUid(501)
+    writePlist(FIXED_PLIST)
+    const runner = fakeRunner()
+
+    const result = cleanupDoctorLaunchAgent({
+      homeDirectory: home,
+      uid: 501,
+      runLaunchctl: runner.run
+    })
+
+    expect(result).toEqual({ plistFound: true, affected: false, removed: false, unregistered: false })
+    expect(existsSync(plistPath)).toBe(true)
+    expect(runner.calls).toEqual([])
+  })
+
+  it('does not touch a real-Node doctor plist that lacks the Electron flag', () => {
+    // The Doctor CLI on a real Node host never names a Helper executable
+    // and never inherited `ELECTRON_RUN_AS_NODE`, so the fixed service
+    // does not set the flag. The crash-loop only happens when launchd
+    // is asked to start an Electron Helper, so a real-Node plist is
+    // left alone — Doctor's own ensure path will keep it consistent.
+    setPlatform('darwin')
+    setUid(501)
+    writePlist(REAL_NODE_PLIST)
+    const runner = fakeRunner()
+
+    const result = cleanupDoctorLaunchAgent({
+      homeDirectory: home,
+      uid: 501,
+      runLaunchctl: runner.run
+    })
+
+    expect(result).toEqual({ plistFound: true, affected: false, removed: false, unregistered: false })
+    expect(existsSync(plistPath)).toBe(true)
+    expect(runner.calls).toEqual([])
+  })
+
+  it('still removes the plist when launchctl bootout fails with a thrown error', () => {
+    setPlatform('darwin')
+    setUid(501)
+    writePlist(HELPER_PLIST)
+    const runner = fakeRunner({ error: new Error('launchctl missing') })
+
+    const result = cleanupDoctorLaunchAgent({
+      homeDirectory: home,
+      uid: 501,
+      runLaunchctl: runner.run
+    })
+
+    expect(result.removed).toBe(true)
+    expect(result.unregistered).toBe(false)
+    expect(existsSync(plistPath)).toBe(false)
+  })
+
+  it('still removes the plist when launchctl exits non-zero', () => {
+    setPlatform('darwin')
+    setUid(501)
+    writePlist(HELPER_PLIST)
+    const runner = fakeRunner({ status: 3 })
+
+    const result = cleanupDoctorLaunchAgent({
+      homeDirectory: home,
+      uid: 501,
+      runLaunchctl: runner.run
+    })
+
+    expect(result.removed).toBe(true)
+    expect(result.unregistered).toBe(false)
+  })
+
+  it('skips launchctl but still removes the plist when uid is not available', () => {
+    setPlatform('darwin')
+    setUid(null)
+    writePlist(HELPER_PLIST)
+    const runner = fakeRunner()
+
+    const result = cleanupDoctorLaunchAgent({
+      homeDirectory: home,
+      runLaunchctl: runner.run
+    })
+
+    expect(result.removed).toBe(true)
+    expect(result.unregistered).toBe(false)
+    expect(runner.calls).toEqual([])
+  })
+
+  it('does not throw when the plist cannot be read', () => {
+    setPlatform('darwin')
+    setUid(501)
+    mkdirSync(join(home, 'Library', 'LaunchAgents'), { recursive: true })
+    // Make the plist a directory so readFileSync throws EISDIR.
+    mkdirSync(plistPath)
+    const runner = fakeRunner()
+    const log: string[] = []
+
+    const result = cleanupDoctorLaunchAgent({
+      homeDirectory: home,
+      uid: 501,
+      runLaunchctl: runner.run,
+      log: (message) => log.push(message)
+    })
+
+    expect(result).toEqual({ plistFound: true, affected: false, removed: false, unregistered: false })
+    expect(runner.calls).toEqual([])
+    expect(log[0]).toContain('failed to read doctor plist')
+  })
+
+  it('keeps the plist on disk when the read succeeds and the file is well-formed but already fixed', () => {
+    setPlatform('darwin')
+    setUid(501)
+    writePlist(FIXED_PLIST)
+    const before = readFileSync(plistPath, 'utf8')
+
+    cleanupDoctorLaunchAgent({ homeDirectory: home, uid: 501 })
+
+    expect(readFileSync(plistPath, 'utf8')).toBe(before)
+  })
+})


### PR DESCRIPTION
## Summary

PR #174 stopped DSH Desktop from pulling the frontmost app to itself through `BrowserWindow.focus()`, but #157 also has a launchd half. `@linxin666/dsh-doctor <= 0.3.3` writes `~/Library/LaunchAgents/com.dsh.doctor.plist` that points the service at the DSH Desktop Helper without `ELECTRON_RUN_AS_NODE=1`, so launchd starts the Helper in Electron mode, hits `EXC_BREAKPOINT`/`SIGTRAP`, and restarts roughly every ten seconds. Each restart yanks focus from whatever app the user is in, and uninstalling the npm package does not unregister the agent — the loop survives a normal "uninstall".

The Doctor fix in `zhu1090093659/dsh-web#1147` only protects fresh installations, so an affected machine needs the bad plist torn down on the host. This change runs a narrow cleanup at the very top of `bootstrap()` on macOS:

- Reads `~/Library/LaunchAgents/com.dsh.doctor.plist`.
- Removes it only when it references a Helper executable **and** omits `ELECTRON_RUN_AS_NODE`.
- Asks launchctl to `bootout` the matching `gui/<uid>/com.dsh.doctor` target first, so a live crash loop also stops.
- A fixed plist that already declares the flag, a real-Node installation, and a missing plist are all left alone, so the cleanup is safe to run on every launch.

## Linked issues

- Fixes the launchd half of #157. PR #174 covers the desktop's own focus calls; together they close the bug.

## Test plan

- [x] `node_modules/.bin/tsc --noEmit -p tsconfig.node.json` is clean.
- [x] `node_modules/.bin/vitest run test/doctor-launchagent-cleanup.test.ts` — 11 new tests cover: path resolution, non-darwin skip, missing plist, Helper plist removal + unregister, fixed-plist no-op, real-Node plist no-op, launchctl error path, launchctl non-zero exit, missing uid, unreadable plist, and the read-then-keep-plist round trip.
- [x] Pre-existing test failures in `model-picker-patch`, `model-selection-search-patch`, `model-settings-catalog-ux-patch`, `onboarding-patch`, and `preset-transfer-patch` are unrelated to this change (verified by re-running the suite with these changes stashed — same 12 failures). They depend on bundled DSH/Node/pnpm runtimes that are not present in this environment, exactly the way PR #174 called out.
- [ ] Manual check on an affected macOS machine: `launchctl print gui/<uid>/com.dsh.doctor` should no longer show a Helper crash loop after DSH Desktop launches once with this build.