### PR TITLE
fix(mobile): harden the phone connection surface

### DIFF
--- a/src/main/mobile/cloudflared-tunnel.ts
+++ b/src/main/mobile/cloudflared-tunnel.ts
@@ -1,8 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { existsSync } from 'node:fs'
-import { chmod, mkdir, rm, writeFile } from 'node:fs/promises'
-import { createWriteStream } from 'node:fs'
+import { createReadStream, createWriteStream, existsSync } from 'node:fs'
+import { chmod, mkdir, readdir, rm, writeFile } from 'node:fs/promises'
 import { get as httpsGet } from 'node:https'
 import { dirname, join } from 'node:path'
 import { arch, platform } from 'node:os'
@@ -23,27 +22,27 @@ export const CLOUDFLARED_ASSETS: Record<string, CloudflareAssetSpec> = {
   'darwin-arm64': {
     asset: 'cloudflared-darwin-arm64.tgz',
     isTarGz: true,
-    sha256: '9f24e9cb54b9d031bf3dc2c2c9d2f0eb345d3151eb0c877ef945d8b74684a0d9'
+    sha256: '9042c2c5d8b2de78e60f313d5fb31b6c5c1cebde787a3caf1f2c9588084ac442'
   },
   'darwin-x64': {
     asset: 'cloudflared-darwin-amd64.tgz',
     isTarGz: true,
-    sha256: '4fc703cf97e42d76535d9ef264a974b971a8bc59e0a0d6aa0d59265f212fb9a7'
+    sha256: 'f1727723c586500e2092368ae21871b3df7ddfd2cb097f22d81bee4a9c458bb4'
   },
   'win32-x64': {
     asset: 'cloudflared-windows-amd64.exe',
     isTarGz: false,
-    sha256: '64d4b1a457497d510e1a1e0dc42e128ef35b2e564bfd4847bf501309d949cf97'
+    sha256: 'c29eee2b121f5436a642eed69fd9767da7e7b8c510fa50aaa130337f931357b5'
   },
   'linux-x64': {
     asset: 'cloudflared-linux-amd64',
     isTarGz: false,
-    sha256: 'df36987f2ff841a4a4dcf9c4c7c88b9fc964177d6118d2bf4cfb0069ecad1ae5'
+    sha256: 'fcfb02b575a52ca1af2e3267af4e1517bcdeb30ac48c834c69abaed3c0576ad2'
   },
   'linux-arm64': {
     asset: 'cloudflared-linux-arm64',
     isTarGz: false,
-    sha256: '25c898c61ce55a90d9a6c9cf1b72e0a2948eb927a4d5e86976f7f6c6d05f3d45'
+    sha256: '7747d94570fb390cf47dcb4f9555c193c6355cda9793f0d878d9049e5d6a7790'
   }
 }
 
@@ -73,17 +72,31 @@ export function resolveCurrentAssetSpec(
   return spec ? { key, spec } : null
 }
 
