### PR TITLE
fix(windows): keep application menu independent from page zoom

### DIFF
--- a/build/windows-menu.html
+++ b/build/windows-menu.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline'"
+    />
+    <title>DSH Desktop application menu</title>
+    <style>html,body{width:100%;height:100%;margin:0;overflow:hidden;background:transparent}</style>
+  </head>
+  <body></body>
+</html>

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
+import { resolve } from 'node:path'
 
 export default defineConfig({
   main: {
@@ -8,6 +9,10 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()],
     build: {
       rollupOptions: {
+        input: {
+          index: resolve('src/preload/index.ts'),
+          'windows-menu': resolve('src/preload/windows-menu.ts')
+        },
         output: {
           format: 'cjs',
           entryFileNames: '[name].cjs'

--- a/package.json
+++ b/package.json
@@ -142,6 +142,10 @@
       {
         "from": "build/safe-mode.html",
         "to": "safe-mode.html"
+      },
+      {
+        "from": "build/windows-menu.html",
+        "to": "windows-menu.html"
       }
     ],
     "publish": [

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import {
   nativeTheme,
   shell,
   utilityProcess,
+  WebContentsView,
   type IpcMainInvokeEvent,
   type MessageBoxOptions
 } from 'electron'
@@ -70,6 +71,7 @@ import {
 import { buildPluginRecoveryViewModel } from './plugin-recovery-view'
 import { buildSafeModeViewModel, shouldStartInSafeMode } from './safe-mode'
 import { aboutDetail, bundledHarnessVersion } from './version-info'
+import { windowsMenuViewBounds } from './windows-menu-view'
 
 type PluginRecoveryAction = 'uninstall' | 'show-log' | 'quit' | 'restart' | 'refresh' | 'safe-mode'
 type SafeModeAction =
@@ -87,6 +89,9 @@ const PLUGIN_RECOVERY_ACTIONS = new Set<PluginRecoveryAction>([
 ])
 
 let mainWindow: BrowserWindow | undefined
+let windowsMenuView: WebContentsView | undefined
+let windowsMenuOpen = false
+let windowsMenuDark = false
 let mobileWindow: BrowserWindow | undefined
 let runtime: HarnessRuntime
 let mobileBridge: LanMobileBridge
@@ -209,8 +214,68 @@ function applyWindowChromeTheme(window: BrowserWindow, isDark: boolean): void {
   if (window.isDestroyed()) return
   window.setBackgroundColor(isDark ? '#141416' : '#ffffff')
   if (process.platform === 'win32') {
+    windowsMenuDark = isDark
     window.setTitleBarOverlay(windowsTitleBarOverlay(isDark))
+    if (windowsMenuView && !windowsMenuView.webContents.isDestroyed()) {
+      windowsMenuView.webContents.send('desktop-titlebar:theme-changed', isDark)
+    }
   }
+}
+
+function updateWindowsMenuViewBounds(window: BrowserWindow): void {
+  if (!windowsMenuView || windowsMenuView.webContents.isDestroyed() || window.isDestroyed()) return
+  const contentSize = window.getContentSize()
+  const width = contentSize[0] ?? 0
+  const height = contentSize[1] ?? 0
+  windowsMenuView.setBounds(
+    windowsMenuViewBounds({ width, height }, windowsMenuOpen, window.isFullScreen())
+  )
+}
+
+function setWindowsMenuOpen(window: BrowserWindow, open: boolean, notifyRenderer = false): void {
+  windowsMenuOpen = open
+  updateWindowsMenuViewBounds(window)
+  if (notifyRenderer && windowsMenuView && !windowsMenuView.webContents.isDestroyed()) {
+    windowsMenuView.webContents.send('desktop-titlebar:close-menu')
+  }
+}
+
+function attachWindowsMenuView(window: BrowserWindow): void {
+  const menuView = new WebContentsView({
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: join(import.meta.dirname, '../preload/windows-menu.cjs'),
+      sandbox: true,
+      webSecurity: true
+    }
+  })
+  windowsMenuView = menuView
+  windowsMenuOpen = false
+  windowsMenuDark = nativeTheme.shouldUseDarkColors
+  menuView.setBackgroundColor('#00000000')
+  menuView.webContents.setZoomFactor(1)
+  menuView.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+  menuView.webContents.on('did-finish-load', () => {
+    if (!menuView.webContents.isDestroyed()) {
+      menuView.webContents.send('desktop-titlebar:theme-changed', windowsMenuDark)
+    }
+  })
+  window.contentView.addChildView(menuView)
+  updateWindowsMenuViewBounds(window)
+
+  const updateBounds = (): void => updateWindowsMenuViewBounds(window)
+  window.on('resize', updateBounds)
+  window.on('enter-full-screen', updateBounds)
+  window.on('leave-full-screen', updateBounds)
+  window.on('blur', () => setWindowsMenuOpen(window, false, true))
+
+  void menuView.webContents.loadFile(desktopResourcePath('windows-menu.html'), {
+    query: {
+      locale: harnessLocale(),
+      theme: windowsMenuDark ? 'dark' : 'light'
+    }
+  }).catch(showUnexpectedError)
 }
 
 function configureAppIdentity(): void {
@@ -456,10 +521,16 @@ function createWindow(): BrowserWindow {
   installContextMenu(window, harnessLocale)
   window.on('closed', () => {
     if (mainWindow === window) mainWindow = undefined
+    if (windowsMenuView && !windowsMenuView.webContents.isDestroyed()) {
+      windowsMenuView.webContents.close()
+    }
+    windowsMenuView = undefined
+    windowsMenuOpen = false
     resolvePluginRecoveryAction('quit')
     resolveSafeModeAction({ type: 'quit' })
   })
   mainWindow = window
+  if (isWindows) attachWindowsMenuView(window)
   return window
 }
 
@@ -642,7 +713,7 @@ function registerHarnessHandlers(): void {
 
   ipcMain.removeHandler('desktop-menu:execute')
   ipcMain.handle('desktop-menu:execute', async (event, command: unknown) => {
-    assertTrustedMainWindowEvent(event)
+    assertTrustedDesktopMenuEvent(event)
     if (!isDesktopMenuCommand(command)) {
       throw new Error('Unknown DSH Desktop menu command.')
     }
@@ -652,8 +723,25 @@ function registerHarnessHandlers(): void {
 
   ipcMain.removeHandler('desktop-menu:get-zoom-factor')
   ipcMain.handle('desktop-menu:get-zoom-factor', (event) => {
-    assertTrustedMainWindowEvent(event)
+    assertTrustedDesktopMenuEvent(event)
     return { zoomFactor: mainWindow?.webContents.getZoomFactor() ?? 1 }
+  })
+
+  ipcMain.removeHandler('desktop-titlebar:set-menu-open')
+  ipcMain.handle('desktop-titlebar:set-menu-open', (event, open: unknown) => {
+    assertTrustedWindowsMenuEvent(event)
+    if (typeof open !== 'boolean') {
+      throw new Error('The application menu state must be a boolean.')
+    }
+    if (mainWindow && !mainWindow.isDestroyed()) setWindowsMenuOpen(mainWindow, open)
+    return { ok: true }
+  })
+
+  ipcMain.removeHandler('desktop-titlebar:close-menu')
+  ipcMain.handle('desktop-titlebar:close-menu', (event) => {
+    assertTrustedMainWindowEvent(event)
+    if (mainWindow && !mainWindow.isDestroyed()) setWindowsMenuOpen(mainWindow, false, true)
+    return { ok: true }
   })
 
   ipcMain.removeHandler('desktop-titlebar:set-theme')
@@ -667,6 +755,33 @@ function registerHarnessHandlers(): void {
     }
     return { ok: true }
   })
+}
+
+function assertTrustedDesktopMenuEvent(event: IpcMainInvokeEvent): void {
+  const fromMainWindow =
+    mainWindow &&
+    !mainWindow.isDestroyed() &&
+    event.sender === mainWindow.webContents &&
+    event.senderFrame === mainWindow.webContents.mainFrame
+  const fromWindowsMenu =
+    windowsMenuView &&
+    !windowsMenuView.webContents.isDestroyed() &&
+    event.sender === windowsMenuView.webContents &&
+    event.senderFrame === windowsMenuView.webContents.mainFrame
+  if (!fromMainWindow && !fromWindowsMenu) {
+    throw new Error('This action is only available from the DSH Desktop window.')
+  }
+}
+
+function assertTrustedWindowsMenuEvent(event: IpcMainInvokeEvent): void {
+  if (
+    !windowsMenuView ||
+    windowsMenuView.webContents.isDestroyed() ||
+    event.sender !== windowsMenuView.webContents ||
+    event.senderFrame !== windowsMenuView.webContents.mainFrame
+  ) {
+    throw new Error('This action is only available from the Windows application menu.')
+  }
 }
 
 function assertTrustedMainWindowEvent(event: IpcMainInvokeEvent): void {

--- a/src/main/windows-menu-view.ts
+++ b/src/main/windows-menu-view.ts
@@ -1,0 +1,37 @@
+import type { Rectangle } from 'electron'
+import { WINDOWS_TITLEBAR_HEIGHT } from '../shared/desktop-menu'
+
+export const WINDOWS_CAPTION_CONTROLS_WIDTH = 140
+export const WINDOWS_MENU_BUTTON_WIDTH = 44
+export const WINDOWS_MENU_PANEL_WIDTH = 304
+export const WINDOWS_MENU_PANEL_MAX_HEIGHT = 760
+
+interface ContentSize {
+  width: number
+  height: number
+}
+
+export function windowsMenuViewBounds(
+  contentSize: ContentSize,
+  menuOpen: boolean,
+  fullscreen = false
+): Rectangle {
+  const contentWidth = Math.max(0, Math.floor(contentSize.width))
+  const contentHeight = Math.max(0, Math.floor(contentSize.height))
+  const captionWidth = fullscreen
+    ? 0
+    : Math.min(WINDOWS_CAPTION_CONTROLS_WIDTH, contentWidth)
+  const availableWidth = Math.max(0, contentWidth - captionWidth)
+  const requestedWidth = menuOpen ? WINDOWS_MENU_PANEL_WIDTH : WINDOWS_MENU_BUTTON_WIDTH
+  const width = Math.min(requestedWidth, availableWidth)
+  const height = menuOpen
+    ? Math.min(WINDOWS_MENU_PANEL_MAX_HEIGHT, contentHeight)
+    : Math.min(WINDOWS_TITLEBAR_HEIGHT, contentHeight)
+
+  return {
+    x: Math.max(0, contentWidth - captionWidth - width),
+    y: 0,
+    width,
+    height
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,7 +8,7 @@ import {
 } from './update-view'
 import { isPluginLoadError } from './plugin-error-view'
 import { findBootFailureText } from './boot-failure'
-import { mountWindowsTitlebar } from './windows-titlebar'
+import { mountWindowsTitlebarLayout } from './windows-titlebar'
 
 const ROOT_ID = 'dsh-desktop-update-root'
 const MOBILE_BUTTON_ID = 'dsh-desktop-mobile-button'
@@ -213,7 +213,7 @@ async function refreshMobileStatus(): Promise<void> {
 
 function initializeUi(): void {
   if (process.platform === 'win32') {
-    mountWindowsTitlebar({ document, ipcRenderer, locale })
+    mountWindowsTitlebarLayout({ document, ipcRenderer })
   }
   mount()
   mountMobileButton()

--- a/src/preload/windows-menu.ts
+++ b/src/preload/windows-menu.ts
@@ -1,0 +1,253 @@
+import { ipcRenderer } from 'electron'
+import { formatZoomPercentage, type DesktopMenuCommand } from '../shared/desktop-menu'
+
+type MenuEntry =
+  | { kind: 'command'; command: DesktopMenuCommand; label: string; shortcut?: string }
+  | { kind: 'separator' }
+  | { kind: 'label'; label: string }
+  | { kind: 'zoom'; label: string }
+
+function mountWindowsMenu(): void {
+  if (!document.body || document.getElementById('application-menu-button')) return
+  const params = new URLSearchParams(location.search)
+  const locale = params.get('locale') === 'zh' ? 'zh' : 'en'
+  applyTheme(params.get('theme') === 'dark')
+
+  const bar = document.createElement('div')
+  bar.className = 'bar'
+  const menuButton = document.createElement('button')
+  menuButton.id = 'application-menu-button'
+  menuButton.className = 'menuButton'
+  menuButton.type = 'button'
+  menuButton.setAttribute('aria-haspopup', 'menu')
+  menuButton.setAttribute('aria-expanded', 'false')
+  menuButton.setAttribute('aria-label', locale === 'zh' ? '打开应用菜单' : 'Open application menu')
+  menuButton.title = locale === 'zh' ? '应用菜单' : 'Application menu'
+  menuButton.innerHTML = chevronIcon
+
+  const menu = document.createElement('div')
+  menu.className = 'menu'
+  menu.hidden = true
+  menu.setAttribute('role', 'menu')
+  menu.setAttribute('aria-label', locale === 'zh' ? '应用菜单' : 'Application menu')
+  let zoomDisplay: HTMLButtonElement | null = null
+
+  const applyZoomState = (result: unknown): void => {
+    const zoomFactor = readZoomFactor(result)
+    if (zoomFactor !== undefined && zoomDisplay) {
+      zoomDisplay.textContent = formatZoomPercentage(zoomFactor)
+    }
+  }
+  const refreshZoomState = (): void => {
+    void ipcRenderer.invoke('desktop-menu:get-zoom-factor').then(applyZoomState).catch((error: unknown) => {
+      console.warn('[desktop-menu] unable to read zoom factor', error)
+    })
+  }
+
+  function openMenu(): void {
+    void ipcRenderer.invoke('desktop-titlebar:set-menu-open', true)
+    refreshZoomState()
+    menu.hidden = false
+    menuButton.classList.add('isOpen')
+    menuButton.setAttribute('aria-expanded', 'true')
+    window.requestAnimationFrame(() => menu.querySelector<HTMLButtonElement>('button:not(:disabled)')?.focus())
+  }
+
+  function closeMenu(restoreFocus = true): void {
+    if (menu.hidden) return
+    menu.hidden = true
+    menuButton.classList.remove('isOpen')
+    menuButton.setAttribute('aria-expanded', 'false')
+    void ipcRenderer.invoke('desktop-titlebar:set-menu-open', false)
+    if (restoreFocus) menuButton.focus()
+  }
+
+  zoomDisplay = renderMenu(menu, menuEntries(locale), () => closeMenu(false), applyZoomState)
+  menuButton.addEventListener('pointerdown', (event) => event.preventDefault())
+  menuButton.addEventListener('click', () => (menu.hidden ? openMenu() : closeMenu()))
+  menu.addEventListener('keydown', (event) => {
+    const buttons = [...menu.querySelectorAll<HTMLButtonElement>('button:not(:disabled)')]
+    const current = buttons.indexOf(document.activeElement as HTMLButtonElement)
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeMenu()
+    } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const direction = event.key === 'ArrowDown' ? 1 : -1
+      const next = current < 0 ? 0 : (current + direction + buttons.length) % buttons.length
+      buttons[next]?.focus()
+    }
+  })
+  ipcRenderer.on('desktop-titlebar:close-menu', () => closeMenu(false))
+  ipcRenderer.on('desktop-titlebar:theme-changed', (_event, isDark: unknown) => {
+    if (typeof isDark === 'boolean') applyTheme(isDark)
+  })
+  window.addEventListener('blur', () => closeMenu(false))
+
+  const style = document.createElement('style')
+  style.textContent = menuStyles
+  document.head.appendChild(style)
+  bar.append(menuButton, menu)
+  document.body.appendChild(bar)
+  refreshZoomState()
+}
+
+function renderMenu(
+  menu: HTMLElement,
+  entries: MenuEntry[],
+  close: () => void,
+  applyZoomState: (result: unknown) => void
+): HTMLButtonElement | null {
+  let zoomDisplay: HTMLButtonElement | null = null
+  for (const entry of entries) {
+    if (entry.kind === 'separator') {
+      const separator = document.createElement('div')
+      separator.className = 'separator'
+      separator.setAttribute('role', 'separator')
+      menu.appendChild(separator)
+      continue
+    }
+    if (entry.kind === 'label') {
+      const label = document.createElement('div')
+      label.className = 'sectionLabel'
+      label.textContent = entry.label
+      menu.appendChild(label)
+      continue
+    }
+    if (entry.kind === 'zoom') {
+      const row = document.createElement('div')
+      row.className = 'zoomRow'
+      const label = document.createElement('span')
+      label.textContent = entry.label
+      row.append(label)
+      for (const [command, text, title] of [
+        ['zoom-out', '−', 'Zoom out'],
+        ['zoom-reset', '100%', 'Reset zoom'],
+        ['zoom-in', '+', 'Zoom in']
+      ] as const) {
+        const zoom = document.createElement('button')
+        zoom.type = 'button'
+        zoom.className = command === 'zoom-reset' ? 'zoomReset' : 'zoomButton'
+        zoom.textContent = text
+        zoom.title = title
+        zoom.setAttribute('aria-label', title)
+        zoom.addEventListener('pointerdown', (event) => event.preventDefault())
+        zoom.addEventListener('click', () => {
+          void ipcRenderer.invoke('desktop-menu:execute', command).then(applyZoomState).catch((error: unknown) => {
+            console.error(`[desktop-menu] unable to execute ${command}`, error)
+          })
+        })
+        if (command === 'zoom-reset') zoomDisplay = zoom
+        row.appendChild(zoom)
+      }
+      menu.appendChild(row)
+      continue
+    }
+
+    const item = document.createElement('button')
+    item.type = 'button'
+    item.className = entry.command === 'quit' ? 'item danger' : 'item'
+    item.setAttribute('role', 'menuitem')
+    const label = document.createElement('span')
+    label.textContent = entry.label
+    item.appendChild(label)
+    if (entry.shortcut) {
+      const shortcut = document.createElement('kbd')
+      shortcut.textContent = entry.shortcut
+      item.appendChild(shortcut)
+    }
+    item.addEventListener('pointerdown', (event) => event.preventDefault())
+    item.addEventListener('click', () => {
+      close()
+      void ipcRenderer.invoke('desktop-menu:execute', entry.command).catch((error: unknown) => {
+        console.error(`[desktop-menu] unable to execute ${entry.command}`, error)
+      })
+    })
+    menu.appendChild(item)
+  }
+  return zoomDisplay
+}
+
+function readZoomFactor(result: unknown): number | undefined {
+  if (typeof result !== 'object' || result === null || !('zoomFactor' in result)) return undefined
+  const zoomFactor = result.zoomFactor
+  return typeof zoomFactor === 'number' && Number.isFinite(zoomFactor) && zoomFactor > 0
+    ? zoomFactor
+    : undefined
+}
+
+function applyTheme(isDark: boolean): void {
+  document.documentElement.dataset.theme = isDark ? 'dark' : 'light'
+}
+
+function menuEntries(locale: 'en' | 'zh'): MenuEntry[] {
+  const zh = locale === 'zh'
+  return [
+    { kind: 'label', label: 'HARNESS' },
+    { kind: 'command', command: 'connect-phone', label: zh ? '连接手机…' : 'Connect Phone…', shortcut: 'Ctrl+Shift+M' },
+    { kind: 'command', command: 'restart-harness', label: zh ? '重启 Harness' : 'Restart Harness', shortcut: 'Ctrl+Shift+R' },
+    { kind: 'command', command: 'safe-mode', label: zh ? '以安全模式重启…' : 'Restart as Safe Mode…' },
+    { kind: 'command', command: 'show-harness-log', label: zh ? '显示 Harness 日志' : 'Show Harness Log' },
+    { kind: 'command', command: 'check-for-updates', label: zh ? '检查更新…' : 'Check for Updates…', shortcut: 'Ctrl+U' },
+    { kind: 'separator' },
+    { kind: 'label', label: zh ? '编辑' : 'EDIT' },
+    { kind: 'command', command: 'undo', label: zh ? '撤销' : 'Undo', shortcut: 'Ctrl+Z' },
+    { kind: 'command', command: 'redo', label: zh ? '重做' : 'Redo', shortcut: 'Ctrl+Y' },
+    { kind: 'command', command: 'cut', label: zh ? '剪切' : 'Cut', shortcut: 'Ctrl+X' },
+    { kind: 'command', command: 'copy', label: zh ? '复制' : 'Copy', shortcut: 'Ctrl+C' },
+    { kind: 'command', command: 'paste', label: zh ? '粘贴' : 'Paste', shortcut: 'Ctrl+V' },
+    { kind: 'command', command: 'select-all', label: zh ? '全选' : 'Select All', shortcut: 'Ctrl+A' },
+    { kind: 'separator' },
+    { kind: 'label', label: zh ? '视图' : 'VIEW' },
+    { kind: 'command', command: 'reload', label: zh ? '重新加载' : 'Reload', shortcut: 'Ctrl+R' },
+    { kind: 'command', command: 'toggle-devtools', label: zh ? '开发者工具' : 'Developer Tools', shortcut: 'Ctrl+Shift+I' },
+    { kind: 'zoom', label: zh ? '界面缩放' : 'Interface scale' },
+    { kind: 'command', command: 'toggle-fullscreen', label: zh ? '切换全屏' : 'Toggle Full Screen', shortcut: 'F11' },
+    { kind: 'separator' },
+    { kind: 'command', command: 'about', label: zh ? '关于 DSH Desktop' : 'About DSH Desktop' },
+    { kind: 'command', command: 'quit', label: zh ? '退出' : 'Exit' }
+  ]
+}
+
+const chevronIcon = `<svg viewBox="0 0 20 20" width="17" height="17" fill="none" aria-hidden="true"><path d="m6.5 8 3.5 3.5L13.5 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>`
+
+const menuStyles = `
+  :root {
+    color-scheme: light;
+    --label-primary: #202124; --label-secondary: #61666b; --label-tertiary: #81858c;
+    --hover: rgba(32,33,36,.08); --surface: #fff; --border: rgba(32,33,36,.13);
+    --separator: rgba(32,33,36,.09); --layer: rgba(32,33,36,.06); --danger: #d93025;
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --label-primary: #f3f4f6; --label-secondary: #b5b7bd; --label-tertiary: #92959b;
+    --hover: rgba(255,255,255,.09); --surface: #28282b; --border: rgba(255,255,255,.12);
+    --separator: rgba(255,255,255,.09); --layer: rgba(255,255,255,.07); --danger: #ee7772;
+  }
+  * { box-sizing: border-box; }
+  html, body { width:100%; height:100%; margin:0; overflow:hidden; background:transparent; }
+  body { color:var(--label-primary); font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; user-select:none; }
+  .bar { position:relative; width:100%; height:100%; display:flex; justify-content:flex-end; align-items:flex-start; }
+  .menuButton { appearance:none; flex:none; width:44px; height:36px; display:grid; place-items:center; padding:0; color:var(--label-secondary); background:transparent; border:0; cursor:pointer; }
+  .menuButton:hover, .menuButton.isOpen { color:var(--label-primary); background:var(--hover); }
+  .menuButton:focus-visible { outline:2px solid #4d6bfe; outline-offset:-3px; }
+  .menu { position:absolute; top:43px; right:0; width:304px; max-height:calc(100vh - 56px); overflow:auto; padding:7px; color:var(--label-primary); background:var(--surface); border:1px solid var(--border); border-radius:12px; box-shadow:0 14px 36px rgba(0,0,0,.2); scrollbar-width:thin; }
+  .menu[hidden] { display:none; }
+  .sectionLabel { padding:7px 10px 4px; color:var(--label-tertiary); font-size:10px; font-weight:600; line-height:14px; letter-spacing:.08em; text-transform:uppercase; }
+  .item { appearance:none; width:100%; min-height:33px; display:flex; align-items:center; justify-content:space-between; gap:20px; padding:6px 10px; color:inherit; background:transparent; border:0; border-radius:7px; font:inherit; font-size:13px; line-height:20px; text-align:left; cursor:pointer; }
+  .item:hover, .item:focus-visible, .zoomButton:hover, .zoomButton:focus-visible, .zoomReset:hover, .zoomReset:focus-visible { outline:none; background:var(--hover); }
+  .item.danger { color:var(--danger); }
+  kbd { flex:none; color:var(--label-tertiary); font:11px/16px ui-monospace,"SFMono-Regular",Consolas,monospace; }
+  .separator { height:1px; margin:6px 3px; background:var(--separator); }
+  .zoomRow { min-height:37px; display:grid; grid-template-columns:1fr 30px 54px 30px; align-items:center; gap:3px; padding:3px 7px 3px 10px; font-size:13px; }
+  .zoomButton, .zoomReset { appearance:none; height:27px; padding:0; color:inherit; background:var(--layer); border:0; border-radius:6px; font:inherit; cursor:pointer; }
+  .zoomReset { font-size:11px; }
+  :root[data-theme="dark"] .menu { box-shadow:0 18px 42px rgba(0,0,0,.46); }
+  @media (prefers-reduced-motion:reduce) { * { scroll-behavior:auto !important; } }
+`
+
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', mountWindowsMenu, { once: true })
+} else {
+  mountWindowsMenu()
+}

--- a/src/preload/windows-titlebar.ts
+++ b/src/preload/windows-titlebar.ts
@@ -1,140 +1,30 @@
 import type { IpcRenderer } from 'electron'
-import {
-  WINDOWS_TITLEBAR_HEIGHT,
-  formatZoomPercentage,
-  type DesktopMenuCommand
-} from '../shared/desktop-menu'
 
-const HOST_ID = 'dsh-desktop-windows-titlebar'
-const LAYOUT_STYLE_ID = `${HOST_ID}-layout`
+const LAYOUT_STYLE_ID = 'dsh-desktop-windows-titlebar-layout-style'
+const DRAG_REGION_ID = 'dsh-desktop-windows-drag-region'
 const SIDEBAR_WIDTH_PROPERTY = '--dsh-desktop-windows-sidebar-width'
 const CAPTION_WIDTH_PROPERTY = '--dsh-desktop-windows-caption-width'
-const INVERSE_ZOOM_PROPERTY = '--dsh-desktop-inverse-zoom'
 
-type MenuEntry =
-  | { kind: 'command'; command: DesktopMenuCommand; label: string; shortcut?: string }
-  | { kind: 'separator' }
-  | { kind: 'label'; label: string }
-  | { kind: 'zoom'; label: string }
-
-interface TitlebarMountOptions {
+interface TitlebarLayoutMountOptions {
   document: Document
   ipcRenderer: Pick<IpcRenderer, 'invoke'>
-  locale: 'en' | 'zh'
 }
 
-export function mountWindowsTitlebar(options: TitlebarMountOptions): void {
-  const { document, ipcRenderer, locale } = options
-  if (!document.body || document.getElementById(HOST_ID)) return
+export function mountWindowsTitlebarLayout(options: TitlebarLayoutMountOptions): void {
+  const { document, ipcRenderer } = options
+  if (!document.body) return
 
   installLayout(document)
+  installDragRegion(document)
   trackSidebarLayout(document)
 
-  const host = document.createElement('div')
-  host.id = HOST_ID
-  host.setAttribute('aria-label', locale === 'zh' ? 'DSH Desktop 标题栏' : 'DSH Desktop title bar')
-  const shadow = host.attachShadow({ mode: 'closed' })
-  const style = document.createElement('style')
-  style.textContent = titlebarStyles
-
-  const bar = document.createElement('div')
-  bar.className = 'bar'
-  const safeArea = document.createElement('div')
-  safeArea.className = 'safeArea'
-  const menuButton = document.createElement('button')
-  menuButton.className = 'menuButton'
-  menuButton.type = 'button'
-  menuButton.setAttribute('aria-haspopup', 'menu')
-  menuButton.setAttribute('aria-expanded', 'false')
-  menuButton.setAttribute('aria-label', locale === 'zh' ? '打开应用菜单' : 'Open application menu')
-  menuButton.title = locale === 'zh' ? '应用菜单' : 'Application menu'
-  menuButton.innerHTML = chevronIcon
-
-  const menu = document.createElement('div')
-  menu.className = 'menu'
-  menu.hidden = true
-  menu.setAttribute('role', 'menu')
-  menu.setAttribute('aria-label', locale === 'zh' ? '应用菜单' : 'Application menu')
-  let zoomDisplay: HTMLButtonElement | null = null
-
-  const applyZoomState = (result: unknown): void => {
-    const zoomFactor = readZoomFactor(result)
-    if (zoomFactor === undefined) return
-    document.documentElement.style.setProperty(INVERSE_ZOOM_PROPERTY, String(1 / zoomFactor))
-    if (zoomDisplay) zoomDisplay.textContent = formatZoomPercentage(zoomFactor)
-  }
-
-  const refreshZoomState = (): void => {
-    void ipcRenderer.invoke('desktop-menu:get-zoom-factor').then(applyZoomState).catch((error: unknown) => {
-      console.warn('[desktop-menu] unable to read zoom factor', error)
+  document.addEventListener('pointerdown', () => {
+    void ipcRenderer.invoke('desktop-titlebar:close-menu').catch((error: unknown) => {
+      console.warn('[desktop-titlebar] unable to close the application menu', error)
     })
-  }
-
-  let zoomRefreshFrame: number | undefined
-  const scheduleZoomStateRefresh = (): void => {
-    if (zoomRefreshFrame !== undefined) return
-    zoomRefreshFrame = window.requestAnimationFrame(() => {
-      zoomRefreshFrame = undefined
-      refreshZoomState()
-    })
-  }
-
-  zoomDisplay = renderMenu(
-    document,
-    menu,
-    menuEntries(locale),
-    ipcRenderer,
-    () => closeMenu(false),
-    applyZoomState
-  )
-
-  function openMenu(): void {
-    refreshZoomState()
-    menu.hidden = false
-    menuButton.classList.add('isOpen')
-    menuButton.setAttribute('aria-expanded', 'true')
-    const first = menu.querySelector<HTMLButtonElement>('button:not(:disabled)')
-    window.requestAnimationFrame(() => first?.focus())
-  }
-
-  function closeMenu(restoreFocus = true): void {
-    if (menu.hidden) return
-    menu.hidden = true
-    menuButton.classList.remove('isOpen')
-    menuButton.setAttribute('aria-expanded', 'false')
-    if (restoreFocus) menuButton.focus()
-  }
-
-  menuButton.addEventListener('pointerdown', (event) => event.preventDefault())
-  menuButton.addEventListener('click', () => (menu.hidden ? openMenu() : closeMenu()))
-  menu.addEventListener('keydown', (event) => {
-    const buttons = [...menu.querySelectorAll<HTMLButtonElement>('button:not(:disabled)')]
-    const current = buttons.indexOf(document.activeElement as HTMLButtonElement)
-    if (event.key === 'Escape') {
-      event.preventDefault()
-      closeMenu()
-    } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault()
-      const direction = event.key === 'ArrowDown' ? 1 : -1
-      const next = current < 0
-        ? 0
-        : (current + direction + buttons.length) % buttons.length
-      buttons[next]?.focus()
-    }
   })
-  document.addEventListener('pointerdown', (event) => {
-    if (!menu.hidden && !event.composedPath().includes(host)) closeMenu(false)
-  })
-  window.addEventListener('blur', () => closeMenu(false))
-  window.addEventListener('resize', scheduleZoomStateRefresh)
 
-  safeArea.append(menuButton, menu)
-  bar.appendChild(safeArea)
-  shadow.append(style, bar)
-  document.body.appendChild(host)
-  refreshZoomState()
   syncTheme(document, ipcRenderer)
-
   const themeObserver = new MutationObserver(() => syncTheme(document, ipcRenderer))
   themeObserver.observe(document.body, {
     attributes: true,
@@ -178,8 +68,28 @@ function installLayout(document: Document): void {
     body.dsh-desktop-windows-titlebar-layout [data-dsh-no-drag] {
       -webkit-app-region: no-drag !important;
     }
+    #${DRAG_REGION_ID} {
+      position: fixed;
+      z-index: 2147483644;
+      top: 0;
+      left: 0;
+      right: calc(var(${CAPTION_WIDTH_PROPERTY}, 140px) + 44px);
+      height: 36px;
+      background: transparent;
+      pointer-events: none;
+      user-select: none;
+      -webkit-app-region: drag;
+    }
   `
   document.head.appendChild(style)
+}
+
+function installDragRegion(document: Document): void {
+  if (document.getElementById(DRAG_REGION_ID)) return
+  const dragRegion = document.createElement('div')
+  dragRegion.id = DRAG_REGION_ID
+  dragRegion.setAttribute('aria-hidden', 'true')
+  document.body.appendChild(dragRegion)
 }
 
 function trackSidebarLayout(document: Document): void {
@@ -212,104 +122,6 @@ function trackSidebarLayout(document: Document): void {
   sync()
 }
 
-function renderMenu(
-  document: Document,
-  menu: HTMLElement,
-  entries: MenuEntry[],
-  ipcRenderer: Pick<IpcRenderer, 'invoke'>,
-  close: () => void,
-  applyZoomState: (result: unknown) => void
-): HTMLButtonElement | null {
-  let zoomDisplay: HTMLButtonElement | null = null
-  for (const entry of entries) {
-    if (entry.kind === 'separator') {
-      const separator = document.createElement('div')
-      separator.className = 'separator'
-      separator.setAttribute('role', 'separator')
-      menu.appendChild(separator)
-      continue
-    }
-    if (entry.kind === 'label') {
-      const label = document.createElement('div')
-      label.className = 'sectionLabel'
-      label.textContent = entry.label
-      menu.appendChild(label)
-      continue
-    }
-    if (entry.kind === 'zoom') {
-      const row = document.createElement('div')
-      row.className = 'zoomRow'
-      const label = document.createElement('span')
-      label.textContent = entry.label
-      row.append(label)
-      for (const [command, text, title] of [
-        ['zoom-out', '−', 'Zoom out'],
-        ['zoom-reset', '100%', 'Reset zoom'],
-        ['zoom-in', '+', 'Zoom in']
-      ] as const) {
-        const zoom = document.createElement('button')
-        zoom.type = 'button'
-        zoom.className = command === 'zoom-reset' ? 'zoomReset' : 'zoomButton'
-        zoom.textContent = text
-        zoom.title = title
-        zoom.setAttribute('aria-label', title)
-        zoom.addEventListener('pointerdown', (event) => event.preventDefault())
-        zoom.addEventListener('click', () => executeZoom(ipcRenderer, command, applyZoomState))
-        if (command === 'zoom-reset') zoomDisplay = zoom
-        row.appendChild(zoom)
-      }
-      menu.appendChild(row)
-      continue
-    }
-
-    const item = document.createElement('button')
-    item.type = 'button'
-    item.className = entry.command === 'quit' ? 'item danger' : 'item'
-    item.setAttribute('role', 'menuitem')
-    const label = document.createElement('span')
-    label.textContent = entry.label
-    item.appendChild(label)
-    if (entry.shortcut) {
-      const shortcut = document.createElement('kbd')
-      shortcut.textContent = entry.shortcut
-      item.appendChild(shortcut)
-    }
-    item.addEventListener('pointerdown', (event) => event.preventDefault())
-    item.addEventListener('click', () => execute(ipcRenderer, entry.command, close))
-    menu.appendChild(item)
-  }
-  return zoomDisplay
-}
-
-function executeZoom(
-  ipcRenderer: Pick<IpcRenderer, 'invoke'>,
-  command: Extract<DesktopMenuCommand, 'zoom-reset' | 'zoom-in' | 'zoom-out'>,
-  applyZoomState: (result: unknown) => void
-): void {
-  void ipcRenderer.invoke('desktop-menu:execute', command).then(applyZoomState).catch((error: unknown) => {
-    console.error(`[desktop-menu] unable to execute ${command}`, error)
-  })
-}
-
-function execute(
-  ipcRenderer: Pick<IpcRenderer, 'invoke'>,
-  command: DesktopMenuCommand,
-  close: () => void
-): void {
-  close()
-  void ipcRenderer.invoke('desktop-menu:execute', command).catch((error: unknown) => {
-    console.error(`[desktop-menu] unable to execute ${command}`, error)
-  })
-}
-
-function readZoomFactor(result: unknown): number | undefined {
-  if (typeof result !== 'object' || result === null || !('zoomFactor' in result)) return undefined
-  const zoomFactor = result.zoomFactor
-  return typeof zoomFactor === 'number' && Number.isFinite(zoomFactor) && zoomFactor > 0
-    ? zoomFactor
-    : undefined
-}
-
 function syncTheme(document: Document, ipcRenderer: Pick<IpcRenderer, 'invoke'>): void {
   const isDark = documentIsDark(document)
   void ipcRenderer.invoke('desktop-titlebar:set-theme', isDark).catch((error: unknown) => {
@@ -327,225 +139,3 @@ export function documentIsDark(document: Document): boolean {
   const [red = 255, green = 255, blue = 255] = channels
   return red * 0.2126 + green * 0.7152 + blue * 0.0722 < 128
 }
-
-function menuEntries(locale: 'en' | 'zh'): MenuEntry[] {
-  const zh = locale === 'zh'
-  return [
-    { kind: 'label', label: 'HARNESS' },
-    {
-      kind: 'command',
-      command: 'connect-phone',
-      label: zh ? '连接手机…' : 'Connect Phone…',
-      shortcut: 'Ctrl+Shift+M'
-    },
-    {
-      kind: 'command',
-      command: 'restart-harness',
-      label: zh ? '重启 Harness' : 'Restart Harness',
-      shortcut: 'Ctrl+Shift+R'
-    },
-    {
-      kind: 'command',
-      command: 'safe-mode',
-      label: zh ? '以安全模式重启…' : 'Restart as Safe Mode…'
-    },
-    {
-      kind: 'command',
-      command: 'show-harness-log',
-      label: zh ? '显示 Harness 日志' : 'Show Harness Log'
-    },
-    {
-      kind: 'command',
-      command: 'check-for-updates',
-      label: zh ? '检查更新…' : 'Check for Updates…',
-      shortcut: 'Ctrl+U'
-    },
-    { kind: 'separator' },
-    { kind: 'label', label: zh ? '编辑' : 'EDIT' },
-    { kind: 'command', command: 'undo', label: zh ? '撤销' : 'Undo', shortcut: 'Ctrl+Z' },
-    { kind: 'command', command: 'redo', label: zh ? '重做' : 'Redo', shortcut: 'Ctrl+Y' },
-    { kind: 'command', command: 'cut', label: zh ? '剪切' : 'Cut', shortcut: 'Ctrl+X' },
-    { kind: 'command', command: 'copy', label: zh ? '复制' : 'Copy', shortcut: 'Ctrl+C' },
-    { kind: 'command', command: 'paste', label: zh ? '粘贴' : 'Paste', shortcut: 'Ctrl+V' },
-    {
-      kind: 'command',
-      command: 'select-all',
-      label: zh ? '全选' : 'Select All',
-      shortcut: 'Ctrl+A'
-    },
-    { kind: 'separator' },
-    { kind: 'label', label: zh ? '视图' : 'VIEW' },
-    { kind: 'command', command: 'reload', label: zh ? '重新加载' : 'Reload', shortcut: 'Ctrl+R' },
-    {
-      kind: 'command',
-      command: 'toggle-devtools',
-      label: zh ? '开发者工具' : 'Developer Tools',
-      shortcut: 'Ctrl+Shift+I'
-    },
-    { kind: 'zoom', label: zh ? '界面缩放' : 'Interface scale' },
-    {
-      kind: 'command',
-      command: 'toggle-fullscreen',
-      label: zh ? '切换全屏' : 'Toggle Full Screen',
-      shortcut: 'F11'
-    },
-    { kind: 'separator' },
-    {
-      kind: 'command',
-      command: 'about',
-      label: zh ? '关于 DSH Desktop' : 'About DSH Desktop'
-    },
-    { kind: 'command', command: 'quit', label: zh ? '退出' : 'Exit' }
-  ]
-}
-
-const chevronIcon = `<svg viewBox="0 0 20 20" width="17" height="17" fill="none" aria-hidden="true"><path d="m6.5 8 3.5 3.5L13.5 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>`
-
-const titlebarStyles = `
-  :host { color-scheme: light dark; }
-  * { box-sizing: border-box; }
-  .bar {
-    position: fixed;
-    z-index: 2147483645;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: ${WINDOWS_TITLEBAR_HEIGHT}px;
-    color: var(--dsw-alias-label-primary, #202124);
-    background: transparent;
-    font-family: var(--dsw-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
-    -webkit-app-region: no-drag;
-    pointer-events: none;
-    user-select: none;
-  }
-  .safeArea {
-    position: absolute;
-    top: 0;
-    left: env(titlebar-area-x, 0px);
-    width: env(titlebar-area-width, calc(100vw - 140px));
-    height: 100%;
-    display: flex;
-    justify-content: flex-end;
-    align-items: stretch;
-    pointer-events: none;
-  }
-  .safeArea::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 44px;
-    height: ${WINDOWS_TITLEBAR_HEIGHT}px;
-    pointer-events: none;
-    -webkit-app-region: drag;
-  }
-  .menuButton {
-    appearance: none;
-    width: 44px;
-    height: 100%;
-    display: grid;
-    place-items: center;
-    padding: 0;
-    zoom: var(${INVERSE_ZOOM_PROPERTY}, 1);
-    color: var(--dsw-alias-label-secondary, #61666b);
-    background: transparent;
-    border: 0;
-    cursor: pointer;
-    pointer-events: auto;
-    -webkit-app-region: no-drag;
-  }
-  .menuButton:hover, .menuButton.isOpen {
-    color: var(--dsw-alias-label-primary, #202124);
-    background: var(--dsw-alias-interactive-bg-hover, rgba(32, 33, 36, 0.08));
-  }
-  .menuButton:focus-visible { outline: 2px solid #4d6bfe; outline-offset: -3px; }
-  .menu {
-    position: absolute;
-    top: calc(100% + 7px);
-    right: 0;
-    width: 304px;
-    max-height: calc(100vh - ${WINDOWS_TITLEBAR_HEIGHT + 20}px);
-    overflow: auto;
-    padding: 7px;
-    color: var(--dsw-alias-label-primary, #202124);
-    background: var(--dsw-specific-menu, #fff);
-    border: 1px solid var(--dsw-alias-border-l2, rgba(32, 33, 36, 0.13));
-    border-radius: 12px;
-    box-shadow: var(--dsw-shadow-lv3, 0 14px 36px rgba(0, 0, 0, 0.17));
-    pointer-events: auto;
-    -webkit-app-region: no-drag;
-    user-select: none;
-    scrollbar-width: thin;
-  }
-  .menu[hidden] { display: none; }
-  .sectionLabel {
-    padding: 7px 10px 4px;
-    color: var(--dsw-alias-label-tertiary, #81858c);
-    font-size: 10px;
-    font-weight: 600;
-    line-height: 14px;
-    letter-spacing: .08em;
-    text-transform: uppercase;
-  }
-  .item {
-    appearance: none;
-    width: 100%;
-    min-height: 33px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 20px;
-    padding: 6px 10px;
-    color: inherit;
-    background: transparent;
-    border: 0;
-    border-radius: 7px;
-    font: inherit;
-    font-size: 13px;
-    line-height: 20px;
-    text-align: left;
-    cursor: pointer;
-  }
-  .item:hover, .item:focus-visible, .zoomButton:hover, .zoomButton:focus-visible, .zoomReset:hover, .zoomReset:focus-visible {
-    outline: none;
-    background: var(--dsw-alias-interactive-bg-hover, rgba(32, 33, 36, 0.08));
-  }
-  .item.danger { color: var(--dsw-alias-state-error-primary, #d93025); }
-  kbd {
-    flex: none;
-    color: var(--dsw-alias-label-tertiary, #81858c);
-    font: 11px/16px var(--ds-font-family-code, ui-monospace, "SFMono-Regular", Consolas, monospace);
-  }
-  .separator {
-    height: 1px;
-    margin: 6px 3px;
-    background: var(--dsw-alias-border-l1, rgba(32, 33, 36, 0.09));
-  }
-  .zoomRow {
-    min-height: 37px;
-    display: grid;
-    grid-template-columns: 1fr 30px 54px 30px;
-    align-items: center;
-    gap: 3px;
-    padding: 3px 7px 3px 10px;
-    font-size: 13px;
-  }
-  .zoomButton, .zoomReset {
-    appearance: none;
-    height: 27px;
-    padding: 0;
-    color: inherit;
-    background: var(--dsw-alias-bg-layer-2, rgba(32, 33, 36, 0.06));
-    border: 0;
-    border-radius: 6px;
-    font: inherit;
-    cursor: pointer;
-  }
-  .zoomReset { font-size: 11px; }
-  @media (prefers-color-scheme: dark) {
-    .bar { color: var(--dsw-alias-label-primary, #f3f4f6); }
-    .menu { color: var(--dsw-alias-label-primary, #f3f4f6); background: var(--dsw-specific-menu, #28282b); border-color: rgba(255,255,255,.12); box-shadow: 0 18px 42px rgba(0,0,0,.46); }
-    .menuButton { color: var(--dsw-alias-label-secondary, #b5b7bd); }
-  }
-  @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; } }
-`

--- a/test/windows-titlebar.test.ts
+++ b/test/windows-titlebar.test.ts
@@ -6,6 +6,12 @@ import {
   formatZoomPercentage,
   isDesktopMenuCommand
 } from '../src/shared/desktop-menu'
+import {
+  WINDOWS_CAPTION_CONTROLS_WIDTH,
+  WINDOWS_MENU_BUTTON_WIDTH,
+  WINDOWS_MENU_PANEL_WIDTH,
+  windowsMenuViewBounds
+} from '../src/main/windows-menu-view'
 
 describe('Windows titlebar menu', () => {
   it('uses a Windows-only overlay while preserving the macOS frame behavior', async () => {
@@ -32,9 +38,8 @@ describe('Windows titlebar menu', () => {
     expect(preload).toContain('padding-top: 6px !important')
     expect(preload).toContain('trackSidebarLayout(document)')
     expect(preload).toContain("document.documentElement.style.setProperty(SIDEBAR_WIDTH_PROPERTY")
-    expect(preload).toContain('background: transparent')
-    expect(preload).toContain('.safeArea::before')
-    expect(preload).toContain('height: ${WINDOWS_TITLEBAR_HEIGHT}px')
+    expect(preload).toContain("dragRegion.id = DRAG_REGION_ID")
+    expect(preload).toContain('-webkit-app-region: drag')
     expect(preload).toContain('body.dsh-desktop-windows-titlebar-layout > #root')
     expect(preload).toContain('left: 0')
     expect(preload).toContain('pointer-events: none')
@@ -48,7 +53,7 @@ describe('Windows titlebar menu', () => {
 
     expect(desktopMenuCommands).toContain('connect-phone')
     expect(desktopMenuCommands).toContain('safe-mode')
-    expect(await readFile('src/preload/windows-titlebar.ts', 'utf8')).toContain(
+    expect(await readFile('src/preload/windows-menu.ts', 'utf8')).toContain(
       "label: zh ? '以安全模式重启…' : 'Restart as Safe Mode…'"
     )
     expect(desktopMenuCommands).toContain('check-for-updates')
@@ -58,23 +63,54 @@ describe('Windows titlebar menu', () => {
     expect(isDesktopMenuCommand({ command: 'quit' })).toBe(false)
     expect(main).toContain("ipcMain.handle('desktop-menu:execute'")
     expect(main).toContain("ipcMain.handle('desktop-menu:get-zoom-factor'")
-    expect(main).toContain('event.senderFrame !== mainWindow.webContents.mainFrame')
+    expect(main).toContain('assertTrustedDesktopMenuEvent(event)')
+    expect(main).toContain('event.sender === windowsMenuView.webContents')
     expect(main).toContain('if (!isDesktopMenuCommand(command))')
   })
 
-  it('shows the live zoom percentage and counter-scales the renderer menu button', async () => {
+  it('hosts the menu in a fixed-zoom child view instead of counter-scaling Harness content', async () => {
     const main = await readFile('src/main/index.ts', 'utf8')
-    const preload = await readFile('src/preload/windows-titlebar.ts', 'utf8')
+    const layoutPreload = await readFile('src/preload/windows-titlebar.ts', 'utf8')
+    const menuPreload = await readFile('src/preload/windows-menu.ts', 'utf8')
+    const viteConfig = await readFile('electron.vite.config.ts', 'utf8')
 
     expect(formatZoomPercentage(1)).toBe('100%')
     expect(formatZoomPercentage(Math.sqrt(1.2))).toBe('110%')
     expect(formatZoomPercentage(1 / Math.sqrt(1.2))).toBe('91%')
     expect(main).toContain('contents.getZoomFactor()')
-    expect(preload).toContain("ipcRenderer.invoke('desktop-menu:get-zoom-factor')")
-    expect(preload).toContain('formatZoomPercentage(zoomFactor)')
-    expect(preload).toContain('zoom: var(${INVERSE_ZOOM_PROPERTY}, 1)')
-    expect(preload).not.toContain('border-left:')
-    expect(preload).not.toContain('border-left-color:')
+    expect(main).toContain('new WebContentsView')
+    expect(main).toContain('window.contentView.addChildView(menuView)')
+    expect(main).toContain('menuView.webContents.setZoomFactor(1)')
+    expect(main).toContain("preload: join(import.meta.dirname, '../preload/windows-menu.cjs')")
+    expect(menuPreload).toContain("ipcRenderer.invoke('desktop-menu:get-zoom-factor')")
+    expect(menuPreload).toContain('formatZoomPercentage(zoomFactor)')
+    expect(layoutPreload).not.toContain('INVERSE_ZOOM_PROPERTY')
+    expect(layoutPreload).not.toContain('menuButton')
+    expect(viteConfig).toContain("'windows-menu': resolve('src/preload/windows-menu.ts')")
+  })
+
+  it('keeps the closed menu button aligned beside native caption controls at every page zoom', () => {
+    expect(WINDOWS_CAPTION_CONTROLS_WIDTH).toBe(140)
+    expect(WINDOWS_MENU_BUTTON_WIDTH).toBe(44)
+    expect(WINDOWS_MENU_PANEL_WIDTH).toBe(304)
+
+    const closedAt100Percent = windowsMenuViewBounds({ width: 1380, height: 900 }, false)
+    const closedAt69Percent = windowsMenuViewBounds({ width: 1380, height: 900 }, false)
+    expect(closedAt100Percent).toEqual({ x: 1196, y: 0, width: 44, height: 36 })
+    expect(closedAt69Percent).toEqual(closedAt100Percent)
+
+    expect(windowsMenuViewBounds({ width: 1380, height: 900 }, true)).toEqual({
+      x: 936,
+      y: 0,
+      width: 304,
+      height: 760
+    })
+    expect(windowsMenuViewBounds({ width: 900, height: 640 }, false, true)).toEqual({
+      x: 856,
+      y: 0,
+      width: 44,
+      height: 36
+    })
   })
 
   it('shows the bundled Harness version and offers an update check from About', async () => {
@@ -91,6 +127,7 @@ describe('Windows titlebar menu', () => {
 
     expect(main).toContain('window.setTitleBarOverlay(windowsTitleBarOverlay(isDark))')
     expect(main).toContain("ipcMain.handle('desktop-titlebar:set-theme'")
+    expect(main).toContain("windowsMenuView.webContents.send('desktop-titlebar:theme-changed', isDark)")
     expect(preload).toContain("attributeFilter: ['data-ds-dark-theme', 'class', 'style']")
     expect(preload).toContain("ipcRenderer.invoke('desktop-titlebar:set-theme', isDark)")
   })


### PR DESCRIPTION
## Summary
- move the Windows application-menu button and dropdown into a dedicated `WebContentsView`
- keep that child view at zoom factor 1 and position it in fixed DIP bounds next to the native caption controls
- retain the main renderer drag region/theme synchronization while removing inverse page-zoom compensation
- add bounds and integration regression coverage, plus package the dedicated menu surface

## Verification
- `npm run typecheck`
- `npx vitest run --dir test` (48 files, 332 tests)
- `npm run build`
- `git diff --check`

## Windows validation
The implementation and fixed-DIP bounds are covered locally, but native Windows chrome is not claimed as visually validated from macOS. The PR Windows x64 workflow must pass and its dev artifact should be checked at 69% and 100% interface scale.