### PR TITLE
test(windows): stabilize profile progress signature coverage

### DIFF
--- a/test/feishu-release-notes.test.ts
+++ b/test/feishu-release-notes.test.ts
@@ -4,26 +4,31 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 describe('Feishu release notes pipeline', () => {
+  const pythonTestTimeoutMs = 15_000
   const scriptPath = join(process.cwd(), '.github', 'scripts', 'feishu_release_notes.py')
   const workflowPath = join(process.cwd(), '.github', 'workflows', 'release.yml')
 
   const pythonEnv = { ...process.env, PYTHONIOENCODING: 'utf-8' }
 
-  it('builds a prompt with valid metadata and evidence blocks', () => {
-    const output = execFileSync('python3', [scriptPath, 'build-prompt', '--tag', 'v0.4.0'], {
-      encoding: 'utf8',
-      env: pythonEnv
-    })
+  it(
+    'builds a prompt with valid metadata and evidence blocks',
+    () => {
+      const output = execFileSync('python3', [scriptPath, 'build-prompt', '--tag', 'v0.4.0'], {
+        encoding: 'utf8',
+        env: pythonEnv
+      })
 
-    expect(output).toContain("You are DSH Desktop's Release Bot.")
-    expect(output).toContain('## DSH Desktop v0.4.0 Release Note')
-    expect(output).toContain('📢 大家可以直接在客户端中更新。')
-    expect(output).toContain('📢 You can update directly from the DSH Desktop app.')
-    expect(output).toContain('<tag-release-note>')
-    expect(output).toContain('<commit-details>')
-    expect(output).toContain('<diff-statistics>')
-    expect(output).toContain('<code-diff>')
-  })
+      expect(output).toContain("You are DSH Desktop's Release Bot.")
+      expect(output).toContain('## DSH Desktop v0.4.0 Release Note')
+      expect(output).toContain('📢 大家可以直接在客户端中更新。')
+      expect(output).toContain('📢 You can update directly from the DSH Desktop app.')
+      expect(output).toContain('<tag-release-note>')
+      expect(output).toContain('<commit-details>')
+      expect(output).toContain('<diff-statistics>')
+      expect(output).toContain('<code-diff>')
+    },
+    pythonTestTimeoutMs
+  )
 
   it('generates deterministic fallback release notes that pass validation', () => {
     const tempFile = join(process.cwd(), '.temp-feishu-test-notes.md')

--- a/test/profile-progress-signature.test.ts
+++ b/test/profile-progress-signature.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, symlink, utimes, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, rm, symlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -27,8 +27,14 @@ describe('install progress signature', () => {
    * assertions are actually about — the poll interval is seconds, so the
    * granularity never matters in production.
    */
-  async function age(path: string): Promise<void> {
+  async function ageTree(path: string): Promise<void> {
     const past = new Date(Date.now() - 60_000)
+    const entries = await readdir(path, { withFileTypes: true })
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
+        .map((entry) => ageTree(join(path, entry.name)))
+    )
     await utimes(path, past, past)
   }
 
@@ -53,7 +59,7 @@ describe('install progress signature', () => {
       const { directory, nodeModules } = await profile()
       const packagePath = join(nodeModules, 'typescript', 'lib')
       await mkdir(packagePath, { recursive: true })
-      await age(packagePath)
+      await ageTree(nodeModules)
       const before = await progressSignature(directory)
       await writeFile(join(packagePath, 'tsc.js'), 'x', 'utf8')
       expect(await progressSignature(directory)).not.toBe(before)
@@ -80,7 +86,7 @@ describe('install progress signature', () => {
       const { directory, nodeModules } = await profile()
       const packagePath = await materialize(nodeModules, 'typescript@5.4.5', 'typescript')
       await mkdir(join(packagePath, 'lib'), { recursive: true })
-      await age(join(packagePath, 'lib'))
+      await ageTree(nodeModules)
       const before = await progressSignature(directory)
       await writeFile(join(packagePath, 'lib', 'tsc.js'), 'x', 'utf8')
       expect(await progressSignature(directory)).not.toBe(before)


### PR DESCRIPTION
## Summary
- age the complete `node_modules` directory tree before deep-write assertions
- prevent Windows clock-tick granularity from leaving a newer parent mtime as the signature maximum
- keep the product progress detector unchanged

## Validation
- `npm test -- --run test/profile-progress-signature.test.ts` repeated 20 times
- `npm test -- --run test/profile-install-marker.test.ts test/profile-progress-signature.test.ts test/shell-environment-encoding.test.ts test/release.test.ts`
- `npm run typecheck`

This fixes the Windows CI failure seen while publishing `v0.6.1`.