### PR TITLE
fix: enlarge collapsed sidebar logo

### DIFF
--- a/patches/@deepseek-ai+dsh-client-ui-sidebar+0.1.1-rc.2.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-sidebar+0.1.1-rc.2.patch
@@ -124,7 +124,7 @@ index b75d41b..6d6d7e7 100644
 -									children: renderSlot("sidebar.brand.mark", { size: 24 }, { fallback: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.FishLogo, { size: 24 }) })
 +								children: [!wide && (0, react_jsx_runtime.jsx)(DshDesktopLogo, {
 +									className: SidebarRoot_module_css_default.railFish,
-+									height: 18
++									height: 20
  								}), (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconPanelLeftOutline16, {
  									className: SidebarRoot_module_css_default.panelIcon,
  									size: wide ? 16 : 18

--- a/test/branding-patch.test.ts
+++ b/test/branding-patch.test.ts
@@ -41,7 +41,7 @@ describe('DSH Desktop sidebar branding', () => {
     expect(patch).not.toContain('children: "DSH Desktop"')
     expect(patch).toContain('height = 18')
     expect(patch).toContain('brandMark{width:27px;height:23.4px')
-    expect(patch).toContain('height: 18')
+    expect(patch).toContain('height: 20')
     expect(patch).toContain('.hHd-Xa_brand:hover')
     expect(patch).toContain('padding-top:32px')
     expect(patch).toContain('navigator.userAgent.includes("Macintosh")')


### PR DESCRIPTION
## Summary
- enlarge the collapsed sidebar DSH logo from 18px to 20px
- keep the expanded sidebar logo unchanged
- update the branding patch regression test

## Verification
- `npm ci`
- `npm test -- --run test/branding-patch.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`