### PR TITLE
docs: clarify CLI-only plugin compatibility for dsh-market

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ If the normal interface cannot be reached, start DSH Desktop with `--safe-mode`.
 open -a "DSH Desktop" --args --safe-mode
 ```
 
+## Plugin compatibility
+
+DSH Desktop ships the community plugin market through `dsh-market`. Keep these constraints in mind:
+
+- Some community plugins are CLI-only (for example, terminal TUI plugins). They are built for the command-line harness, do not run inside the desktop's web profile, and may collide with the official core bundles' loader entry ids and break the next Harness launch.
+- `dsh-market` 1.10.1 and later detects loader-entry-id collisions at install time and auto-removes the conflicting package. The DSH Desktop installer pulls `dsh-market@latest`, so a fresh install gets the fix automatically.
+- If an incompatible plugin such as `dsh-tui` has already been installed and Harness can no longer start, restart in Safe Mode as above and uninstall the problematic plugin from the Safe Mode banner before returning to a normal launch.
+
 ## Local data and security
 
 - The Harness Web UI is served only on a random loopback port.

--- a/README.zh.md
+++ b/README.zh.md
@@ -73,6 +73,14 @@ Harness 本身始终运行在随机的 `127.0.0.1` 端口。手机访问由独�
 open -a "DSH Desktop" --args --safe-mode
 ```
 
+## 插件兼容性
+
+DSH Desktop 通过 `dsh-market` 提供社区插件市场。需要注意：
+
+- 部分社区插件是 CLI-only 插件（例如终端 TUI 类插件），它们只针对命令行场景设计，在 DSH Desktop 的 Web Profile 中既无法运行，也可能与官方核心 Bundle 的 loader 条目 id 冲突，导致 Harness 启动失败。
+- `dsh-market` 1.10.1+ 会在安装前检测 loader 条目 id 冲突，并自动移除冲突的插件，因此请保持 `dsh-market` 为最新版本（DSH Desktop 的安装器默认会拉取 `latest`）。
+- 如果已经因为安装了不兼容的插件（例如 `dsh-tui`）而无法启动 Harness，请使用上面的安全模式重启，然后在安全模式提示中卸载问题插件；之后再回到正常启动。
+
 ## 本地数据与安全边界
 
 - Harness Web UI 只运行在随机回环端口。


### PR DESCRIPTION
## Summary

Addresses #198 — dsh-tui (and other CLI-only community plugins) cannot run in the DSH Desktop web profile, and a manual install can also collide with the official core bundles' loader entry ids and break the next Harness launch.

The actual conflict-detection fix lives in dsh-market ([dsh-market/dsh-market#123](https://github.com/dsh-market/dsh-market/pull/123), shipped in `dshmarket@1.10.1`). The DSH Desktop installer already pulls `dshmarket@latest`, so a fresh install gets that fix. This PR closes the user-facing gap on the desktop side by documenting:

- Some community plugins (e.g. `dsh-tui`) are CLI-only and not designed for the desktop's web profile.
- `dsh-market` 1.10.1+ detects loader-entry-id collisions at install time and auto-removes the conflicting package.
- If an incompatible plugin has already been installed and Harness can no longer start, users can restart in Safe Mode and uninstall the problematic plugin from the Safe Mode banner.

## Changes

- `README.md` — new "Plugin compatibility" section right after "Safe Mode and recovery".
- `README.zh.md` — mirrored "插件兼容性" section, since the original issue is in Chinese.

No code changes; this is a docs-only follow-up because the runtime fix is in dsh-market and is already shipped.

## Test plan

- [x] Verified the new section renders correctly in both English and Chinese READMEs.
- [x] Confirmed branch is based on `origin/main` (`95f2fda` on top of `e589bf6`).
- [x] No new code paths; existing tests unaffected.

Fixes #198