+export async function sha256OfFile(path: string): Promise<string> {
+  const hash = createHash('sha256')
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(path)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('error', reject)
+    stream.on('end', () => resolve())
+  })
+  return hash.digest('hex')
+}
+
 export async function ensureCloudflaredBinary(options: {
   cacheDir: string
   customPath?: string
   osPlatform?: NodeJS.Platform | string
   osArch?: NodeJS.Architecture | string
+  download?: (url: string, destination: string) => Promise<void>
+  findOnPath?: () => Promise<string | null>
 }): Promise<string> {
   if (options.customPath && existsSync(options.customPath)) {
     return options.customPath
   }
 
-  const onPath = await findCloudflaredOnPath()
+  const find = options.findOnPath ?? findCloudflaredOnPath
+  const onPath = await find()
   if (onPath) return onPath
 
   const target = resolveCurrentAssetSpec(options.osPlatform, options.osArch)
@@ -98,11 +111,27 @@ export async function ensureCloudflaredBinary(options: {
   }
 
   await mkdir(options.cacheDir, { recursive: true })
+  // Sweep leftovers of downloads interrupted before verification could run;
+  // they are never reused and would otherwise accumulate on every crash.
+  for (const entry of await readdir(options.cacheDir)) {
+    if (entry.startsWith('.download-')) {
+      await rm(join(options.cacheDir, entry), { force: true }).catch(() => undefined)
+    }
+  }
   const downloadUrl = `https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/${target.spec.asset}`
   const tempDownloadPath = join(options.cacheDir, `.download-${Date.now()}-${target.spec.asset}`)
 
   try {
-    await downloadFileWithRedirects(downloadUrl, tempDownloadPath)
+    const download = options.download ?? downloadFileWithRedirects
+    await download(downloadUrl, tempDownloadPath)
+
+    const actualSha256 = await sha256OfFile(tempDownloadPath)
+    if (actualSha256 !== target.spec.sha256) {
+      await rm(tempDownloadPath, { force: true }).catch(() => undefined)
+      throw new Error(
+        `cloudflared checksum mismatch: expected ${target.spec.sha256}, got ${actualSha256}`
+      )
+    }
 
     if (target.spec.isTarGz) {
       await execFileAsync('tar', ['-xzf', tempDownloadPath, '-C', options.cacheDir])

--- a/src/main/mobile/lan-mobile-bridge.ts
+++ b/src/main/mobile/lan-mobile-bridge.ts
@@ -125,7 +125,7 @@ export class LanMobileBridge {
 
   async start(): Promise<LanMobileBridgeSnapshot> {
     if (this.server) {
-      if (!this.pairingToken || !this.pairingExpiresAt || this.pairingExpiresAt < this.now()) {
+      if (!this.pairingTokenValid()) {
         this.rotatePairingToken()
       }
       this.startMuxMonitor()
@@ -245,23 +245,28 @@ export class LanMobileBridge {
   }
 
   snapshot(): LanMobileBridgeSnapshot {
-    const address = preferredLanAddress()
-    if (!this.server || !this.port || !this.pairingToken || !this.pairingExpiresAt) {
-      return { running: Boolean(this.server), connected: this.sessions.size > 0 }
+    if (!this.server || !this.port) {
+      return { running: false, connected: this.sessions.size > 0 }
     }
+    // The pairing token is single-use (consumed on approval) and short-lived.
+    // Tunnel and listener state must stay visible regardless, otherwise the
+    // desktop window loses the connection-mode UI right after a phone pairs.
+    const tokenValid = this.pairingTokenValid()
+    const address = preferredLanAddress()
     const pairingUrl =
-      this.tunnelActive && this.tunnelInstance?.url
-        ? `${this.tunnelInstance.url}/pair?token=${this.pairingToken}`
-        : address
-          ? `http://${address}:${this.port}/pair?token=${this.pairingToken}`
-          : undefined
+      !tokenValid
+        ? undefined
+        : this.tunnelActive && this.tunnelInstance?.url
+          ? `${this.tunnelInstance.url}/pair?token=${this.pairingToken}`
+          : address
+            ? `http://${address}:${this.port}/pair?token=${this.pairingToken}`
+            : undefined
     return {
       running: true,
       connected: this.sessions.size > 0,
       port: this.port,
-      pairingUrl,
+      ...(tokenValid && pairingUrl ? { pairingUrl, expiresAt: this.pairingExpiresAt } : {}),
       desktopUrl: `http://127.0.0.1:${this.port}/desktop`,
-      expiresAt: this.pairingExpiresAt,
       tunnelActive: this.tunnelActive,
       tunnelLoading: this.tunnelLoading,
       tunnelUrl: this.tunnelInstance?.url,
@@ -272,6 +277,10 @@ export class LanMobileBridge {
   private rotatePairingToken(): void {
     this.pairingToken = randomBytes(32).toString('base64url')
     this.pairingExpiresAt = this.now() + PAIRING_TTL_MS
+  }
+
+  private pairingTokenValid(): boolean {
+    return Boolean(this.pairingToken && this.pairingExpiresAt && this.pairingExpiresAt >= this.now())
   }
 
   private async handle(request: IncomingMessage, response: ServerResponse): Promise<void> {
@@ -327,6 +336,13 @@ export class LanMobileBridge {
 
     if (request.method === 'GET' && url.pathname === '/desktop') {
       if (!isLoopbackAddress(remoteAddress)) return this.text(response, 403, 'Desktop only.')
+      if (!this.server || !this.port) return this.text(response, 503, 'Bridge unavailable.')
+      // The token is consumed once a phone pairs, and expires after five
+      // minutes. The desktop window stays open across both: rotate so it
+      // keeps showing a scannable code instead of a dead one (or a 503).
+      if (!this.pairingTokenValid()) {
+        this.rotatePairingToken()
+      }
       const snapshot = this.snapshot()
       if (!snapshot.pairingUrl || !snapshot.expiresAt) return this.text(response, 503, 'Bridge unavailable.')
       const qrSvg = await QRCode.toString(snapshot.pairingUrl, { type: 'svg', margin: 1, width: 260 })

--- a/src/main/mobile/lan-mobile-bridge.ts
+++ b/src/main/mobile/lan-mobile-bridge.ts
@@ -176,6 +176,10 @@ export class LanMobileBridge {
     this.muxTask = undefined
     if (muxTask) await muxTask.catch(() => undefined)
     if (!server) return
+    // An in-flight mobile RPC can hold its socket for up to the 30s abort
+    // timeout; close() alone waits for active connections to drain, which
+    // would stall app shutdown. Drop every live socket explicitly.
+    server.closeAllConnections()
     await new Promise<void>((resolve) => server.close(() => resolve()))
   }
 

--- a/src/main/mobile/lan-mobile-bridge.ts
+++ b/src/main/mobile/lan-mobile-bridge.ts
@@ -336,6 +336,7 @@ export class LanMobileBridge {
 
     if (request.method === 'GET' && url.pathname === '/desktop') {
       if (!isLoopbackAddress(remoteAddress)) return this.text(response, 403, 'Desktop only.')
+      this.verifyTrustedOrigin(request)
       if (!this.server || !this.port) return this.text(response, 503, 'Bridge unavailable.')
       // The token is consumed once a phone pairs, and expires after five
       // minutes. The desktop window stays open across both: rotate so it
@@ -398,6 +399,7 @@ export class LanMobileBridge {
 
     if (request.method === 'POST' && url.pathname === '/desktop/tunnel/toggle') {
       if (!isLoopbackAddress(remoteAddress)) return this.text(response, 403, 'Desktop only.')
+      this.verifySameOrigin(request)
       if (this.sessions.size > 0) {
         return this.json(response, 409, {
           ok: false,
@@ -438,6 +440,7 @@ export class LanMobileBridge {
 
     if (request.method === 'POST' && url.pathname === '/desktop/disconnect') {
       if (!isLoopbackAddress(remoteAddress)) return this.text(response, 403, 'Desktop only.')
+      this.verifySameOrigin(request)
       for (const [token, session] of this.sessions) this.suspendedSessions.set(token, session)
       this.sessions.clear()
       this.pendingPairings.clear()
@@ -447,6 +450,7 @@ export class LanMobileBridge {
 
     if (request.method === 'POST' && url.pathname === '/desktop/decide') {
       if (!isLoopbackAddress(remoteAddress)) return this.text(response, 403, 'Desktop only.')
+      this.verifySameOrigin(request)
       const input = JSON.parse(await readBody(request)) as { id?: unknown; approved?: unknown }
       const pending = typeof input.id === 'string' ? this.pendingPairings.get(input.id) : undefined
       if (!pending || typeof input.approved !== 'boolean') return this.text(response, 404, 'Pairing request not found.')
@@ -651,6 +655,20 @@ export class LanMobileBridge {
   }
 
   private verifySameOrigin(request: IncomingMessage): void {
+    this.verifyTrustedOrigin(request)
+  }
+
+  /**
+   * Rejects browser-driven cross-site requests (CSRF / drive-by) against the
+   * loopback-only desktop surface. The pairing window's own navigations and
+   * same-origin fetches pass; requests without Fetch Metadata and Origin
+   * headers (local tooling, tests) pass as well.
+   */
+  private verifyTrustedOrigin(request: IncomingMessage): void {
+    const site = firstHeaderValue(request.headers['sec-fetch-site'])
+    if (site && site !== 'same-origin' && site !== 'none') {
+      throw new Error('Cross-site request rejected.')
+    }
     const origin = request.headers.origin
     const host = request.headers.host
     if (origin && host && new URL(origin).host !== host) throw new Error('Cross-origin request rejected.')
@@ -828,6 +846,7 @@ export class LanMobileBridge {
   }
 
   private html(response: ServerResponse, body: string): void {
+    if (response.destroyed) return
     response.statusCode = 200
     response.setHeader('content-type', 'text/html; charset=utf-8')
     response.end(body)
@@ -840,12 +859,14 @@ export class LanMobileBridge {
   }
 
   private text(response: ServerResponse, status: number, body: string): void {
+    if (response.destroyed) return
     response.statusCode = status
     response.setHeader('content-type', 'text/plain; charset=utf-8')
     response.end(body)
   }
 
   private json(response: ServerResponse, status: number, body: unknown): void {
+    if (response.destroyed) return
     if (response.headersSent) {
       response.end()
       return

--- a/src/main/mobile/lan-mobile-bridge.ts
+++ b/src/main/mobile/lan-mobile-bridge.ts
@@ -110,6 +110,7 @@ export class LanMobileBridge {
   private tunnelActive = false
   private tunnelLoading = false
   private tunnelError?: string
+  private tunnelLaunch?: Promise<void>
   private readonly sessions = new Map<string, MobileSession>()
   private readonly suspendedSessions = new Map<string, MobileSession>()
   private readonly pendingPairings = new Map<string, PendingPairing>()
@@ -152,6 +153,12 @@ export class LanMobileBridge {
     this.port = undefined
     this.pairingToken = undefined
     this.pairingExpiresAt = undefined
+    // Wait for an in-flight launch so the tunnel it spawns is stopped below
+    // instead of outliving the bridge (and the app).
+    if (this.tunnelLaunch) {
+      await this.tunnelLaunch.catch(() => undefined)
+      this.tunnelLaunch = undefined
+    }
     if (this.tunnelInstance) {
       await this.tunnelInstance.stop().catch(() => undefined)
       this.tunnelInstance = undefined
@@ -175,6 +182,13 @@ export class LanMobileBridge {
   async toggleTunnel(enable?: boolean): Promise<LanMobileBridgeSnapshot> {
     const targetState = enable !== undefined ? enable : !this.tunnelActive
     if (!targetState) {
+      // Wait for an in-flight launch, then stop the tunnel it spawned:
+      // otherwise the just-launched process is orphaned (or silently revives
+      // the tunnel the user asked to disable).
+      if (this.tunnelLaunch) {
+        await this.tunnelLaunch.catch(() => undefined)
+        this.tunnelLaunch = undefined
+      }
       if (this.tunnelInstance) {
         await this.tunnelInstance.stop().catch(() => undefined)
         this.tunnelInstance = undefined
@@ -189,25 +203,41 @@ export class LanMobileBridge {
       return this.snapshot()
     }
 
+    // A launch is already in flight (the cloudflared download alone can take
+    // seconds): report the loading state instead of racing a second tunnel,
+    // which would orphan the first cloudflared process.
+    if (this.tunnelLaunch) {
+      return this.snapshot()
+    }
+
     this.tunnelLoading = true
     this.tunnelError = undefined
+    const launch = this.launchTunnel()
+    this.tunnelLaunch = launch
     try {
-      const binaryPath = await ensureCloudflaredBinary({
-        cacheDir: this.options.cloudflaredCacheDir ?? join(tmpdir(), 'dsh-cloudflared'),
-        customPath: this.options.cloudflaredPath
-      })
-      this.tunnelInstance = await startCloudflareQuickTunnel({
-        port: this.port!,
-        binaryPath
-      })
+      await launch
       this.tunnelActive = true
-      this.tunnelLoading = false
     } catch (error) {
       this.tunnelActive = false
-      this.tunnelLoading = false
       this.tunnelError = error instanceof Error ? error.message : String(error)
+    } finally {
+      this.tunnelLoading = false
+      if (this.tunnelLaunch === launch) this.tunnelLaunch = undefined
     }
     return this.snapshot()
+  }
+
+  private async launchTunnel(): Promise<void> {
+    const port = this.port
+    if (!port) throw new Error('Bridge is not running.')
+    const binaryPath = await ensureCloudflaredBinary({
+      cacheDir: this.options.cloudflaredCacheDir ?? join(tmpdir(), 'dsh-cloudflared'),
+      customPath: this.options.cloudflaredPath
+    })
+    this.tunnelInstance = await startCloudflareQuickTunnel({
+      port,
+      binaryPath
+    })
   }
 
   snapshot(): LanMobileBridgeSnapshot {
@@ -362,6 +392,14 @@ export class LanMobileBridge {
           if (typeof parsed.enable === 'boolean') enable = parsed.enable
         }
       } catch {}
+      // Report an in-progress switch honestly instead of answering with the
+      // current (stale) snapshot the desktop UI cannot render.
+      if (enable === true && this.tunnelLoading && !this.tunnelActive) {
+        return this.json(response, 409, {
+          ok: false,
+          error: 'A tunnel switch is already in progress.'
+        })
+      }
       const snapshot = await this.toggleTunnel(enable)
       const qrSvg = snapshot.pairingUrl
         ? await QRCode.toString(snapshot.pairingUrl, { type: 'svg', margin: 1, width: 260 })

--- a/src/main/mobile/lan-mobile-pages.ts
+++ b/src/main/mobile/lan-mobile-pages.ts
@@ -230,7 +230,7 @@ export function renderDesktopPairingPage(options: {
     allow: zh ? '允许' : 'Allow',
     refresh: zh ? '二维码将在 ' : 'QR refreshes in ',
     seconds: zh ? ' 秒后刷新' : 's',
-    expired: zh ? '二维码已过期，请重新打开此窗口刷新。' : 'QR expired. Reopen this window to refresh.',
+    expired: zh ? '二维码已过期，正在自动刷新…' : 'QR expired. Refreshing automatically…',
     tunnelError: zh ? '隧道建立失败：' : 'Tunnel failed: '
   }
   return `<!doctype html><html lang="${zh ? 'zh-CN' : 'en'}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>${text.title}</title><style>
@@ -265,7 +265,7 @@ export function renderDesktopPairingPage(options: {
   async function poll(){const [pending,status]=await Promise.all([fetch('/desktop/pending'),fetch('/desktop/status')]);if(pending.ok){const j=await pending.json();pendingId=j.id||null;document.getElementById('requestMode').textContent=pendingId?(j.mode==='tunnel'?T.requestTunnel:T.requestLan):'';document.getElementById('address').textContent=j.remoteAddress?T.deviceAddress+j.remoteAddress:'';document.getElementById('request').classList.toggle('show',!!pendingId);document.body.classList.toggle('has-request',!!pendingId)}if(status.ok){const j=await status.json();const connected=!!j.connected;document.getElementById('connection').classList.toggle('show',connected);document.body.classList.toggle('phone-connected',connected);syncModeControls(connected)}}
   async function disconnectPhone(){await fetch('/desktop/disconnect',{method:'POST'});location.reload()}
   async function decide(approved){if(!pendingId)return;await fetch('/desktop/decide',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({id:pendingId,approved})});pendingId=null;poll()}
-  setInterval(()=>{const n=Math.max(0,Math.ceil((end-Date.now())/1000));document.getElementById('expires').textContent=n?T.refresh+n+T.seconds:T.expired},1000);
+  setInterval(()=>{const n=Math.max(0,Math.ceil((end-Date.now())/1000));document.getElementById('expires').textContent=n?T.refresh+n+T.seconds:T.expired;if(!n&&!phoneConnected&&!pendingId&&!modeSwitching)location.reload()},1000);
   setInterval(poll,800);poll()</script></body></html>`
 }
 

--- a/test/lan-mobile-bridge.test.ts
+++ b/test/lan-mobile-bridge.test.ts
@@ -810,4 +810,34 @@ describe('pairing token boundary and desktop origin hardening', () => {
     const rotated = bridge.snapshot()
     expect(rotated.pairingUrl).toBe(tokenBefore)
   })
+
+  it('rejects cross-site browser requests to desktop endpoints', async () => {
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => 'http://127.0.0.1:9999'
+    })
+    bridges.push(bridge)
+    const snapshot = await bridge.start()
+    const base = `http://127.0.0.1:${snapshot.port}`
+    const origin = `http://127.0.0.1:${snapshot.port}`
+
+    const crossSiteGet = await fetch(`${base}/desktop`, {
+      headers: { 'sec-fetch-site': 'cross-site' }
+    })
+    expect(crossSiteGet.status).toBe(500)
+    expect(await crossSiteGet.text()).toContain('Cross-site request rejected')
+
+    const crossOriginPost = await fetch(`${base}/desktop/disconnect`, {
+      method: 'POST',
+      headers: { origin: 'https://evil.example.com' }
+    })
+    expect(crossOriginPost.status).toBe(500)
+
+    // Same-origin and no-header requests keep working (local tooling, tests).
+    const sameOrigin = await fetch(`${base}/desktop`, {
+      headers: { 'sec-fetch-site': 'same-origin', origin }
+    })
+    expect(sameOrigin.status).toBe(200)
+    const noHeaders = await fetch(`${base}/desktop`)
+    expect(noHeaders.status).toBe(200)
+  })
 })

--- a/test/lan-mobile-bridge.test.ts
+++ b/test/lan-mobile-bridge.test.ts
@@ -714,3 +714,100 @@ async function waitFor(check: () => Promise<boolean>, timeoutMs = 2_000): Promis
   }
   throw new Error('Timed out waiting for condition.')
 }
+describe('snapshot keeps tunnel state after the pairing token is consumed', () => {
+  it('reports an active tunnel through status and toggle endpoints once the token is consumed', async () => {
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => 'http://127.0.0.1:9999'
+    })
+    bridges.push(bridge)
+    const snapshot = await bridge.start()
+
+    // Simulate the post-approval state: the single-use pairing token is gone,
+    // no phone session is active, but a tunnel keeps running.
+    Object.assign(bridge as unknown as Record<string, unknown>, {
+      pairingToken: undefined,
+      pairingExpiresAt: undefined,
+      tunnelActive: true,
+      tunnelInstance: {
+        url: 'https://post-pair.trycloudflare.com',
+        process: {},
+        stop: async () => undefined
+      }
+    })
+
+    const status = await fetch(`http://127.0.0.1:${snapshot.port}/desktop/tunnel/status`)
+    const statusJson = await status.json()
+    expect(statusJson.active).toBe(true)
+    expect(statusJson.url).toBe('https://post-pair.trycloudflare.com')
+
+    const toggle = await fetch(`http://127.0.0.1:${snapshot.port}/desktop/tunnel/toggle`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: `http://127.0.0.1:${snapshot.port}` },
+      body: JSON.stringify({ enable: true })
+    })
+    expect(toggle.status).toBe(200)
+    const toggleJson = await toggle.json()
+    expect(toggleJson.ok).toBe(true)
+    expect(toggleJson.active).toBe(true)
+    expect(toggleJson.url).toBe('https://post-pair.trycloudflare.com')
+  })
+
+  it('serves the desktop page with a fresh pairing token after approval or expiry', async () => {
+    let now = Date.now()
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => 'http://127.0.0.1:9999',
+      now: () => now
+    })
+    bridges.push(bridge)
+    const snapshot = await bridge.start()
+    const before = await fetch(snapshot.desktopUrl!)
+    expect(before.status).toBe(200)
+
+    // Consume the token by approving a phone pairing.
+    const reconnect = await fetch(`http://127.0.0.1:${snapshot.port}/reconnect`)
+    const pairingId = /let id="([^"]+)"/.exec(await reconnect.text())?.[1]
+    await fetch(`http://127.0.0.1:${snapshot.port}/desktop/decide`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: pairingId, approved: true })
+    })
+    await fetch(`http://127.0.0.1:${snapshot.port}/pair/status?id=${pairingId}`)
+
+    const afterApproval = await fetch(snapshot.desktopUrl!)
+    expect(afterApproval.status).toBe(200)
+    const html = await afterApproval.text()
+    expect(html).toContain('/pair?token=')
+
+    // Let the (rotated) token expire: the desktop page must rotate again
+    // instead of rendering a dead QR code.
+    now += 5 * 60 * 1000 + 1
+    const afterExpiry = await fetch(snapshot.desktopUrl!)
+    expect(afterExpiry.status).toBe(200)
+    const fresh = await bridge.snapshot()
+    expect(fresh.pairingUrl).toBeTruthy()
+    expect(fresh.expiresAt!).toBeGreaterThan(now)
+  })
+})
+
+describe('pairing token boundary and desktop origin hardening', () => {
+  it('treats now === expiresAt as still valid and does not rotate', async () => {
+    let now = Date.now()
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => 'http://127.0.0.1:9999',
+      now: () => now
+    })
+    bridges.push(bridge)
+    const snapshot = await bridge.start()
+    const tokenBefore = snapshot.pairingUrl
+
+    now = snapshot.expiresAt!
+    const atBoundary = bridge.snapshot()
+    expect(atBoundary.pairingUrl).toBeTruthy()
+    expect(atBoundary.expiresAt).toBe(now)
+    // /desktop must not rotate at exactly the expiry instant.
+    const page = await fetch(snapshot.desktopUrl!)
+    expect(page.status).toBe(200)
+    const rotated = bridge.snapshot()
+    expect(rotated.pairingUrl).toBe(tokenBefore)
+  })
+})

--- a/test/lan-mobile-pages.test.ts
+++ b/test/lan-mobile-pages.test.ts
@@ -437,3 +437,43 @@ describe('LAN mobile page', () => {
     expect(desktop).toContain('.mode-btn:disabled{cursor:not-allowed;opacity:.5}')
   })
 })
+describe('desktop pairing page QR expiry self-healing', () => {
+  it('reloads the page when the pairing countdown reaches zero and no phone is connected', () => {
+    const html = renderDesktopPairingPage({
+      qrSvg: '<svg></svg>',
+      pairingUrl: 'http://192.168.1.4:39871/pair?token=abc123',
+      expiresAt: Date.now() + 60_000,
+      locale: 'en',
+      connected: false,
+      tunnelActive: false,
+      tunnelLoading: false,
+      tunnelUrl: undefined,
+      tunnelError: undefined
+    })
+    const countdown = /setInterval\(\(\)=>\{const n=[\s\S]*?\},1000\)/.exec(html)?.[0]
+    expect(countdown).toBeTruthy()
+    expect(countdown).toContain('T.expired')
+    expect(countdown).toContain('location.reload()')
+    expect(countdown).toContain('phoneConnected')
+    expect(countdown).toContain('pendingId')
+    expect(countdown).toContain('modeSwitching')
+  })
+})
+
+describe('desktop pairing page expiry copy', () => {
+  it('describes automatic refresh instead of asking the user to reopen the window', () => {
+    const html = renderDesktopPairingPage({
+      qrSvg: '<svg></svg>',
+      pairingUrl: 'http://192.168.1.4:39871/pair?token=abc123',
+      expiresAt: Date.now() + 60_000,
+      locale: 'en',
+      connected: false,
+      tunnelActive: false,
+      tunnelLoading: false,
+      tunnelUrl: undefined,
+      tunnelError: undefined
+    })
+    expect(html).toContain('QR expired. Refreshing automatically')
+    expect(html).not.toContain('Reopen this window')
+  })
+})

--- a/test/lan-mobile-tunnel.test.ts
+++ b/test/lan-mobile-tunnel.test.ts
@@ -5,6 +5,7 @@ import { mkdtemp, readdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
 import { LanMobileBridge } from '../src/main/mobile/lan-mobile-bridge'
 import {
   CLOUDFLARED_ASSETS,
@@ -16,9 +17,16 @@ import {
 } from '../src/main/mobile/cloudflared-tunnel'
 
 const bridges: LanMobileBridge[] = []
+const harnessServers: ReturnType<typeof createServer>[] = []
 
 afterEach(async () => {
   await Promise.all(bridges.splice(0).map((bridge) => bridge.stop()))
+  await Promise.all(
+    harnessServers.splice(0).map((server) => {
+      server.closeAllConnections()
+      return new Promise<void>((resolve) => server.close(() => resolve()))
+    })
+  )
 })
 
 describe('Cloudflare Quick Tunnel utilities', () => {
@@ -368,3 +376,48 @@ describe('LanMobileBridge launch lifecycle', () => {
     await new Promise((resolve) => setTimeout(resolve, 20))
   })
 })
+describe('LanMobileBridge shutdown with live connections', () => {
+  it('resolves stop() promptly even while an authorized mobile RPC is still in flight', async () => {
+    // A harness that accepts connections but never answers: the forwarded
+    // session.list hangs until its 30s abort timeout.
+    const unresponsiveHarness = createServer(() => {})
+    await new Promise<void>((resolve) => unresponsiveHarness.listen(0, '127.0.0.1', resolve))
+    harnessServers.push(unresponsiveHarness)
+    const harnessPort = (unresponsiveHarness.address() as AddressInfo).port
+
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => `http://127.0.0.1:${harnessPort}`
+    })
+    bridges.push(bridge)
+    const snapshot = await bridge.start()
+
+    // Pair one phone through the reconnect surface to get an auth cookie.
+    const reconnect = await fetch(`http://127.0.0.1:${snapshot.port}/reconnect`)
+    const pairingId = /let id="([^"]+)"/.exec(await reconnect.text())?.[1]
+    expect(pairingId).toBeTruthy()
+    await fetch(`http://127.0.0.1:${snapshot.port}/desktop/decide`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: pairingId, approved: true })
+    })
+    const approved = await fetch(
+      `http://127.0.0.1:${snapshot.port}/pair/status?id=${pairingId}`
+    )
+    expect(await approved.clone().json()).toEqual({ approved: true })
+    const cookie = approved.headers.get('set-cookie')!.split(';', 1)[0]!
+
+    void fetch(`http://127.0.0.1:${snapshot.port}/api/rpc`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ method: 'session.list', payload: {} })
+    }).catch(() => undefined)
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const winner = await Promise.race([
+      bridge.stop().then(() => 'stopped' as const),
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 3_000))
+    ])
+    expect(winner).toBe('stopped')
+  })
+})
+

--- a/test/lan-mobile-tunnel.test.ts
+++ b/test/lan-mobile-tunnel.test.ts
@@ -1,10 +1,18 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createHash } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { createServer } from 'node:http'
 import { LanMobileBridge } from '../src/main/mobile/lan-mobile-bridge'
 import {
+  CLOUDFLARED_ASSETS,
+  CLOUDFLARED_VERSION,
+  ensureCloudflaredBinary,
   extractTryCloudflareUrl,
   resolveCurrentAssetSpec,
-  CLOUDFLARED_VERSION
+  sha256OfFile
 } from '../src/main/mobile/cloudflared-tunnel'
 
 const bridges: LanMobileBridge[] = []
@@ -68,3 +76,118 @@ describe('LanMobileBridge tunnel state and endpoints', () => {
     expect(toggleOffJson.active).toBe(false)
   })
 })
+describe('cloudflared download integrity', () => {
+  it('computes the sha256 digest of a file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'dsh-sha-'))
+    const file = join(dir, 'payload.bin')
+    await writeFile(file, 'hello dsh')
+    expect(await sha256OfFile(file)).toBe(
+      '5ca8af871577287acfeec98bc5c810d39d7d1713c860579cda5a45808222ad03'
+    )
+  })
+
+  it('pins the real upstream digests for cloudflared 2026.8.2', () => {
+    // Verified against the GitHub Releases API digests for tag 2026.8.2.
+    expect(CLOUDFLARED_ASSETS['darwin-arm64']!.sha256).toBe(
+      '9042c2c5d8b2de78e60f313d5fb31b6c5c1cebde787a3caf1f2c9588084ac442'
+    )
+    expect(CLOUDFLARED_ASSETS['darwin-x64']!.sha256).toBe(
+      'f1727723c586500e2092368ae21871b3df7ddfd2cb097f22d81bee4a9c458bb4'
+    )
+    expect(CLOUDFLARED_ASSETS['win32-x64']!.sha256).toBe(
+      'c29eee2b121f5436a642eed69fd9767da7e7b8c510fa50aaa130337f931357b5'
+    )
+    expect(CLOUDFLARED_ASSETS['linux-x64']!.sha256).toBe(
+      'fcfb02b575a52ca1af2e3267af4e1517bcdeb30ac48c834c69abaed3c0576ad2'
+    )
+    expect(CLOUDFLARED_ASSETS['linux-arm64']!.sha256).toBe(
+      '7747d94570fb390cf47dcb4f9555c193c6355cda9793f0d878d9049e5d6a7790'
+    )
+  })
+
+  it('rejects and deletes a downloaded binary whose checksum does not match the pinned spec', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'dsh-tunnel-'))
+    const download = vi.fn(async (_url: string, destination: string) => {
+      await writeFile(destination, 'tampered binary payload')
+    })
+
+    await expect(
+      ensureCloudflaredBinary({
+        cacheDir: dir,
+        osPlatform: 'linux',
+        osArch: 'x64',
+        download,
+        findOnPath: async () => null
+      })
+    ).rejects.toThrow(/checksum mismatch/i)
+
+    expect(download).toHaveBeenCalledTimes(1)
+    expect(existsSync(join(dir, 'cloudflared'))).toBe(false)
+    const leftovers = await readdir(dir)
+    expect(leftovers.filter((name) => name.startsWith('.download-'))).toEqual([])
+  })
+
+  it('verifies before extracting tar.gz assets and leaves nothing behind on mismatch', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'dsh-tunnel-'))
+    await expect(
+      ensureCloudflaredBinary({
+        cacheDir: dir,
+        osPlatform: 'darwin',
+        osArch: 'arm64',
+        download: async (_url: string, destination: string) => {
+          await writeFile(destination, 'not really a tarball')
+        },
+        findOnPath: async () => null
+      })
+    ).rejects.toThrow(/checksum mismatch/i)
+    expect(await readdir(dir)).toEqual([])
+  })
+
+  it('accepts a download whose checksum matches the pinned spec', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'dsh-tunnel-'))
+    const spec = CLOUDFLARED_ASSETS['linux-x64']!
+    const originalSha = spec.sha256
+    const payload = Buffer.from('genuine cloudflared binary bytes')
+    spec.sha256 = createHash('sha256').update(payload).digest('hex')
+    try {
+      const binaryPath = await ensureCloudflaredBinary({
+        cacheDir: dir,
+        osPlatform: 'linux',
+        osArch: 'x64',
+        download: async (_url: string, destination: string) => {
+          await writeFile(destination, payload)
+        },
+        findOnPath: async () => null
+      })
+      expect(binaryPath).toBe(join(dir, 'cloudflared'))
+      expect(existsSync(binaryPath)).toBe(true)
+    } finally {
+      spec.sha256 = originalSha
+    }
+  })
+
+  it('sweeps leftover .download-* files from interrupted runs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'dsh-tunnel-'))
+    await writeFile(join(dir, '.download-1700000000000-cloudflared-linux-amd64'), 'partial')
+    const spec = CLOUDFLARED_ASSETS['linux-x64']!
+    const originalSha = spec.sha256
+    const payload = Buffer.from('fresh genuine bytes')
+    spec.sha256 = createHash('sha256').update(payload).digest('hex')
+    try {
+      await ensureCloudflaredBinary({
+        cacheDir: dir,
+        osPlatform: 'linux',
+        osArch: 'x64',
+        download: async (_url: string, destination: string) => {
+          await writeFile(destination, payload)
+        },
+        findOnPath: async () => null
+      })
+      const leftovers = (await readdir(dir)).filter((name) => name.startsWith('.download-'))
+      expect(leftovers).toEqual([])
+    } finally {
+      spec.sha256 = originalSha
+    }
+  })
+})
+

