### PR TITLE
fix(windows): decode the captured shell environment as UTF-8

### DIFF
--- a/src/main/runtime/harness-runtime.ts
+++ b/src/main/runtime/harness-runtime.ts
@@ -68,6 +68,16 @@ export function resolveShellEnvironment(): NodeJS.ProcessEnv {
           '-NonInteractive',
           '-OutputFormat', 'Text',
           '-Command',
+          // Windows PowerShell writes stdout in the console codepage, not
+          // UTF-8, and we decode as UTF-8 below. On a CJK install (ACP 936)
+          // every non-ASCII byte then arrives as U+FFFD, so a user profile
+          // directory like C:\Users\数据项素 comes back as eight replacement
+          // characters — and TEMP, captured here and passed to Harness
+          // unchanged, points nowhere. Harness dies in mkdtemp before it can
+          // load a plugin tree. Pinning the output encoding is what makes the
+          // decode below true; dropping undecodable values is the belt to its
+          // braces.
+          '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ' +
           // Dot-source the profile (suppress errors if it doesn't exist),
           // then emit NAME=VALUE for every environment variable.
           '. $PROFILE 2>$null; Get-ChildItem Env: | ForEach-Object { "$($_.Name)=$($_.Value)" }'
@@ -78,7 +88,10 @@ export function resolveShellEnvironment(): NodeJS.ProcessEnv {
           stdio: ['ignore', 'pipe', 'ignore']
         }
       )
-      resolvedShellEnvironment = parseEnvOutput(output, /\r?\n/)
+      resolvedShellEnvironment = withoutUndecodableValues(
+        parseEnvOutput(output, /\r?\n/),
+        process.env
+      )
     } else {
       // macOS / Linux: run a login + interactive shell so both .zprofile
       // (Homebrew, OrbStack) and .zshrc (mise shims, ~/.local/bin, cargo,
@@ -97,6 +110,39 @@ export function resolveShellEnvironment(): NodeJS.ProcessEnv {
   }
 
   return resolvedShellEnvironment
+}
+
+/**
+ * Replace captured values that lost characters in decoding with the ones this
+ * process already holds.
+ *
+ * A value carrying U+FFFD did not survive the trip out of the shell, and there
+ * is no recovering the original from it — the byte that produced it is gone.
+ * Passing it on is the harmful option: `TEMP` from a mis-decoded capture names
+ * a directory that does not exist, and Harness fails in `mkdtemp` before it
+ * loads anything, which reads as a launch that hangs. The inherited value is
+ * always intact, because it never went through a console.
+ *
+ * A variable that exists only in the shell profile and mis-decoded has no
+ * fallback to take; it is dropped rather than passed on broken, which leaves
+ * the consumer to its own default instead of pointing it somewhere wrong.
+ * @param captured - what the shell reported.
+ * @param inherited - this process's own environment.
+ */
+export function withoutUndecodableValues(
+  captured: NodeJS.ProcessEnv,
+  inherited: NodeJS.ProcessEnv
+): NodeJS.ProcessEnv {
+  const result: NodeJS.ProcessEnv = {}
+  for (const [name, value] of Object.entries(captured)) {
+    if (value === undefined || !value.includes('�')) {
+      result[name] = value
+      continue
+    }
+    const fallback = inherited[name]
+    if (fallback !== undefined) result[name] = fallback
+  }
+  return result
 }
 
 function parseEnvOutput(output: string, lineSeparator: RegExp): NodeJS.ProcessEnv {

--- a/test/shell-environment-encoding.test.ts
+++ b/test/shell-environment-encoding.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { withoutUndecodableValues } from '../src/main/runtime/harness-runtime'
+
+/**
+ * Windows PowerShell writes stdout in the console codepage. Decoding that as
+ * UTF-8 on a CJK install turns every non-ASCII byte into U+FFFD, and the
+ * value most likely to carry one is a path under the user's profile
+ * directory. Passing such a TEMP to Harness points it at a directory that
+ * does not exist, and it dies in mkdtemp before loading a plugin tree.
+ */
+describe('captured shell environment', () => {
+  // C:\Users\数据项素\AppData\Local\Temp as GBK bytes decoded as UTF-8.
+  const mojibakeTemp = 'C:\Users\\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\AppData\Local\Temp'
+  const realTemp = 'C:\Users\数据项素\AppData\Local\Temp'
+
+  it('replaces a mis-decoded value with the inherited one', () => {
+    const result = withoutUndecodableValues({ TEMP: mojibakeTemp }, { TEMP: realTemp })
+    expect(result.TEMP).toBe(realTemp)
+  })
+
+  it('keeps values that decoded cleanly', () => {
+    const result = withoutUndecodableValues(
+      { PATH: 'C:\bin;C:\Users\数据项素\.local\bin' },
+      { PATH: 'C:\bin' }
+    )
+    expect(result.PATH).toBe('C:\bin;C:\Users\数据项素\.local\bin')
+  })
+
+  // A variable that exists only in the shell profile has nothing to fall back
+  // to. Dropping it leaves the consumer its own default; passing it on broken
+  // points it somewhere wrong.
+  it('drops a mis-decoded value that has no inherited counterpart', () => {
+    const result = withoutUndecodableValues({ CONDA_PREFIX: mojibakeTemp }, {})
+    expect('CONDA_PREFIX' in result).toBe(false)
+  })
+
+  it('leaves an ASCII-only environment untouched', () => {
+    const captured = { PATH: 'C:\bin', TEMP: 'C:\Temp' }
+    expect(withoutUndecodableValues(captured, {})).toEqual(captured)
+  })
+
+  it('preserves an empty value', () => {
+    expect(withoutUndecodableValues({ EMPTY: '' }, {})).toEqual({ EMPTY: '' })
+  })
+})


### PR DESCRIPTION
Windows PowerShell writes stdout in the console codepage, and the capture decodes it as UTF-8. On a CJK install (ACP 936) every non-ASCII byte arrives as U+FFFD, so a profile directory like C:\Users\数据项素 comes back as eight replacement characters. TEMP is captured here and passed to Harness unchanged, so Harness resolves a directory that does not exist and dies in mkdtemp while loading spill-local -- before any plugin tree exists. What the user sees is a window stuck on the splash screen, with the cause five frames deep in a log.

DSH_HOME hid the blast radius: it is assigned explicitly after the capture, so the one path the desktop cares about looked fine while everything inherited from the shell was already broken.

Pinning [Console]::OutputEncoding makes the UTF-8 decode true. Undecodable values are then replaced with this process's own, which never went through a console -- a value carrying U+FFFD cannot be recovered from, and passing it on is worse than not having captured it. One with no inherited counterpart is dropped rather than forwarded broken.

Observed on Windows 10 19045, ACP 936, desktop 0.6.0: the capture returns 'TEMP=C:\Users\<8x U+FFFD>\AppData\Local\Temp' where the raw bytes decode correctly as GBK.