### PR TITLE
fix(macos): stop rogue LaunchAgents from daemonising the app and stealing focus

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import {
   detectPluginRecovery,
   PLUGIN_RECOVERY_EVIDENCE_TIMEOUT_MS
 } from './plugin-recovery-detection'
+import { isDaemonLaunch, isUserInitiatedInstance } from './launchd-guard'
 import { secureWindow } from './security'
 import { ensureLaunchRoot } from './state/launch-root'
 import {
@@ -44,6 +45,7 @@ import {
 } from './state/plugin-recovery'
 import { ensureSafeModeProfile, SAFE_MODE_PROFILE } from './state/safe-mode-profile'
 import { cleanupPluginOwnedComponents } from './state/plugin-component-cleanup'
+import { appBundlePathFromExecutable, auditLaunchAgents } from './state/launch-agent-audit'
 import {
   desktopHarnessUrl,
   isAbortedNavigationError,
@@ -643,6 +645,36 @@ async function reportProfileConsistency(dshHome: string): Promise<void> {
   }
 }
 
+/**
+ * Correct any LaunchAgent that would have launchd start this bundle as a
+ * desktop process. Those agents steal focus and crash on every restart, and
+ * the daemon guard only silences the symptom for as long as the job keeps
+ * failing, so the job itself is repaired here.
+ */
+async function auditInstalledLaunchAgents(dshHome: string): Promise<void> {
+  const appBundlePath = appBundlePathFromExecutable(process.execPath)
+  if (appBundlePath === undefined) return
+  try {
+    const result = await auditLaunchAgents({
+      dshHome,
+      appBundlePath,
+      log: (message) => runtime.note(message)
+    })
+    for (const finding of result.findings) {
+      const owner = finding.owner === undefined ? '' : ` installed by ${finding.owner}`
+      runtime.note(
+        finding.action === 'escalated'
+          ? `[desktop] ${finding.label}${owner} keeps recreating a background service that starts DSH Desktop; consider removing that plugin`
+          : `[desktop] ${finding.action} the background service ${finding.label}${owner}`
+      )
+    }
+    for (const failure of result.failures) runtime.note(`[desktop] launch agent audit: ${failure}`)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    runtime.note(`[desktop] launch agent audit failed: ${detail}`)
+  }
+}
+
 function launchHarness(): Promise<void> {
   if (harnessLaunchOperation) return harnessLaunchOperation
 
@@ -661,6 +693,7 @@ function launchHarness(): Promise<void> {
     await repairProfilePackages(dshHome)
     await pruneMissingProfileBundles(dshHome).catch(() => false)
     await reportProfileConsistency(dshHome)
+    await auditInstalledLaunchAgents(dshHome)
     await runtime.start(launchDirectory)
   })().finally(() => {
     harnessLaunchOperation = undefined
@@ -1582,47 +1615,56 @@ async function bootstrap(): Promise<void> {
   }
 }
 
-configureAppIdentity()
-configureApplicationLocale()
-const singleInstance = app.requestSingleInstanceLock()
-if (!singleInstance) {
-  app.quit()
+if (isDaemonLaunch(process.env, process.platform)) {
+  // launchd started this bundle from a LaunchAgent instead of the user
+  // opening the app. Requesting the single instance lock here would reach
+  // the running app's second-instance handler, which raises and focuses
+  // its window as though the user had asked for it, so leave first.
+  app.exit(0)
 } else {
-  app.on('second-instance', (_event, argv) => {
-    if (shouldStartInSafeMode(argv)) {
-      void showSafeMode().catch(showUnexpectedError)
-      return
-    }
-    const snapshot = runtime?.snapshot()
-    if (snapshot?.phase === 'ready' && snapshot.url) {
-      void openHarness(snapshot.url, 'user').catch(showUnexpectedError)
-    }
-  })
-  app.whenReady().then(bootstrap).catch((error: unknown) => {
-    showUnexpectedError(error)
+  configureAppIdentity()
+  configureApplicationLocale()
+  const singleInstance = app.requestSingleInstanceLock()
+  if (!singleInstance) {
     app.quit()
-  })
-  app.on('activate', () => {
-    if (safeModeVisible && mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.show()
-      mainWindow.focus()
-      return
-    }
-    const snapshot = runtime?.snapshot()
-    if (snapshot?.phase === 'ready' && snapshot.url) {
-      void openHarness(snapshot.url, 'user').catch(showUnexpectedError)
-    } else if (snapshot?.phase === 'idle') {
-      void launchHarness().catch(showUnexpectedError)
-    }
-  })
-  app.on('window-all-closed', () => {
-    if (process.platform !== 'darwin') app.quit()
-  })
-  app.on('before-quit', (event) => {
-    if (quitting || !runtime) return
-    event.preventDefault()
-    quitting = true
-    stopUpdateManager()
-    void Promise.all([runtime.stop(), mobileBridge?.stop()]).finally(() => app.quit())
-  })
+  } else {
+    app.on('second-instance', (_event, argv) => {
+      if (!isUserInitiatedInstance(argv)) return
+      if (shouldStartInSafeMode(argv)) {
+        void showSafeMode().catch(showUnexpectedError)
+        return
+      }
+      const snapshot = runtime?.snapshot()
+      if (snapshot?.phase === 'ready' && snapshot.url) {
+        void openHarness(snapshot.url, 'user').catch(showUnexpectedError)
+      }
+    })
+    app.whenReady().then(bootstrap).catch((error: unknown) => {
+      showUnexpectedError(error)
+      app.quit()
+    })
+    app.on('activate', () => {
+      if (safeModeVisible && mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.show()
+        mainWindow.focus()
+        return
+      }
+      const snapshot = runtime?.snapshot()
+      if (snapshot?.phase === 'ready' && snapshot.url) {
+        void openHarness(snapshot.url, 'user').catch(showUnexpectedError)
+      } else if (snapshot?.phase === 'idle') {
+        void launchHarness().catch(showUnexpectedError)
+      }
+    })
+    app.on('window-all-closed', () => {
+      if (process.platform !== 'darwin') app.quit()
+    })
+    app.on('before-quit', (event) => {
+      if (quitting || !runtime) return
+      event.preventDefault()
+      quitting = true
+      stopUpdateManager()
+      void Promise.all([runtime.stop(), mobileBridge?.stop()]).finally(() => app.quit())
+    })
+  }
 }

--- a/src/main/launchd-guard.ts
+++ b/src/main/launchd-guard.ts
@@ -1,0 +1,35 @@
+/**
+ * macOS reports how a process was started through XPC_SERVICE_NAME. A GUI
+ * launch carries an `application.<bundle id>.<n>.<n>` service name, while a
+ * process launchd started from a LaunchAgent or LaunchDaemon carries that
+ * job's own label.
+ */
+export function isDaemonLaunch(
+  environment: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform
+): boolean {
+  if (platform !== 'darwin') return false
+  const serviceName = environment.XPC_SERVICE_NAME
+  if (serviceName === undefined || serviceName === '' || serviceName === '0') return false
+  return !serviceName.startsWith('application.')
+}
+
+const scriptArgumentPattern = /\.[mc]?js$/i
+
+/**
+ * A LaunchAgent that daemonises the app binary can still slip past
+ * `isDaemonLaunch` (its own env lies about how it was started, or it wasn't
+ * caught before boot) and reach `requestSingleInstanceLock`'s second-instance
+ * event on the already-running app. That handler must not treat every second
+ * launch as the user asking for the window: a helper binary, or a script
+ * argument meant for a runtime rather than a file to open, marks the launch
+ * as synthetic instead.
+ */
+export function isUserInitiatedInstance(argv: string[]): boolean {
+  if (argv.length === 0) return true
+  const [binary, ...rest] = argv as [string, ...string[]]
+  if (binary.includes('/Contents/Frameworks/')) return false
+  const firstArgument = rest[0]
+  if (firstArgument === undefined) return true
+  return !scriptArgumentPattern.test(firstArgument)
+}

--- a/src/main/state/component-ledger.ts
+++ b/src/main/state/component-ledger.ts
@@ -1,0 +1,53 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+/**
+ * A plugin that recreates its LaunchAgent after every repair would otherwise
+ * trap the app in an endless correct-and-be-overwritten cycle. Past this many
+ * repairs of one label the app stops correcting it silently and asks the user
+ * to decide.
+ */
+export const REPAIR_ESCALATION_THRESHOLD = 3
+
+export interface ComponentLedgerEntry {
+  repairs: number
+  lastRepairAt: string
+}
+
+export type ComponentLedger = Record<string, ComponentLedgerEntry>
+
+function ledgerPath(dshHome: string): string {
+  return join(dshHome, 'recovery', 'launch-agent-ledger.json')
+}
+
+export async function readComponentLedger(dshHome: string): Promise<ComponentLedger> {
+  try {
+    const parsed = JSON.parse(await readFile(ledgerPath(dshHome), 'utf8')) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+    return parsed as ComponentLedger
+  } catch {
+    // A missing or damaged ledger only costs escalation history, never safety.
+    return {}
+  }
+}
+
+export async function recordComponentRepair(
+  dshHome: string,
+  label: string,
+  now: () => Date = () => new Date()
+): Promise<ComponentLedgerEntry> {
+  const ledger = await readComponentLedger(dshHome)
+  const entry: ComponentLedgerEntry = {
+    repairs: (ledger[label]?.repairs ?? 0) + 1,
+    lastRepairAt: now().toISOString()
+  }
+  ledger[label] = entry
+  const path = ledgerPath(dshHome)
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(ledger, undefined, 2)}\n`)
+  return entry
+}
+
+export function shouldEscalateRepairs(entry: ComponentLedgerEntry): boolean {
+  return entry.repairs >= REPAIR_ESCALATION_THRESHOLD
+}

--- a/src/main/state/launch-agent-audit.ts
+++ b/src/main/state/launch-agent-audit.ts
@@ -1,0 +1,311 @@
+import { spawn } from 'node:child_process'
+import { homedir, tmpdir } from 'node:os'
+import { basename, isAbsolute, join, relative, resolve } from 'node:path'
+import { copyFile, mkdir, mkdtemp, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import {
+  readComponentLedger,
+  recordComponentRepair,
+  shouldEscalateRepairs
+} from './component-ledger'
+
+const LAUNCH_AGENT_LABEL_PATTERN = /^[a-z0-9._-]+$/i
+const COMMAND_TIMEOUT_MS = 10_000
+const COMMAND_OUTPUT_LIMIT = 64 * 1024
+
+export interface LaunchAgentRecord {
+  Label?: unknown
+  Program?: unknown
+  ProgramArguments?: unknown
+  EnvironmentVariables?: unknown
+  // A job definition carries any number of keys a repair must hand back.
+  [key: string]: unknown
+}
+
+export interface CommandResult {
+  code: number | null
+  stdout: string
+  stderr: string
+}
+
+export type AuditAction = 'repaired' | 'escalated' | 'quarantined'
+
+export interface AuditFinding {
+  label: string
+  plistPath: string
+  action: AuditAction
+  owner?: string
+  backupPath?: string
+  repairs?: number
+}
+
+export interface LaunchAgentAuditOptions {
+  dshHome: string
+  appBundlePath: string
+  homeDirectory?: string
+  platform?: NodeJS.Platform
+  uid?: number | null
+  readLaunchAgent?: (plistPath: string) => Promise<LaunchAgentRecord>
+  writeLaunchAgent?: (plistPath: string, record: LaunchAgentRecord) => Promise<void>
+  bootoutLaunchAgent?: (target: string) => Promise<CommandResult>
+  bootstrapLaunchAgent?: (domain: string, plistPath: string) => Promise<CommandResult>
+  now?: () => Date
+  log?: (message: string) => void
+}
+
+export interface LaunchAgentAuditResult {
+  findings: AuditFinding[]
+  failures: string[]
+}
+
+function pathInside(parent: string, child: string): boolean {
+  const nested = relative(parent, child)
+  return nested === '' || (!nested.startsWith('..') && !isAbsolute(nested))
+}
+
+function executablePath(record: LaunchAgentRecord): string | undefined {
+  if (typeof record.Program === 'string' && isAbsolute(record.Program)) return record.Program
+  const args = Array.isArray(record.ProgramArguments) ? record.ProgramArguments : []
+  const first = args[0]
+  return typeof first === 'string' && isAbsolute(first) ? first : undefined
+}
+
+function runsAsNode(record: LaunchAgentRecord): boolean {
+  const environment = record.EnvironmentVariables
+  if (typeof environment !== 'object' || environment === null) return false
+  const flag = (environment as Record<string, unknown>).ELECTRON_RUN_AS_NODE
+  return flag === '1' || flag === 1 || flag === true
+}
+
+/**
+ * The same agent, corrected rather than removed: the job keeps its schedule,
+ * its arguments and its own environment, and only gains the flag that makes
+ * our binary run as plain node instead of booting the desktop application.
+ */
+export function repairedLaunchAgent(record: LaunchAgentRecord): LaunchAgentRecord {
+  const environment = typeof record.EnvironmentVariables === 'object' && record.EnvironmentVariables !== null
+    ? record.EnvironmentVariables as Record<string, unknown>
+    : {}
+  return {
+    ...record,
+    EnvironmentVariables: { ...environment, ELECTRON_RUN_AS_NODE: '1' }
+  }
+}
+
+/**
+ * A LaunchAgent that runs this application's own binary as a background job
+ * without ELECTRON_RUN_AS_NODE is always a defect: launchd starts a full GUI
+ * Electron process, which activates the app over whatever the user is doing
+ * and then dies. The binary belongs to us, so the pattern is self-attributing
+ * and needs no package ownership check.
+ */
+export function describesDaemonisedAppBinary(
+  record: LaunchAgentRecord,
+  appBundlePath: string
+): boolean {
+  const executable = executablePath(record)
+  if (executable === undefined) return false
+  if (!pathInside(resolve(appBundlePath), resolve(executable))) return false
+  return !runsAsNode(record)
+}
+
+/**
+ * The application bundle an executable belongs to. The outermost `.app` is the
+ * right boundary: helper executables live in nested bundles inside it, and an
+ * agent abusing any of them is abusing this installation.
+ */
+export function appBundlePathFromExecutable(executable: string): string | undefined {
+  const segments = executable.split('/')
+  const bundle = segments.findIndex((segment) => segment.endsWith('.app'))
+  if (bundle === -1) return undefined
+  return segments.slice(0, bundle + 1).join('/')
+}
+
+/**
+ * The package a LaunchAgent was installed by, when one of its arguments still
+ * points inside an installed package. Attribution only enriches what the app
+ * tells the user; a broken agent is corrected whether or not it succeeds.
+ */
+export function pluginOwnerFromArguments(record: LaunchAgentRecord): string | undefined {
+  const args = Array.isArray(record.ProgramArguments) ? record.ProgramArguments : []
+  const candidates = [
+    typeof record.Program === 'string' ? record.Program : undefined,
+    ...args.filter((value): value is string => typeof value === 'string')
+  ].filter((value): value is string => value !== undefined)
+
+  for (const candidate of candidates) {
+    const segments = candidate.split('/')
+    const marker = segments.lastIndexOf('node_modules')
+    if (marker === -1) continue
+    const first = segments[marker + 1]
+    if (first === undefined || first === '') continue
+    if (first.startsWith('@')) {
+      const second = segments[marker + 2]
+      if (second !== undefined && second !== '') return `${first}/${second}`
+      continue
+    }
+    return first
+  }
+  return undefined
+}
+
+function runCommand(command: string, args: readonly string[]): Promise<CommandResult> {
+  return new Promise((resolveResult) => {
+    const child = spawn(command, [...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: COMMAND_TIMEOUT_MS,
+      killSignal: 'SIGKILL'
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout = (stdout + chunk).slice(-COMMAND_OUTPUT_LIMIT)
+    })
+    child.stderr.on('data', (chunk: string) => {
+      stderr = (stderr + chunk).slice(-COMMAND_OUTPUT_LIMIT)
+    })
+    child.once('error', (error) => resolveResult({ code: null, stdout, stderr: error.message }))
+    child.once('close', (code) => resolveResult({ code, stdout, stderr }))
+  })
+}
+
+async function defaultReadLaunchAgent(plistPath: string): Promise<LaunchAgentRecord> {
+  const result = await runCommand('/usr/bin/plutil', ['-convert', 'json', '-o', '-', plistPath])
+  if (result.code !== 0) throw new Error(result.stderr.trim() || `plutil exited ${String(result.code)}`)
+  return JSON.parse(result.stdout) as LaunchAgentRecord
+}
+
+async function defaultWriteLaunchAgent(
+  plistPath: string,
+  record: LaunchAgentRecord
+): Promise<void> {
+  const staging = await mkdtemp(join(tmpdir(), 'dsh-launch-agent-'))
+  const source = join(staging, 'agent.json')
+  try {
+    await writeFile(source, JSON.stringify(record))
+    const result = await runCommand('/usr/bin/plutil', ['-convert', 'xml1', '-o', plistPath, source])
+    if (result.code !== 0) {
+      throw new Error(result.stderr.trim() || `plutil exited ${String(result.code)}`)
+    }
+  } finally {
+    await rm(staging, { recursive: true, force: true })
+  }
+}
+
+function defaultBootoutLaunchAgent(target: string): Promise<CommandResult> {
+  return runCommand('/bin/launchctl', ['bootout', target])
+}
+
+function defaultBootstrapLaunchAgent(domain: string, plistPath: string): Promise<CommandResult> {
+  return runCommand('/bin/launchctl', ['bootstrap', domain, plistPath])
+}
+
+function timestamp(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+/**
+ * Correct every LaunchAgent that would start this application as a background
+ * desktop process. Repair is preferred over removal so the plugin behind the
+ * agent keeps working; removal is the fallback when the repair cannot land.
+ */
+export async function auditLaunchAgents(
+  options: LaunchAgentAuditOptions
+): Promise<LaunchAgentAuditResult> {
+  const platform = options.platform ?? process.platform
+  const findings: AuditFinding[] = []
+  const failures: string[] = []
+  if (platform !== 'darwin') return { findings, failures }
+
+  const homeDirectory = options.homeDirectory ?? homedir()
+  const launchAgentsDirectory = join(homeDirectory, 'Library', 'LaunchAgents')
+  const readLaunchAgent = options.readLaunchAgent ?? defaultReadLaunchAgent
+  const writeLaunchAgent = options.writeLaunchAgent ?? defaultWriteLaunchAgent
+  const bootoutLaunchAgent = options.bootoutLaunchAgent ?? defaultBootoutLaunchAgent
+  const bootstrapLaunchAgent = options.bootstrapLaunchAgent ?? defaultBootstrapLaunchAgent
+  const now = options.now ?? (() => new Date())
+  const uid = options.uid === undefined ? process.getuid?.() ?? null : options.uid
+
+  let entries
+  try {
+    entries = await readdir(launchAgentsDirectory, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { findings, failures }
+    const detail = error instanceof Error ? error.message : String(error)
+    return { findings, failures: [`cannot inspect ${launchAgentsDirectory}: ${detail}`] }
+  }
+
+  const ledger = await readComponentLedger(options.dshHome)
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.plist')) continue
+    const plistPath = join(launchAgentsDirectory, entry.name)
+
+    let record: LaunchAgentRecord
+    try {
+      record = await readLaunchAgent(plistPath)
+    } catch {
+      // An unreadable plist proves nothing about ownership and is left alone.
+      continue
+    }
+    if (!describesDaemonisedAppBinary(record, options.appBundlePath)) continue
+
+    const label = typeof record.Label === 'string' && LAUNCH_AGENT_LABEL_PATTERN.test(record.Label)
+      ? record.Label
+      : undefined
+    if (label === undefined || typeof uid !== 'number') {
+      failures.push(`${plistPath}: missing a safe LaunchAgent label or user id`)
+      continue
+    }
+
+    const owner = pluginOwnerFromArguments(record)
+    const previous = ledger[label]
+    if (previous !== undefined && shouldEscalateRepairs(previous)) {
+      findings.push({ label, plistPath, action: 'escalated', owner, repairs: previous.repairs })
+      options.log?.(`[launch-agents] ${label} keeps returning; leaving it to the user`)
+      continue
+    }
+
+    const target = `gui/${String(uid)}/${label}`
+    const domain = `gui/${String(uid)}`
+    const stampDirectory = join(options.dshHome, 'recovery', 'repaired-components', timestamp(now()))
+    const backupPath = join(stampDirectory, basename(plistPath))
+
+    try {
+      await mkdir(stampDirectory, { recursive: true })
+      await copyFile(plistPath, backupPath)
+      await bootoutLaunchAgent(target)
+      await writeLaunchAgent(plistPath, repairedLaunchAgent(record))
+      await bootstrapLaunchAgent(domain, plistPath)
+      const recorded = await recordComponentRepair(options.dshHome, label, now)
+      findings.push({ label, plistPath, action: 'repaired', owner, backupPath, repairs: recorded.repairs })
+      options.log?.(`[launch-agents] repaired ${label} to run as node`)
+      continue
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      failures.push(`${plistPath}: repair failed (${detail})`)
+    }
+
+    // The job still boots a desktop process, so stopping it beats leaving it.
+    try {
+      await bootoutLaunchAgent(target)
+      const quarantineDirectory = join(
+        options.dshHome,
+        'recovery',
+        'quarantined-components',
+        timestamp(now())
+      )
+      await mkdir(quarantineDirectory, { recursive: true })
+      const quarantinePath = join(quarantineDirectory, basename(plistPath))
+      await rename(plistPath, quarantinePath)
+      findings.push({ label, plistPath, action: 'quarantined', owner, backupPath: quarantinePath })
+      options.log?.(`[launch-agents] quarantined ${label} after a failed repair`)
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      failures.push(`${plistPath}: quarantine failed (${detail})`)
+    }
+  }
+
+  return { findings, failures }
+}

--- a/test/component-ledger.test.ts
+++ b/test/component-ledger.test.ts
@@ -1,0 +1,72 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  readComponentLedger,
+  recordComponentRepair,
+  REPAIR_ESCALATION_THRESHOLD,
+  shouldEscalateRepairs
+} from '../src/main/state/component-ledger'
+
+describe('component ledger', () => {
+  const testRoot = join(__dirname, '.temp-component-ledger')
+  const dshHome = join(testRoot, 'dsh-home')
+  const at = (iso: string) => () => new Date(iso)
+
+  beforeEach(async () => {
+    await mkdir(dshHome, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(testRoot, { recursive: true, force: true })
+  })
+
+  it('records the first repair of a label', async () => {
+    const entry = await recordComponentRepair(dshHome, 'com.dsh.doctor', at('2026-08-25T10:00:00.000Z'))
+
+    expect(entry.repairs).toBe(1)
+    expect(entry.lastRepairAt).toBe('2026-08-25T10:00:00.000Z')
+  })
+
+  it('counts a label that keeps coming back broken', async () => {
+    await recordComponentRepair(dshHome, 'com.dsh.doctor', at('2026-08-25T10:00:00.000Z'))
+    await recordComponentRepair(dshHome, 'com.dsh.doctor', at('2026-08-25T11:00:00.000Z'))
+    const entry = await recordComponentRepair(dshHome, 'com.dsh.doctor', at('2026-08-25T12:00:00.000Z'))
+
+    expect(entry.repairs).toBe(3)
+    expect(entry.lastRepairAt).toBe('2026-08-25T12:00:00.000Z')
+  })
+
+  it('counts each label separately', async () => {
+    await recordComponentRepair(dshHome, 'com.dsh.doctor', at('2026-08-25T10:00:00.000Z'))
+    await recordComponentRepair(dshHome, 'com.dsh.doctor', at('2026-08-25T11:00:00.000Z'))
+    await recordComponentRepair(dshHome, 'com.other.agent', at('2026-08-25T11:30:00.000Z'))
+
+    const ledger = await readComponentLedger(dshHome)
+
+    expect(ledger['com.dsh.doctor']?.repairs).toBe(2)
+    expect(ledger['com.other.agent']?.repairs).toBe(1)
+  })
+
+  it('reads an empty ledger when none has been written', async () => {
+    expect(await readComponentLedger(dshHome)).toEqual({})
+  })
+
+  it('starts over when the stored ledger is unreadable', async () => {
+    const recovery = join(dshHome, 'recovery')
+    await mkdir(recovery, { recursive: true })
+    await writeFile(join(recovery, 'launch-agent-ledger.json'), '{ not json')
+
+    expect(await readComponentLedger(dshHome)).toEqual({})
+  })
+
+  it('keeps repairing while the label stays under the threshold', () => {
+    expect(shouldEscalateRepairs({ repairs: REPAIR_ESCALATION_THRESHOLD - 1, lastRepairAt: '' }))
+      .toBe(false)
+  })
+
+  it('escalates once a label has been repaired too many times', () => {
+    expect(shouldEscalateRepairs({ repairs: REPAIR_ESCALATION_THRESHOLD, lastRepairAt: '' }))
+      .toBe(true)
+  })
+})

--- a/test/launch-agent-audit-run.test.ts
+++ b/test/launch-agent-audit-run.test.ts
@@ -1,0 +1,169 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { auditLaunchAgents, type LaunchAgentRecord } from '../src/main/state/launch-agent-audit'
+import { readComponentLedger, REPAIR_ESCALATION_THRESHOLD } from '../src/main/state/component-ledger'
+
+describe('launch agent audit', () => {
+  const testRoot = join(__dirname, '.temp-launch-agent-audit')
+  const dshHome = join(testRoot, 'dsh-home')
+  const home = join(testRoot, 'home')
+  const launchAgents = join(home, 'Library', 'LaunchAgents')
+  const appBundlePath = '/Applications/DSH Desktop.app'
+  const helper = `${appBundlePath}/Contents/Frameworks/DSH Desktop Helper.app/Contents/MacOS/DSH Desktop Helper`
+  const doctorPlist = join(launchAgents, 'com.dsh.doctor.plist')
+
+  const brokenAgent: LaunchAgentRecord = {
+    Label: 'com.dsh.doctor',
+    ProgramArguments: [helper, '/Users/alex/.dsh/profiles/web/node_modules/@vendor/dsh-doctor/daemon.js'],
+    KeepAlive: true
+  }
+
+  async function writeAgentFile(path: string): Promise<void> {
+    await writeFile(path, 'binary plist placeholder')
+  }
+
+  function options(overrides: Record<string, unknown> = {}) {
+    return {
+      dshHome,
+      appBundlePath,
+      homeDirectory: home,
+      platform: 'darwin' as NodeJS.Platform,
+      uid: 501,
+      readLaunchAgent: async () => structuredClone(brokenAgent),
+      writeLaunchAgent: vi.fn(async (path: string, record: LaunchAgentRecord) => {
+        await writeFile(path, JSON.stringify(record))
+      }),
+      bootoutLaunchAgent: vi.fn(async () => ({ code: 0, stdout: '', stderr: '' })),
+      bootstrapLaunchAgent: vi.fn(async () => ({ code: 0, stdout: '', stderr: '' })),
+      now: () => new Date('2026-08-25T10:00:00.000Z'),
+      ...overrides
+    }
+  }
+
+  beforeEach(async () => {
+    await mkdir(launchAgents, { recursive: true })
+    await mkdir(dshHome, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(testRoot, { recursive: true, force: true })
+  })
+
+  it('repairs an agent that boots our binary as a desktop application', async () => {
+    await writeAgentFile(doctorPlist)
+    const settings = options()
+
+    const result = await auditLaunchAgents(settings)
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({ label: 'com.dsh.doctor', action: 'repaired', plistPath: doctorPlist })
+    ])
+    const written = JSON.parse(await readFile(doctorPlist, 'utf8')) as LaunchAgentRecord
+    expect(written.EnvironmentVariables).toEqual({ ELECTRON_RUN_AS_NODE: '1' })
+    expect(written.KeepAlive).toBe(true)
+  })
+
+  it('reloads the repaired job so the running process stops', async () => {
+    await writeAgentFile(doctorPlist)
+    const settings = options()
+
+    await auditLaunchAgents(settings)
+
+    expect(settings.bootoutLaunchAgent).toHaveBeenCalledWith('gui/501/com.dsh.doctor')
+    expect(settings.bootstrapLaunchAgent).toHaveBeenCalledWith('gui/501', doctorPlist)
+  })
+
+  it('backs up the original definition before rewriting it', async () => {
+    await writeAgentFile(doctorPlist)
+
+    const result = await auditLaunchAgents(options())
+
+    expect(result.findings[0]?.backupPath).toBeDefined()
+    expect(existsSync(result.findings[0]!.backupPath!)).toBe(true)
+  })
+
+  it('leaves an agent belonging to another application untouched', async () => {
+    const foreign = join(launchAgents, 'com.google.keystone.agent.plist')
+    await writeAgentFile(foreign)
+    const settings = options({
+      readLaunchAgent: async () => ({
+        Label: 'com.google.keystone.agent',
+        ProgramArguments: ['/Users/alex/Library/Google/GoogleUpdater/Current/updater']
+      })
+    })
+
+    const result = await auditLaunchAgents(settings)
+
+    expect(result.findings).toEqual([])
+    expect(settings.bootoutLaunchAgent).not.toHaveBeenCalled()
+    expect(await readFile(foreign, 'utf8')).toBe('binary plist placeholder')
+  })
+
+  it('does nothing away from macOS', async () => {
+    await writeAgentFile(doctorPlist)
+    const settings = options({ platform: 'win32' as NodeJS.Platform })
+
+    const result = await auditLaunchAgents(settings)
+
+    expect(result.findings).toEqual([])
+    expect(settings.writeLaunchAgent).not.toHaveBeenCalled()
+  })
+
+  it('counts each repair against the label', async () => {
+    await writeAgentFile(doctorPlist)
+
+    await auditLaunchAgents(options())
+
+    expect((await readComponentLedger(dshHome))['com.dsh.doctor']?.repairs).toBe(1)
+  })
+
+  it('stops repairing a label the plugin keeps rewriting and asks the user instead', async () => {
+    await writeAgentFile(doctorPlist)
+    for (let attempt = 0; attempt < REPAIR_ESCALATION_THRESHOLD; attempt += 1) {
+      await writeAgentFile(doctorPlist)
+      await auditLaunchAgents(options())
+    }
+    await writeAgentFile(doctorPlist)
+    const settings = options()
+
+    const result = await auditLaunchAgents(settings)
+
+    expect(result.findings[0]?.action).toBe('escalated')
+    expect(settings.writeLaunchAgent).not.toHaveBeenCalled()
+  })
+
+  it('quarantines the agent when the repair cannot be written', async () => {
+    await writeAgentFile(doctorPlist)
+    const settings = options({
+      writeLaunchAgent: async () => { throw new Error('read-only file system') }
+    })
+
+    const result = await auditLaunchAgents(settings)
+
+    expect(result.findings[0]?.action).toBe('quarantined')
+    expect(existsSync(doctorPlist)).toBe(false)
+    expect(settings.bootoutLaunchAgent).toHaveBeenCalledWith('gui/501/com.dsh.doctor')
+  })
+
+  it('skips a plist it cannot parse rather than guessing', async () => {
+    await writeAgentFile(doctorPlist)
+    const settings = options({
+      readLaunchAgent: async () => { throw new Error('not a plist') }
+    })
+
+    const result = await auditLaunchAgents(settings)
+
+    expect(result.findings).toEqual([])
+    expect(settings.bootoutLaunchAgent).not.toHaveBeenCalled()
+  })
+
+  it('names the plugin package behind the agent when the path reveals it', async () => {
+    await writeAgentFile(doctorPlist)
+
+    const result = await auditLaunchAgents(options())
+
+    expect(result.findings[0]?.owner).toBe('@vendor/dsh-doctor')
+  })
+})

--- a/test/launch-agent-audit.test.ts
+++ b/test/launch-agent-audit.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import {
+  describesDaemonisedAppBinary,
+  repairedLaunchAgent,
+  appBundlePathFromExecutable,
+  type LaunchAgentRecord
+} from '../src/main/state/launch-agent-audit'
+
+const appBundle = '/Applications/DSH Desktop.app'
+const helper = `${appBundle}/Contents/Frameworks/DSH Desktop Helper.app/Contents/MacOS/DSH Desktop Helper`
+
+describe('daemonised app binary detection', () => {
+  it('flags an agent running the app binary without the node runtime flag', () => {
+    const record = {
+      Label: 'com.dsh.doctor',
+      ProgramArguments: [helper, '/Users/alex/.dsh/plugin/daemon.js']
+    }
+
+    expect(describesDaemonisedAppBinary(record, appBundle)).toBe(true)
+  })
+
+  it('accepts an agent that already runs the binary as node', () => {
+    const record = {
+      Label: 'com.dsh.doctor',
+      ProgramArguments: [helper, '/Users/alex/.dsh/plugin/daemon.js'],
+      EnvironmentVariables: { ELECTRON_RUN_AS_NODE: '1' }
+    }
+
+    expect(describesDaemonisedAppBinary(record, appBundle)).toBe(false)
+  })
+
+  it('leaves agents belonging to other applications alone', () => {
+    const record = {
+      Label: 'com.google.keystone.agent',
+      ProgramArguments: ['/Users/alex/Library/Google/GoogleUpdater/Current/updater']
+    }
+
+    expect(describesDaemonisedAppBinary(record, appBundle)).toBe(false)
+  })
+
+  it('reads the executable from Program when ProgramArguments is absent', () => {
+    expect(describesDaemonisedAppBinary({ Label: 'com.dsh.doctor', Program: helper }, appBundle))
+      .toBe(true)
+  })
+
+  it('ignores an agent with no absolute executable path', () => {
+    expect(describesDaemonisedAppBinary({ Label: 'com.dsh.doctor', ProgramArguments: ['node'] }, appBundle))
+      .toBe(false)
+  })
+
+  it('does not treat a sibling bundle as our own', () => {
+    const sibling = '/Applications/DSH Desktop Dev.app/Contents/MacOS/DSH Desktop Dev'
+
+    expect(describesDaemonisedAppBinary({ Label: 'com.dsh.dev', ProgramArguments: [sibling] }, appBundle))
+      .toBe(false)
+  })
+
+  it('does not treat a bundle whose name merely extends ours as our own', () => {
+    const lookalike = '/Applications/DSH Desktop.app.disabled/Contents/MacOS/DSH Desktop'
+
+    expect(describesDaemonisedAppBinary({ Label: 'com.dsh.old', ProgramArguments: [lookalike] }, appBundle))
+      .toBe(false)
+  })
+})
+
+describe('launch agent repair', () => {
+  it('adds the node runtime flag so launchd stops starting a GUI process', () => {
+    const record = {
+      Label: 'com.dsh.doctor',
+      ProgramArguments: [helper, '/Users/alex/.dsh/plugin/daemon.js']
+    }
+
+    const repaired = repairedLaunchAgent(record)
+
+    expect(repaired.EnvironmentVariables).toEqual({ ELECTRON_RUN_AS_NODE: '1' })
+    expect(describesDaemonisedAppBinary(repaired, appBundle)).toBe(false)
+  })
+
+  it('keeps the environment variables the agent already declared', () => {
+    const record = {
+      Label: 'com.dsh.doctor',
+      ProgramArguments: [helper],
+      EnvironmentVariables: { PATH: '/usr/bin', DSH_MODE: 'watch' }
+    }
+
+    expect(repairedLaunchAgent(record).EnvironmentVariables).toEqual({
+      PATH: '/usr/bin',
+      DSH_MODE: 'watch',
+      ELECTRON_RUN_AS_NODE: '1'
+    })
+  })
+
+  it('leaves the original record untouched', () => {
+    const record: LaunchAgentRecord = { Label: 'com.dsh.doctor', ProgramArguments: [helper] }
+
+    repairedLaunchAgent(record)
+
+    expect(record.EnvironmentVariables).toBeUndefined()
+  })
+
+  it('preserves every other key in the agent definition', () => {
+    const record = {
+      Label: 'com.dsh.doctor',
+      ProgramArguments: [helper],
+      KeepAlive: true,
+      RunAtLoad: true
+    }
+
+    const repaired = repairedLaunchAgent(record) as typeof record
+
+    expect(repaired.Label).toBe('com.dsh.doctor')
+    expect(repaired.KeepAlive).toBe(true)
+    expect(repaired.RunAtLoad).toBe(true)
+  })
+})
+
+describe('app bundle path', () => {
+  it('finds the bundle root above the executable', () => {
+    expect(appBundlePathFromExecutable('/Applications/DSH Desktop.app/Contents/MacOS/DSH Desktop'))
+      .toBe('/Applications/DSH Desktop.app')
+  })
+
+  it('stops at the outermost bundle so helpers map to the app itself', () => {
+    expect(appBundlePathFromExecutable(helper)).toBe(appBundle)
+  })
+
+  it('has no bundle to report for an unpackaged executable', () => {
+    expect(appBundlePathFromExecutable('/usr/local/bin/electron')).toBeUndefined()
+  })
+})

--- a/test/launch-agent-plist-roundtrip.test.ts
+++ b/test/launch-agent-plist-roundtrip.test.ts
@@ -1,0 +1,80 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { auditLaunchAgents } from '../src/main/state/launch-agent-audit'
+
+// Exercises the real plutil-backed reader and writer; only launchctl is stubbed
+// so the test never touches the user's actual services.
+describe.runIf(process.platform === 'darwin')('launch agent plist round trip', () => {
+  const testRoot = join(__dirname, '.temp-launch-agent-plist')
+  const dshHome = join(testRoot, 'dsh-home')
+  const home = join(testRoot, 'home')
+  const launchAgents = join(home, 'Library', 'LaunchAgents')
+  const appBundlePath = join(testRoot, 'Applications', 'DSH Desktop.app')
+  const helper = join(appBundlePath, 'Contents', 'MacOS', 'DSH Desktop')
+  const plistPath = join(launchAgents, 'com.dsh.doctor.plist')
+
+  beforeEach(async () => {
+    await mkdir(launchAgents, { recursive: true })
+    await mkdir(dshHome, { recursive: true })
+    await writeFile(plistPath, `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.dsh.doctor</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${helper}</string>
+    <string>/Users/alex/.dsh/profiles/web/node_modules/@vendor/dsh-doctor/daemon.js</string>
+  </array>
+  <key>KeepAlive</key><true/>
+  <key>RunAtLoad</key><true/>
+  <key>ThrottleInterval</key><integer>10</integer>
+</dict>
+</plist>
+`)
+  })
+
+  afterEach(async () => {
+    await rm(testRoot, { recursive: true, force: true })
+  })
+
+  it('rewrites a real plist as a valid property list that runs as node', async () => {
+    const result = await auditLaunchAgents({
+      dshHome,
+      appBundlePath,
+      homeDirectory: home,
+      platform: 'darwin',
+      uid: 501,
+      bootoutLaunchAgent: vi.fn(async () => ({ code: 0, stdout: '', stderr: '' })),
+      bootstrapLaunchAgent: vi.fn(async () => ({ code: 0, stdout: '', stderr: '' }))
+    })
+
+    expect(result.failures).toEqual([])
+    expect(result.findings[0]?.action).toBe('repaired')
+    expect(result.findings[0]?.owner).toBe('@vendor/dsh-doctor')
+
+    const rewritten = await readFile(plistPath, 'utf8')
+    expect(rewritten).toContain('<?xml')
+    expect(rewritten).toContain('ELECTRON_RUN_AS_NODE')
+    expect(rewritten).toContain('ThrottleInterval')
+    expect(rewritten).toContain('KeepAlive')
+  })
+
+  it('leaves the repaired agent stable when the audit runs again', async () => {
+    const settings = {
+      dshHome,
+      appBundlePath,
+      homeDirectory: home,
+      platform: 'darwin' as NodeJS.Platform,
+      uid: 501,
+      bootoutLaunchAgent: vi.fn(async () => ({ code: 0, stdout: '', stderr: '' })),
+      bootstrapLaunchAgent: vi.fn(async () => ({ code: 0, stdout: '', stderr: '' }))
+    }
+
+    await auditLaunchAgents(settings)
+    const second = await auditLaunchAgents(settings)
+
+    expect(second.findings).toEqual([])
+  })
+})

--- a/test/launchd-guard.test.ts
+++ b/test/launchd-guard.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { isDaemonLaunch } from '../src/main/launchd-guard'
+
+describe('launchd guard', () => {
+  it('detects a launch driven by a LaunchAgent label', () => {
+    expect(isDaemonLaunch({ XPC_SERVICE_NAME: 'com.dsh.doctor' }, 'darwin')).toBe(true)
+  })
+
+  it('treats an application service name as an ordinary GUI launch', () => {
+    expect(
+      isDaemonLaunch({ XPC_SERVICE_NAME: 'application.io.dsh.desktop.44736077.44736083' }, 'darwin')
+    ).toBe(false)
+  })
+
+  it('treats the placeholder service name as an ordinary launch', () => {
+    expect(isDaemonLaunch({ XPC_SERVICE_NAME: '0' }, 'darwin')).toBe(false)
+  })
+
+  it('treats a missing service name as an ordinary launch', () => {
+    expect(isDaemonLaunch({}, 'darwin')).toBe(false)
+  })
+
+  it('never claims a daemon launch away from macOS', () => {
+    expect(isDaemonLaunch({ XPC_SERVICE_NAME: 'com.dsh.doctor' }, 'win32')).toBe(false)
+  })
+})

--- a/test/second-instance-intent.test.ts
+++ b/test/second-instance-intent.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { isUserInitiatedInstance } from '../src/main/launchd-guard'
+
+const mainBinary = '/Applications/DSH Desktop.app/Contents/MacOS/DSH Desktop'
+const helperBinary =
+  '/Applications/DSH Desktop.app/Contents/Frameworks/DSH Desktop Helper.app/Contents/MacOS/DSH Desktop Helper'
+
+describe('second instance intent', () => {
+  it('treats a plain application launch as the user asking for the window', () => {
+    expect(isUserInitiatedInstance([mainBinary])).toBe(true)
+  })
+
+  it('treats a launch carrying a file to open as the user asking for the window', () => {
+    expect(isUserInitiatedInstance([mainBinary, '/Users/alex/project'])).toBe(true)
+  })
+
+  it('rejects a helper binary, which no user launch ever runs', () => {
+    expect(isUserInitiatedInstance([helperBinary, '/plugin/cli.mjs', 'supervisor'])).toBe(false)
+  })
+
+  it('rejects a launch that carries a script for the runtime to execute', () => {
+    expect(isUserInitiatedInstance([mainBinary, '/plugin/cli.mjs', 'supervisor'])).toBe(false)
+  })
+
+  it('rejects a commonjs script argument just the same', () => {
+    expect(isUserInitiatedInstance([mainBinary, '/plugin/daemon.js'])).toBe(false)
+  })
+
+  it('treats an empty argument list as a user launch rather than guessing', () => {
+    expect(isUserInitiatedInstance([])).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- A third-party plugin can install a LaunchAgent whose `ProgramArguments[0]` is this app's own Electron binary, without `ELECTRON_RUN_AS_NODE`. launchd then boots it as a full GUI process on every restart, which raises and focuses the app window as if the user asked for it, then exits — repeating via `KeepAlive`.
- Adds three layers of defense:
  - **Guard**: at top-level startup, exit immediately when `XPC_SERVICE_NAME` shows launchd (not the user) started this process, before ever requesting the single-instance lock.
  - **Guard**: the `second-instance` handler now ignores launches that don't look user-initiated (a Helper binary path, or a script argument meant for a runtime).
  - **Repair**: on launch, scan `~/Library/LaunchAgents/*.plist` for jobs that daemonise this app's own binary, and repair them in place (add `ELECTRON_RUN_AS_NODE=1`, reload via bootout/bootstrap), falling back to quarantining the plist if the repair fails, and escalating to a log message instead of looping forever once a label has been repaired 3 times.
- Upstream root cause (the plugin writing an unsafe LaunchAgent) is filed at zhu1090093659/dsh-web#1202; this PR is the host-side mitigation, valid regardless of whether that gets fixed.

## Test plan
- [x] `npx vitest run` — 383/384 passing (the one failure is pre-existing and unrelated, verified against `main`)
- [x] `npx tsc --noEmit`
- [x] Manually verified against a real `com.dsh.doctor` LaunchAgent installed by the dsh-doctor plugin: repackaged the app, restarted, confirmed no focus steal, and confirmed via `launchctl print`/process list that the daemon-launched instance exits immediately instead of raising a window