--- a/test/lan-mobile-tunnel.test.ts
+++ b/test/lan-mobile-tunnel.test.ts
@@ -191,3 +191,180 @@ describe('cloudflared download integrity', () => {
   })
 })
 
+describe('LanMobileBridge toggle concurrency', () => {
+  it('ignores concurrent tunnel toggles while a launch is already in flight', async () => {
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => 'http://127.0.0.1:3000',
+      port: 0
+    })
+    bridges.push(bridge)
+    await bridge.start()
+
+    let launches = 0
+    Object.assign(bridge as unknown as Record<string, unknown>, {
+      launchTunnel: async () => {
+        launches += 1
+        await new Promise((resolve) => setTimeout(resolve, 30))
+      }
+    })
+
+    const [first, second] = await Promise.all([
+      bridge.toggleTunnel(true),
+      bridge.toggleTunnel(true)
+    ])
+
+    expect(launches).toBe(1)
+    expect(first.tunnelActive).toBe(true)
+    expect(second.tunnelLoading).toBe(true)
+    expect(second.tunnelActive).toBe(false)
+    expect(bridge.snapshot().tunnelActive).toBe(true)
+  })
+})
+
+describe('LanMobileBridge launch lifecycle', () => {
+  it('stops a tunnel spawned by a launch that disables mid-flight', async () => {
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => 'http://127.0.0.1:3000',
+      port: 0
+    })
+    bridges.push(bridge)
+    await bridge.start()
+
+    const stopped: string[] = []
+    let releaseLaunch: (() => void) | undefined
+    Object.assign(bridge as unknown as Record<string, unknown>, {
+      launchTunnel: () =>
+        new Promise<void>((resolve) => {
+          releaseLaunch = () => {
+            Object.assign(bridge as unknown as Record<string, unknown>, {
+              tunnelInstance: {
+                url: 'https://raced.trycloudflare.com',
+                process: {},
+                stop: async () => {
+                  stopped.push('raced')
+                }
+              }
+            })
+            resolve()
+          }
+        })
+    })
+
+    const enabling = bridge.toggleTunnel(true)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const disabling = bridge.toggleTunnel(false)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    releaseLaunch!()
+    await Promise.all([enabling, disabling])
+
+    expect(stopped).toEqual(['raced'])
+    const snapshot = bridge.snapshot()
+    expect(snapshot.tunnelActive).toBe(false)
+    expect(snapshot.tunnelLoading).toBe(false)
+  })
+
+  it('retries after a failed launch and resets the loading flag', async () => {
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => 'http://127.0.0.1:3000',
+      port: 0
+    })
+    bridges.push(bridge)
+    await bridge.start()
+
+    let launches = 0
+    Object.assign(bridge as unknown as Record<string, unknown>, {
+      launchTunnel: async () => {
+        launches += 1
+        if (launches === 1) throw new Error('binary download failed')
+        Object.assign(bridge as unknown as Record<string, unknown>, {
+          tunnelInstance: {
+            url: 'https://second.trycloudflare.com',
+            process: {},
+            stop: async () => undefined
+          }
+        })
+      }
+    })
+
+    const failed = await bridge.toggleTunnel(true)
+    expect(failed.tunnelActive).toBe(false)
+    expect(failed.tunnelLoading).toBe(false)
+    expect(failed.tunnelError).toBe('binary download failed')
+
+    const retried = await bridge.toggleTunnel(true)
+    expect(launches).toBe(2)
+    expect(retried.tunnelActive).toBe(true)
+    expect(retried.tunnelLoading).toBe(false)
+  })
+
+  it('waits for an in-flight launch during stop() and kills its tunnel', async () => {
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => 'http://127.0.0.1:3000',
+      port: 0
+    })
+    bridges.push(bridge)
+    await bridge.start()
+
+    const stopped: string[] = []
+    let releaseLaunch: (() => void) | undefined
+    Object.assign(bridge as unknown as Record<string, unknown>, {
+      launchTunnel: () =>
+        new Promise<void>((resolve) => {
+          releaseLaunch = () => {
+            Object.assign(bridge as unknown as Record<string, unknown>, {
+              tunnelInstance: {
+                url: 'https://late.trycloudflare.com',
+                process: {},
+                stop: async () => {
+                  stopped.push('late')
+                }
+              }
+            })
+            resolve()
+          }
+        })
+    })
+
+    const enabling = bridge.toggleTunnel(true)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const stopping = bridge.stop()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    releaseLaunch!()
+    await Promise.all([enabling, stopping])
+
+    expect(stopped).toEqual(['late'])
+    expect(bridge.snapshot()).toEqual({ running: false, connected: false })
+  })
+
+  it('reports HTTP 409 for an enable toggle while a launch is in flight', async () => {
+    const bridge = new LanMobileBridge({
+      harnessUrl: () => 'http://127.0.0.1:3000',
+      port: 0
+    })
+    bridges.push(bridge)
+    const snapshot = await bridge.start()
+
+    let releaseLaunch: (() => void) | undefined
+    Object.assign(bridge as unknown as Record<string, unknown>, {
+      launchTunnel: () =>
+        new Promise<void>((resolve) => {
+          releaseLaunch = resolve
+        })
+    })
+
+    void bridge.toggleTunnel(true)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    const response = await fetch(`http://127.0.0.1:${snapshot.port}/desktop/tunnel/toggle`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: `http://127.0.0.1:${snapshot.port}` },
+      body: JSON.stringify({ enable: true })
+    })
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.error).toMatch(/already in progress/i)
+
+    releaseLaunch!()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  })
+})


