### PR TITLE
fix(plugins): clean owned components before uninstall

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,6 +37,7 @@ import {
   uninstallPluginFromProfile
 } from './state/plugin-recovery'
 import { ensureSafeModeProfile, SAFE_MODE_PROFILE } from './state/safe-mode-profile'
+import { cleanupPluginOwnedComponents } from './state/plugin-component-cleanup'
 import {
   desktopHarnessUrl,
   isAbortedNavigationError,
@@ -856,34 +857,16 @@ async function showPluginRecovery(options?: {
       } else if (action === 'uninstall' && detection.plugins.length > 0) {
         const failedPlugins: string[] = []
         for (const plugin of detection.plugins) {
-          const removed = await uninstallPluginFromProfile(dshHome, plugin, async (pluginName) => {
-            const result = await removeProfilePluginWithDsh(
-              {
-                dshHome,
-                dshEntryPath: dshEntryPath(),
-                nodeExecutablePath: bundledNodePath(),
-                pnpmEntryPath: bundledPnpmEntryPath(),
-                pnpmRunnerPath: bundledPnpmRunnerPath(),
-                environment: resolveShellEnvironment()
-              },
-              pluginName
-            )
-            if (!result.ok) {
-              console.warn(
-                `[plugin-recovery] Failed to remove ${pluginName}: ${result.detail ?? 'unknown error'}`
-              )
-            }
-            return result.ok
-          })
+          const removed = await removeProfilePluginCompletely(
+            dshHome,
+            plugin,
+            resolveShellEnvironment(),
+            'plugin-recovery'
+          )
           if (removed) {
             if (!removedPlugins.includes(plugin)) removedPlugins.push(plugin)
           } else {
-            const fallbackRemoved = await resetPluginProfile(dshHome, plugin)
-            if (fallbackRemoved) {
-              if (!removedPlugins.includes(plugin)) removedPlugins.push(plugin)
-            } else {
-              failedPlugins.push(plugin)
-            }
+            failedPlugins.push(plugin)
           }
         }
 
@@ -1022,6 +1005,32 @@ async function waitForSafeModeAction(options: {
 }
 
 async function removeSafeModePlugin(dshHome: string, pluginName: string): Promise<boolean> {
+  return removeProfilePluginCompletely(
+    dshHome,
+    pluginName,
+    process.env,
+    'safe-mode'
+  )
+}
+
+async function removeProfilePluginCompletely(
+  dshHome: string,
+  pluginName: string,
+  environment: NodeJS.ProcessEnv,
+  logPrefix: string
+): Promise<boolean> {
+  const cleanup = await cleanupPluginOwnedComponents({
+    dshHome,
+    pluginName,
+    log: (message) => runtime.note(`[${logPrefix}] ${message}`)
+  })
+  if (!cleanup.ok) {
+    for (const failure of cleanup.failures) {
+      runtime.note(`[${logPrefix}] failed to clean components for ${pluginName}: ${failure}`)
+    }
+    return false
+  }
+
   const removed = await uninstallPluginFromProfile(dshHome, pluginName, async (name) => {
     const result = await removeProfilePluginWithDsh(
       {
@@ -1030,18 +1039,17 @@ async function removeSafeModePlugin(dshHome: string, pluginName: string): Promis
         nodeExecutablePath: bundledNodePath(),
         pnpmEntryPath: bundledPnpmEntryPath(),
         pnpmRunnerPath: bundledPnpmRunnerPath(),
-        environment: process.env
+        environment
       },
       name
     )
     if (!result.ok) {
-      runtime.note(`[safe-mode] failed to remove ${name}: ${result.detail ?? 'unknown error'}`)
+      runtime.note(`[${logPrefix}] failed to remove ${name}: ${result.detail ?? 'unknown error'}`)
     }
     return result.ok
   })
-  // Unlike failure attribution, Safe Mode already receives an exact root
-  // bundle selected by the user. Never widen that selection to sibling
-  // packages from the same npm scope.
+  // Both recovery paths pass an exact configured root bundle. The fallback
+  // must not widen that ownership to similarly-named or same-scope siblings.
   if (removed || await resetPluginProfile(dshHome, pluginName, false)) return true
   // A package command can finish the profile edit but fail its own final
   // verification (for example after a lockfile cleanup). Treat the observable

--- a/src/main/state/plugin-component-cleanup.ts
+++ b/src/main/state/plugin-component-cleanup.ts
@@ -1,0 +1,296 @@
+import { spawn } from 'node:child_process'
+import { homedir } from 'node:os'
+import { basename, isAbsolute, join, relative, resolve } from 'node:path'
+import { mkdir, readdir, readFile, realpath, rename } from 'node:fs/promises'
+
+const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/i
+const LAUNCH_AGENT_LABEL_PATTERN = /^[a-z0-9._-]+$/i
+const COMPONENT_COMMAND_TIMEOUT_MS = 10_000
+const COMPONENT_COMMAND_OUTPUT_LIMIT = 64 * 1024
+
+interface PackageManifest {
+  dependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+}
+
+interface InstalledPackage {
+  directory: string
+  canonicalDirectory: string
+  manifest: PackageManifest
+}
+
+export interface LaunchAgentDescription {
+  Label?: unknown
+  Program?: unknown
+  ProgramArguments?: unknown
+}
+
+interface CommandResult {
+  code: number | null
+  stdout: string
+  stderr: string
+}
+
+export interface PluginComponentCleanupOptions {
+  dshHome: string
+  pluginName: string
+  platform?: NodeJS.Platform
+  homeDirectory?: string
+  uid?: number | null
+  now?: () => Date
+  readLaunchAgent?: (plistPath: string) => Promise<LaunchAgentDescription>
+  bootoutLaunchAgent?: (target: string) => Promise<CommandResult>
+  log?: (message: string) => void
+}
+
+export interface PluginComponentCleanupResult {
+  ok: boolean
+  matched: number
+  quarantined: string[]
+  failures: string[]
+}
+
+function profileDirectory(dshHome: string): string {
+  return join(dshHome, 'profiles', 'web')
+}
+
+async function installedPackage(
+  profile: string,
+  packageName: string,
+  ownerDirectory?: string
+): Promise<InstalledPackage | undefined> {
+  if (!PACKAGE_NAME_PATTERN.test(packageName)) return undefined
+  const candidates = ownerDirectory === undefined
+    ? [join(profile, 'node_modules', packageName)]
+    : [join(ownerDirectory, 'node_modules', packageName), join(profile, 'node_modules', packageName)]
+
+  for (const directory of candidates) {
+    try {
+      const manifest = JSON.parse(
+        await readFile(join(directory, 'package.json'), 'utf8')
+      ) as PackageManifest
+      return {
+        directory: resolve(directory),
+        canonicalDirectory: await realpath(directory),
+        manifest
+      }
+    } catch { }
+  }
+  return undefined
+}
+
+async function packageClosure(
+  profile: string,
+  roots: readonly string[]
+): Promise<Map<string, InstalledPackage>> {
+  const closure = new Map<string, InstalledPackage>()
+  const pending: Array<{ packageName: string; ownerDirectory?: string }> = roots.map(
+    (packageName) => ({ packageName })
+  )
+
+  while (pending.length > 0) {
+    const candidate = pending.pop()
+    if (!candidate) break
+    const found = await installedPackage(profile, candidate.packageName, candidate.ownerDirectory)
+    if (!found || closure.has(found.canonicalDirectory)) continue
+    closure.set(found.canonicalDirectory, found)
+    for (const dependency of [
+      ...Object.keys(found.manifest.dependencies ?? {}),
+      ...Object.keys(found.manifest.optionalDependencies ?? {})
+    ]) {
+      pending.push({ packageName: dependency, ownerDirectory: found.directory })
+    }
+  }
+  return closure
+}
+
+/**
+ * Package directories that disappear only because one configured root plugin
+ * is being removed. A dependency shared by any remaining profile root is not
+ * owned by this uninstall and must not drive external cleanup.
+ */
+export async function orphanedPluginPackageDirectories(
+  dshHome: string,
+  pluginName: string
+): Promise<string[]> {
+  if (!PACKAGE_NAME_PATTERN.test(pluginName)) return []
+  const profile = profileDirectory(dshHome)
+  let manifest: PackageManifest
+  try {
+    manifest = JSON.parse(await readFile(join(profile, 'package.json'), 'utf8')) as PackageManifest
+  } catch {
+    return []
+  }
+  if (!Object.hasOwn(manifest.dependencies ?? {}, pluginName)) return []
+
+  const target = await packageClosure(profile, [pluginName])
+  const remainingRoots = Object.keys(manifest.dependencies ?? {}).filter((name) => name !== pluginName)
+  const remaining = await packageClosure(profile, remainingRoots)
+  const directories = new Set<string>()
+  for (const [canonicalDirectory, pkg] of target) {
+    if (remaining.has(canonicalDirectory)) continue
+    directories.add(pkg.directory)
+    directories.add(canonicalDirectory)
+  }
+  return [...directories]
+}
+
+function pathInside(parent: string, child: string): boolean {
+  const nested = relative(parent, child)
+  return nested === '' || (!nested.startsWith('..') && !isAbsolute(nested))
+}
+
+async function launchAgentReferencesDirectories(
+  launchAgent: LaunchAgentDescription,
+  directories: readonly string[]
+): Promise<boolean> {
+  const values = [
+    typeof launchAgent.Program === 'string' ? launchAgent.Program : undefined,
+    ...Array.isArray(launchAgent.ProgramArguments)
+      ? launchAgent.ProgramArguments.filter((value): value is string => typeof value === 'string')
+      : []
+  ].filter((value): value is string => value !== undefined && isAbsolute(value))
+
+  for (const value of values) {
+    const lexical = resolve(value)
+    let canonical = lexical
+    try {
+      canonical = await realpath(value)
+    } catch { }
+    if (directories.some((directory) => pathInside(directory, lexical) || pathInside(directory, canonical))) {
+      return true
+    }
+  }
+  return false
+}
+
+function runCommand(command: string, args: readonly string[]): Promise<CommandResult> {
+  return new Promise((resolveResult) => {
+    const child = spawn(command, [...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: COMPONENT_COMMAND_TIMEOUT_MS,
+      killSignal: 'SIGKILL'
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout = (stdout + chunk).slice(-COMPONENT_COMMAND_OUTPUT_LIMIT)
+    })
+    child.stderr.on('data', (chunk: string) => {
+      stderr = (stderr + chunk).slice(-COMPONENT_COMMAND_OUTPUT_LIMIT)
+    })
+    child.once('error', (error) => resolveResult({ code: null, stdout, stderr: error.message }))
+    child.once('close', (code) => resolveResult({ code, stdout, stderr }))
+  })
+}
+
+async function defaultReadLaunchAgent(plistPath: string): Promise<LaunchAgentDescription> {
+  const result = await runCommand('/usr/bin/plutil', ['-convert', 'json', '-o', '-', plistPath])
+  if (result.code !== 0) throw new Error(result.stderr.trim() || `plutil exited ${String(result.code)}`)
+  return JSON.parse(result.stdout) as LaunchAgentDescription
+}
+
+function defaultBootoutLaunchAgent(target: string): Promise<CommandResult> {
+  return runCommand('/bin/launchctl', ['bootout', target])
+}
+
+function bootoutSucceeded(result: CommandResult): boolean {
+  return result.code === 0 || /could not find specified service/i.test(result.stderr)
+}
+
+function quarantineTimestamp(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+/**
+ * Stop and quarantine user LaunchAgents whose executable arguments point into
+ * packages owned exclusively by the selected root plugin. No package names,
+ * service labels, or plugin data directories are special-cased.
+ */
+export async function cleanupPluginOwnedComponents(
+  options: PluginComponentCleanupOptions
+): Promise<PluginComponentCleanupResult> {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'darwin') return { ok: true, matched: 0, quarantined: [], failures: [] }
+
+  const directories = await orphanedPluginPackageDirectories(options.dshHome, options.pluginName)
+  if (directories.length === 0) return { ok: true, matched: 0, quarantined: [], failures: [] }
+
+  const homeDirectory = options.homeDirectory ?? homedir()
+  const launchAgentsDirectory = join(homeDirectory, 'Library', 'LaunchAgents')
+  const readLaunchAgent = options.readLaunchAgent ?? defaultReadLaunchAgent
+  const bootoutLaunchAgent = options.bootoutLaunchAgent ?? defaultBootoutLaunchAgent
+  const uid = options.uid === undefined ? process.getuid?.() ?? null : options.uid
+  const quarantined: string[] = []
+  const failures: string[] = []
+  let matched = 0
+  let entries
+  try {
+    entries = await readdir(launchAgentsDirectory, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ok: true, matched: 0, quarantined, failures }
+    }
+    const detail = error instanceof Error ? error.message : String(error)
+    const message = `cannot inspect ${launchAgentsDirectory}: ${detail}`
+    return { ok: false, matched: 0, quarantined, failures: [message] }
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.plist')) continue
+    const plistPath = join(launchAgentsDirectory, entry.name)
+    let launchAgent: LaunchAgentDescription
+    try {
+      launchAgent = await readLaunchAgent(plistPath)
+    } catch {
+      // An unrelated unreadable plist proves no ownership and is left alone.
+      continue
+    }
+    if (!await launchAgentReferencesDirectories(launchAgent, directories)) continue
+    matched += 1
+
+    const label = typeof launchAgent.Label === 'string' && LAUNCH_AGENT_LABEL_PATTERN.test(launchAgent.Label)
+      ? launchAgent.Label
+      : undefined
+    if (label === undefined || typeof uid !== 'number') {
+      failures.push(`${plistPath}: missing a safe LaunchAgent label or user id`)
+      continue
+    }
+
+    const target = `gui/${uid}/${label}`
+    let bootout: CommandResult
+    try {
+      bootout = await bootoutLaunchAgent(target)
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      failures.push(`${plistPath}: launchctl bootout failed (${detail})`)
+      continue
+    }
+    if (!bootoutSucceeded(bootout)) {
+      const detail = bootout.stderr.trim() || String(bootout.code)
+      failures.push(`${plistPath}: launchctl bootout failed (${detail})`)
+      continue
+    }
+
+    const quarantineDirectory = join(
+      options.dshHome,
+      'recovery',
+      'uninstalled-components',
+      quarantineTimestamp((options.now ?? (() => new Date()))())
+    )
+    const quarantinePath = join(quarantineDirectory, basename(plistPath))
+    try {
+      await mkdir(quarantineDirectory, { recursive: true })
+      await rename(plistPath, quarantinePath)
+      quarantined.push(quarantinePath)
+      options.log?.(`[plugin-components] quarantined ${plistPath} for ${options.pluginName}`)
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      failures.push(`${plistPath}: quarantine failed (${detail})`)
+    }
+  }
+
+  return { ok: failures.length === 0, matched, quarantined, failures }
+}

--- a/test/plugin-component-cleanup.test.ts
+++ b/test/plugin-component-cleanup.test.ts
@@ -1,0 +1,213 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanupPluginOwnedComponents,
+  orphanedPluginPackageDirectories,
+  type LaunchAgentDescription
+} from '../src/main/state/plugin-component-cleanup'
+
+describe('plugin component cleanup', () => {
+  const testRoot = join(__dirname, '.temp-plugin-component-cleanup')
+  const dshHome = join(testRoot, 'dsh-home')
+  const profile = join(dshHome, 'profiles', 'web')
+  const home = join(testRoot, 'home')
+  const launchAgents = join(home, 'Library', 'LaunchAgents')
+  const plugin = '@example/plugin-all'
+  const doctor = '@example/plugin-doctor'
+
+  async function writePackage(name: string, dependencies: Record<string, string> = {}): Promise<string> {
+    const directory = join(profile, 'node_modules', name)
+    await mkdir(directory, { recursive: true })
+    await writeFile(
+      join(directory, 'package.json'),
+      JSON.stringify({ name, version: '1.0.0', dependencies })
+    )
+    return directory
+  }
+
+  async function writeProfile(dependencies: Record<string, string>): Promise<void> {
+    await mkdir(profile, { recursive: true })
+    await writeFile(join(profile, 'package.json'), JSON.stringify({ dependencies }))
+  }
+
+  async function installPluginGraph(shared = false): Promise<string> {
+    await writeProfile({ [plugin]: '1.0.0', ...(shared ? { '@example/other-root': '1.0.0' } : {}) })
+    await writePackage(plugin, { [doctor]: '1.0.0' })
+    const doctorDirectory = await writePackage(doctor)
+    if (shared) await writePackage('@example/other-root', { [doctor]: '1.0.0' })
+    return doctorDirectory
+  }
+
+  beforeEach(async () => {
+    await mkdir(launchAgents, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(testRoot, { recursive: true, force: true })
+  })
+
+  it('finds transitive packages owned only by the selected root', async () => {
+    const doctorDirectory = await installPluginGraph()
+
+    const directories = await orphanedPluginPackageDirectories(dshHome, plugin)
+
+    expect(directories).toContain(join(profile, 'node_modules', plugin))
+    expect(directories).toContain(doctorDirectory)
+  })
+
+  it('does not claim a transitive package still used by another profile root', async () => {
+    const doctorDirectory = await installPluginGraph(true)
+
+    const directories = await orphanedPluginPackageDirectories(dshHome, plugin)
+
+    expect(directories).toContain(join(profile, 'node_modules', plugin))
+    expect(directories).not.toContain(doctorDirectory)
+  })
+
+  it('boots out and quarantines a LaunchAgent that references an orphaned package', async () => {
+    const doctorDirectory = await installPluginGraph()
+    const plistPath = join(launchAgents, 'com.example.doctor.plist')
+    await writeFile(plistPath, 'fixture')
+    const bootout = vi.fn(async () => ({ code: 0, stdout: '', stderr: '' }))
+    const logs: string[] = []
+
+    const result = await cleanupPluginOwnedComponents({
+      dshHome,
+      pluginName: plugin,
+      platform: 'darwin',
+      homeDirectory: home,
+      uid: 501,
+      now: () => new Date('2026-08-25T12:00:00.000Z'),
+      readLaunchAgent: async () => ({
+        Label: 'com.example.doctor',
+        ProgramArguments: ['/usr/bin/node', join(doctorDirectory, 'lib', 'cli.mjs'), 'supervisor']
+      }),
+      bootoutLaunchAgent: bootout,
+      log: (message) => logs.push(message)
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.matched).toBe(1)
+    expect(bootout).toHaveBeenCalledWith('gui/501/com.example.doctor')
+    expect(existsSync(plistPath)).toBe(false)
+    expect(result.quarantined).toHaveLength(1)
+    expect(await readFile(result.quarantined[0] as string, 'utf8')).toBe('fixture')
+    expect(logs[0]).toContain('quarantined')
+  })
+
+  it('leaves an unrelated LaunchAgent and plugin data untouched', async () => {
+    await installPluginGraph()
+    const plistPath = join(launchAgents, 'com.example.unrelated.plist')
+    const pluginData = join(home, '.plugin-data', 'state.json')
+    await mkdir(join(home, '.plugin-data'), { recursive: true })
+    await writeFile(plistPath, 'fixture')
+    await writeFile(pluginData, '{}')
+    const bootout = vi.fn(async () => ({ code: 0, stdout: '', stderr: '' }))
+
+    const result = await cleanupPluginOwnedComponents({
+      dshHome,
+      pluginName: plugin,
+      platform: 'darwin',
+      homeDirectory: home,
+      uid: 501,
+      readLaunchAgent: async () => ({
+        Label: 'com.example.unrelated',
+        ProgramArguments: ['/usr/bin/node', '/opt/example/cli.mjs']
+      }),
+      bootoutLaunchAgent: bootout
+    })
+
+    expect(result).toEqual({ ok: true, matched: 0, quarantined: [], failures: [] })
+    expect(bootout).not.toHaveBeenCalled()
+    expect(existsSync(plistPath)).toBe(true)
+    expect(existsSync(pluginData)).toBe(true)
+  })
+
+  it('does not stop a service whose package is shared by another root', async () => {
+    const doctorDirectory = await installPluginGraph(true)
+    const plistPath = join(launchAgents, 'com.example.doctor.plist')
+    await writeFile(plistPath, 'fixture')
+    const bootout = vi.fn(async () => ({ code: 0, stdout: '', stderr: '' }))
+
+    const result = await cleanupPluginOwnedComponents({
+      dshHome,
+      pluginName: plugin,
+      platform: 'darwin',
+      homeDirectory: home,
+      uid: 501,
+      readLaunchAgent: async (): Promise<LaunchAgentDescription> => ({
+        Label: 'com.example.doctor',
+        ProgramArguments: ['/usr/bin/node', join(doctorDirectory, 'lib', 'cli.mjs')]
+      }),
+      bootoutLaunchAgent: bootout
+    })
+
+    expect(result.matched).toBe(0)
+    expect(bootout).not.toHaveBeenCalled()
+    expect(existsSync(plistPath)).toBe(true)
+  })
+
+  it('fails closed and keeps the plist when the owned service cannot be stopped', async () => {
+    const doctorDirectory = await installPluginGraph()
+    const plistPath = join(launchAgents, 'com.example.doctor.plist')
+    await writeFile(plistPath, 'fixture')
+
+    const result = await cleanupPluginOwnedComponents({
+      dshHome,
+      pluginName: plugin,
+      platform: 'darwin',
+      homeDirectory: home,
+      uid: 501,
+      readLaunchAgent: async () => ({
+        Label: 'com.example.doctor',
+        ProgramArguments: ['/usr/bin/node', join(doctorDirectory, 'lib', 'cli.mjs')]
+      }),
+      bootoutLaunchAgent: async () => ({ code: 5, stdout: '', stderr: 'permission denied' })
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.matched).toBe(1)
+    expect(result.failures[0]).toContain('launchctl bootout failed')
+    expect(existsSync(plistPath)).toBe(true)
+  })
+
+  it('contains a bootout execution error and keeps the package removable state intact', async () => {
+    const doctorDirectory = await installPluginGraph()
+    const plistPath = join(launchAgents, 'com.example.doctor.plist')
+    await writeFile(plistPath, 'fixture')
+
+    const result = await cleanupPluginOwnedComponents({
+      dshHome,
+      pluginName: plugin,
+      platform: 'darwin',
+      homeDirectory: home,
+      uid: 501,
+      readLaunchAgent: async () => ({
+        Label: 'com.example.doctor',
+        ProgramArguments: ['/usr/bin/node', join(doctorDirectory, 'lib', 'cli.mjs')]
+      }),
+      bootoutLaunchAgent: async () => { throw new Error('launchctl unavailable') }
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures[0]).toContain('launchctl unavailable')
+    expect(existsSync(plistPath)).toBe(true)
+  })
+
+  it('is a no-op on non-macOS platforms', async () => {
+    const readLaunchAgent = vi.fn(async () => ({}))
+
+    const result = await cleanupPluginOwnedComponents({
+      dshHome,
+      pluginName: plugin,
+      platform: 'win32',
+      homeDirectory: home,
+      readLaunchAgent
+    })
+
+    expect(result).toEqual({ ok: true, matched: 0, quarantined: [], failures: [] })
+    expect(readLaunchAgent).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Strengthens plugin removal so uninstalling a root bundle also stops and quarantines macOS user LaunchAgents that are provably owned by packages disappearing with that bundle.

This is component-based rather than plugin-specific: no package name, service label, or data directory is hard-coded.

Refs #157

## Problem

The existing removal flow correctly removes an exact profile root from `dependencies`, `dsh.profile.bundles`, the pnpm lockfile, `node_modules`, workspace package sources, and the user patch layer. It cannot see components created outside the profile.

For example, `@linxin666/dsh-web-ui-all@0.3.3` depends on `@linxin666/dsh-doctor@0.3.3`. Doctor creates a user LaunchAgent. Removing the root npm package can therefore leave a live/background service behind even though the profile no longer lists the plugin.

## Ownership model

Before package removal, Desktop now:

1. Reads the installed dependency graph for the selected configured root.
2. Computes the packages that become orphaned after removing that root.
3. Subtracts packages still reachable from every remaining direct profile dependency.
4. On macOS, parses regular files in `~/Library/LaunchAgents` with `plutil`.
5. Treats a LaunchAgent as owned only when an absolute `Program` or `ProgramArguments` path is inside one of those orphaned package directories.

Shared dependencies, unrelated or unreadable plists, symlinks, unsafe labels, and unproven ownership are never removed.

## Cleanup behavior

- Harness is already stopped by the recovery/Safe Mode flows before cleanup starts.
- Owned services are stopped through `launchctl bootout gui/<uid>/<label>`.
- Their plist files are moved, not deleted, to:
  `DSH_HOME/recovery/uninstalled-components/<timestamp>/`
- Plugin data directories outside the profile are deliberately preserved.
- If an owned service cannot be stopped or quarantined, removal fails closed and the package remains installed for retry.
- User-triggered Safe Mode and automatic recovery share the same cleanup/removal path.
- Exact configured roots remain exact during fallback; same-scope or similarly named siblings are not widened into the removal.
- Windows and Linux behavior is unchanged.

## Validation

- `npm test` — 44 files, 306 tests passed.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- `git diff --check` — passed.
- Read-only dry-run against the current development profile confirmed that removing `@linxin666/dsh-web-ui-all@0.3.3` identifies its Doctor dependency and the existing Doctor LaunchAgent. A forced bootout failure produced one match, zero quarantined files, and left the machine unchanged.

## Future contract

This PR intentionally does not invent a Desktop-only package manifest hook. A declarative uninstall hook/service registry should be standardized in DSH upstream; this change provides a safe compatibility path for existing plugins whose external service definitions already contain authoritative package paths.