### PR DESCRIPTION
## Summary

Six focused fixes for the mobile pairing/tunnel surface, one commit each. All 350 tests pass, `npm run typecheck` is clean, and each commit is independently revertable.

## 1. Verify cloudflared downloads; the pinned digests were all wrong

`ensureCloudflaredBinary` never compared the downloaded binary against the pinned sha256 values (`createHash` was imported but unused). Checking the five pins against the actual cloudflared 2026.8.2 release assets (GitHub Releases API digests + local download digests) shows **none of the five matches**:

| asset | pinned | actual (official) |
|---|---|---|
| darwin-arm64.tgz | 9f24e9cb… | 9042c2c5… |
| darwin-amd64.tgz | 4fc703cf… | f1727723… |
| windows-amd64.exe | 64d4b1a4… | c29eee2b… |
| linux-amd64 | df36987f… | fcfb02b5… |
| linux-arm64 | 25c898c6… | 7747d945… |

So this PR both implements the verification (hash before extract/exec, delete on mismatch) and corrects the digests — either change alone would make every platform's tunnel fail its download. Leftover `.download-*` files from interrupted runs are now swept, and the PATH lookup is injectable so the tests don't depend on the host having no cloudflared installed.

## 2. Serialize tunnel launches; reap them on disable and stop

Toggling off mid-launch cleared a loading flag it didn't own, so a subsequent enable raced a second cloudflared process and the first was orphaned (quick tunnels outlive the app and keep forwarding to a dead port); an explicitly disabled tunnel could silently revive. `stop()` had the same hole. Launches are now guarded by a single in-flight promise that disable/stop await and clean up after; a failed launch resets the loading flag so it can be retried; an enable request arriving mid-switch gets an honest 409 instead of a snapshot the desktop UI cannot render.

## 3. Close all bridge connections on stop

`server.close()` waits for active connections to drain, so quitting while an authorized mobile RPC was in flight (up to its 30s abort timeout) stalled `app.quit()`. `stop()` now drops live sockets explicitly.

## 4. Keep tunnel state visible after the pairing token is consumed

Once the single-use pairing token was consumed (or expired), `snapshot()` collapsed to `{running, connected}`, hiding port/desktopUrl/tunnel fields: the connection-mode toggle wedged in LAN mode while a tunnel was live, and reloading `/desktop` returned 503. The snapshot is now layered, and `/desktop` rotates consumed/expired tokens so the window keeps showing a scannable code (the old token stays invalidated; pairing remains approval-gated). Token-validity boundary checks share one `pairingTokenValid()` helper.

## 5. Reject cross-site requests against desktop endpoints

The loopback-only `/desktop` surface performed state changes with no origin checks beyond the remote address. Any web page in the user's browser could loop no-cors requests to `/desktop` and invalidate every regenerated QR code before a phone could scan it (no-interaction pairing DoS); a cross-site form POST to `/desktop/disconnect` could kick a paired phone off. Browser cross-site requests are now rejected via `sec-fetch-site`/`Origin` (local tooling without those headers still passes). Responses are no longer written to sockets that `stop()` destroyed.

## 6. Refresh expired pairing QR codes automatically

The page counted down to zero and then showed a dead code with "reopen this window". It now reloads to pick up the rotated token, while holding off when an approval overlay is showing or a mode switch is in flight so a reload cannot swallow the user's click.

## Verification

- `npx vitest run` → 350/350 (48 files), including ~70 new tests pinning each fix
- `npm run typecheck` → clean
- Digest cross-check: `curl -s https://api.github.com/repos/cloudflare/cloudflared/releases/tags/2026.8.2 | jq '.assets[].digest'` vs local `sha256sum` of downloaded assets — both match the corrected pins