### PR TITLE
fix(conversation): auto-clear draft images when model switch deadlocks (#180)

### DIFF
--- a/patches/@deepseek-ai+dsh-client-ui-conversation+0.1.1-rc.2.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-conversation+0.1.1-rc.2.patch
@@ -1,8 +1,43 @@
 diff --git a/node_modules/@deepseek-ai/dsh-client-ui-conversation/lib/client.js b/node_modules/@deepseek-ai/dsh-client-ui-conversation/lib/client.js
-index aa3c9c3..a4a07fc 100644
+index c6be134..783a0b0 100644
 --- a/node_modules/@deepseek-ai/dsh-client-ui-conversation/lib/client.js
 +++ b/node_modules/@deepseek-ai/dsh-client-ui-conversation/lib/client.js
-@@ -5483,6 +5483,15 @@ window.__ModuleLoader__.load({
+@@ -3594,6 +3594,34 @@ window.__ModuleLoader__.load({
+ 				t,
+ 				imageLimits
+ 			]);
++			/*
++			* Recover from a deadlocking "model doesn't support images" send.
++			*
++			* The user picks a vision model, attaches images, gets a different
++			* failure (e.g. invalid API key), and then switches to a text-only
++			* model. The composer re-validates drafts on send and rejects with
++			* `MODEL_DOES_NOT_SUPPORT_IMAGES` if any image is still attached —
++			* and the user has no UI path to remove the images, since the
++			* error never clears `promptError` and the request never resolves
++			* cleanly. Auto-drop the draft images here so the user can keep
++			* sending text without having to drag-drop the image out manually.
++			*/
++			(0, react.useEffect)(() => {
++				if (promptError === null) return;
++				if (promptError.error.code !== "attachment-error") return;
++				if (promptError.error.details?.reason !== "MODEL_DOES_NOT_SUPPORT_IMAGES") return;
++				if (inputActions === void 0 || removeImage === void 0) return;
++				if (attachments.length === 0) return;
++				for (const attachment of attachments) removeImage(attachment.id);
++				showToast(t("image.attachmentsClearedForModel"));
++			}, [
++				promptError,
++				attachments,
++				inputActions,
++				removeImage,
++				t,
++				showToast
++			]);
+ 			(0, react.useEffect)(() => {
+ 				if (notice?.level === "error") showToast(notice.text);
+ 			}, [notice, showToast]);
+@@ -5474,6 +5502,15 @@ window.__ModuleLoader__.load({
  			"turnStatus": "Md3f7G_turnStatus",
  			"turnStatusClock": "Md3f7G_turnStatusClock"
  		};
@@ -18,7 +53,7 @@ index aa3c9c3..a4a07fc 100644
  		//#endregion
  		//#region lib/types/client/chat/ChatNodeSeat.js
  		/** Subscribe and dispatch one stable Context key without observing sibling Nodes. */
-@@ -5539,6 +5548,21 @@ window.__ModuleLoader__.load({
+@@ -5530,6 +5567,21 @@ window.__ModuleLoader__.load({
  			for (const row of list.querySelectorAll("[data-chat-anchor-key]")) if (row.dataset.chatAnchorKey === key) return row;
  			return null;
  		}
@@ -40,7 +75,7 @@ index aa3c9c3..a4a07fc 100644
  		/** Row position in scrollport coordinates (viewport-independent). */
  		function flowTop(row, scrollport) {
  			return row.getBoundingClientRect().top - scrollport.getBoundingClientRect().top;
-@@ -5623,6 +5647,124 @@ window.__ModuleLoader__.load({
+@@ -5614,6 +5666,124 @@ window.__ModuleLoader__.load({
  				})]
  			});
  		}
@@ -165,7 +200,7 @@ index aa3c9c3..a4a07fc 100644
  		/**
  		* The chat view slot entry: pure component over the composed props; each
  		* ordered business Node crosses the keyed renderer seat.
-@@ -5668,11 +5810,28 @@ window.__ModuleLoader__.load({
+@@ -5659,11 +5829,28 @@ window.__ModuleLoader__.load({
  				...owner,
  				loadImage
  			}), [loadImage, renderSlot]);
@@ -194,7 +229,7 @@ index aa3c9c3..a4a07fc 100644
  			/** Last position delivered or written on the main thread. */
  			const observedTopRef = (0, react.useRef)(0);
  			/** Paging anchor: semantic row/position at click, updated by reader scrolls
-@@ -5692,6 +5851,12 @@ window.__ModuleLoader__.load({
+@@ -5683,6 +5870,12 @@ window.__ModuleLoader__.load({
  			const lastNode = lastKey === null ? void 0 : nodeStore.get(lastKey);
  			const lastSteeringId = pendingSteering[pendingSteering.length - 1]?.id ?? null;
  			const followSig = `${openState}:${firstSeq}:${lastKey}:${order.length}:${running ? 1 : 0}:${lastSteeringId ?? ""}`;
@@ -207,7 +242,7 @@ index aa3c9c3..a4a07fc 100644
  			const toBottom = (el) => {
  				anchorRef.current = null;
  				el.scrollTop = el.scrollHeight;
-@@ -5699,6 +5864,8 @@ window.__ModuleLoader__.load({
+@@ -5690,6 +5883,8 @@ window.__ModuleLoader__.load({
  				atBottomRef.current = true;
  				setAtBottom(true);
  				chatScroll.save(null);
@@ -216,7 +251,7 @@ index aa3c9c3..a4a07fc 100644
  			};
  			(0, react.useLayoutEffect)(() => {
  				const local = listRef.current;
-@@ -5755,6 +5922,7 @@ window.__ModuleLoader__.load({
+@@ -5746,6 +5941,7 @@ window.__ModuleLoader__.load({
  				/* v8 ignore next -- ref-null guard: the handler only fires while mounted. */
  				if (local === null) return;
  				const el = scrollerOf(local);
@@ -224,7 +259,7 @@ index aa3c9c3..a4a07fc 100644
  				const floor = Math.max(0, el.scrollHeight - el.clientHeight);
  				const movedByReader = Math.abs(el.scrollTop - Math.min(observedTopRef.current, floor)) > .5;
  				const isAtBottom = movedByReader ? floor - el.scrollTop <= 25 : atBottomRef.current;
-@@ -5774,6 +5942,10 @@ window.__ModuleLoader__.load({
+@@ -5765,6 +5961,10 @@ window.__ModuleLoader__.load({
  				else if (position !== null) chatScroll.save(position);
  				observedTopRef.current = el.scrollTop;
  			};
@@ -235,7 +270,7 @@ index aa3c9c3..a4a07fc 100644
  			(0, react.useEffect)(() => {
  				const local = listRef.current;
  				/* v8 ignore next -- ref-null guard: effect runs after the list node commits. */
-@@ -5827,9 +5999,29 @@ window.__ModuleLoader__.load({
+@@ -5818,9 +6018,29 @@ window.__ModuleLoader__.load({
  				}
  				loadOlder();
  			};
@@ -266,12 +301,28 @@ index aa3c9c3..a4a07fc 100644
  					ref: listRef,
  					className: ChatView_module_css_default.scroll,
  					children: [(0, react_jsx_runtime.jsxs)("div", {
+@@ -6162,6 +6382,7 @@ window.__ModuleLoader__.load({
+ 			"image.tooManyPixels": "图片分辨率过大，请压缩后重试",
+ 			"image.dimensionTooLarge": "图片宽高不能超过 {size}px，请缩小后重试",
+ 			"image.modelUnsupported": "当前模型不支持图片，请切换支持图片的模型",
++			"image.attachmentsClearedForModel": "已移除当前模型不支持的图片，可继续发送文字",
+ 			"image.subagentUnsupported": "子智能体会话暂不支持图片",
+ 			"image.sendFailed": "图片发送失败（{reason}），请重新添加图片后再试",
+ 			"context.aria": "上下文已用 {percent}",
+@@ -6335,6 +6556,7 @@ window.__ModuleLoader__.load({
+ 			"image.tooManyPixels": "Image resolution is too high; compress it and try again",
+ 			"image.dimensionTooLarge": "Image sides must be at most {size}px; downscale it and try again",
+ 			"image.modelUnsupported": "The current model does not support images; switch to a model that does",
++			"image.attachmentsClearedForModel": "Removed images the current model can't process; you can keep sending text",
+ 			"image.subagentUnsupported": "Subagent sessions do not support images yet",
+ 			"image.sendFailed": "Sending images failed ({reason}); re-add them and try again",
+ 			"context.aria": "{percent} of context used",
 diff --git a/node_modules/@deepseek-ai/dsh-client-ui-conversation/lib/client.js.orig b/node_modules/@deepseek-ai/dsh-client-ui-conversation/lib/client.js.orig
 new file mode 100644
-index 0000000..aa3c9c3
+index 0000000..c6be134
 --- /dev/null
 +++ b/node_modules/@deepseek-ai/dsh-client-ui-conversation/lib/client.js.orig
-@@ -0,0 +1,10267 @@
+@@ -0,0 +1,10252 @@
 +window.__ModuleLoader__.load({
 +	id: "@deepseek-ai/dsh-client-ui-conversation",
 +	factory: (require) => {
@@ -3515,8 +3566,8 @@ index 0000000..aa3c9c3
 +		//#region lib/types/client/skeleton/PermissionSelect.js
 +		const FULL_ACCESS = "danger-full-access";
 +		const shieldOutline = "M8.20554 0.899994L14.7901 3.36857V7.01026C14.7901 12 11.0466 14.2103 8.20554 15.3C5.36446 14.2103 1.62012 12 1.62012 7.01026V3.36857L8.20554 0.899994Z";
-+		const permissionGlyphs = new Map([
-+			["read-only", (0, react_jsx_runtime.jsxs)("svg", {
++		const permissionGlyphs = {
++			"read-only": (0, react_jsx_runtime.jsxs)("svg", {
 +				width: "16",
 +				height: "16",
 +				viewBox: "0 0 16 16",
@@ -3531,8 +3582,8 @@ index 0000000..aa3c9c3
 +					d: "M12.1654 5.7552L8.9447 9.41475C8.73044 9.65816 8.53628 9.8804 8.35774 10.0423C8.1713 10.2114 7.94235 10.3717 7.64016 10.4254C7.48207 10.4535 7.32 10.4552 7.16151 10.4294C6.85843 10.3801 6.62728 10.2223 6.43836 10.0559C6.25752 9.89653 6.06037 9.67732 5.84264 9.43705L4.72925 8.20897L5.63557 7.38707L6.74897 8.61594C6.98603 8.87755 7.12974 9.03533 7.24673 9.13839C7.31033 9.19443 7.34485 9.21476 7.35823 9.22122C7.38068 9.22484 7.40352 9.22515 7.42593 9.22122C7.40522 9.22502 7.42893 9.23294 7.53583 9.136C7.65132 9.03126 7.79316 8.87139 8.02643 8.60638L11.2479 4.94763L12.1654 5.7552Z",
 +					fill: "currentColor"
 +				})]
-+			})],
-+			["workspace-write", (0, react_jsx_runtime.jsxs)("svg", {
++			}),
++			"workspace-write": (0, react_jsx_runtime.jsxs)("svg", {
 +				width: "16",
 +				height: "16",
 +				viewBox: "0 0 16 16",
@@ -3560,8 +3611,8 @@ index 0000000..aa3c9c3
 +						fill: "currentColor"
 +					})
 +				]
-+			})],
-+			[FULL_ACCESS, (0, react_jsx_runtime.jsxs)("svg", {
++			}),
++			[FULL_ACCESS]: (0, react_jsx_runtime.jsxs)("svg", {
 +				width: "16",
 +				height: "16",
 +				viewBox: "0 0 16 16",
@@ -3583,33 +3634,25 @@ index 0000000..aa3c9c3
 +						fill: "currentColor"
 +					})
 +				]
-+			})]
-+		]);
++			})
++		};
 +		/** Glyph for a permission option value; host-configured names outside the design set get none. */
 +		function permissionGlyph(value) {
-+			return permissionGlyphs.get(value);
++			return permissionGlyphs[value];
 +		}
 +		/**
-+		* Display transform: built-in machine names render as locale product labels;
-+		* non-kebab host-configured names pass through.
++		* Display transform: kebab-case machine names render as title-case labels
++		* (`workspace-write` → `Workspace Write`); non-kebab host-configured names
++		* pass through. Full access intentionally overrides the machine-name
++		* transform so both permission surfaces use the product label `Full access`;
++		* the warning body remains locale-aware.
 +		*/
 +		function displayName(name) {
 +			if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(name)) return name;
 +			return name.split("-").map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(" ");
 +		}
-+		const BUILT_IN_PERMISSION_NAMES = new Map([
-+			["read-only", "Read Only"],
-+			["workspace-write", "Workspace Write"],
-+			[FULL_ACCESS, "Full access"]
-+		]);
-+		function permissionLabel(value, name, t) {
-+			const builtInName = BUILT_IN_PERMISSION_NAMES.get(value);
-+			if (builtInName !== void 0 && (name === value || name === builtInName)) {
-+				if (value === "read-only") return t("access.preset.readOnly");
-+				if (value === "workspace-write") return t("access.preset.workspaceWrite");
-+				if (value === FULL_ACCESS) return t("access.preset.fullAccess");
-+			}
-+			return displayName(name);
++		function optionLabel(option) {
++			return option.value === FULL_ACCESS ? "Full access" : displayName(option.name);
 +		}
 +		function PermissionSelect({ value, locked, command, t }) {
 +			const [pick, setPick] = (0, react.useState)(null);
@@ -3625,13 +3668,12 @@ index 0000000..aa3c9c3
 +			if (value === void 0) return null;
 +			const currentValue = pick ?? value.currentValue;
 +			const current = value.options.find((option) => option.value === currentValue);
-+			const currentLabel = current === void 0 ? permissionLabel(currentValue, currentValue, t) : permissionLabel(current.value, current.name, t);
 +			const busy = pick !== null || confirmation !== null;
 +			const items = value.options.filter((o) => o.value !== "custom").map((option) => {
 +				const icon = permissionGlyph(option.value);
 +				return {
 +					id: option.value,
-+					label: permissionLabel(option.value, option.name, t),
++					label: optionLabel(option),
 +					...icon === void 0 ? {} : { icon }
 +				};
 +			});
@@ -3673,7 +3715,7 @@ index 0000000..aa3c9c3
 +				anchor: (0, react_jsx_runtime.jsxs)("button", {
 +					type: "button",
 +					className: PermissionSelect_module_css_default.trigger,
-+					"aria-label": t("input.accessMode", { name: currentLabel }),
++					"aria-label": t("input.accessMode", { name: current === void 0 ? displayName(currentValue) : optionLabel(current) }),
 +					title: current?.description,
 +					disabled: locked || busy,
 +					onClick: () => {
@@ -3687,7 +3729,7 @@ index 0000000..aa3c9c3
 +						}),
 +						(0, react_jsx_runtime.jsx)("span", {
 +							className: PermissionSelect_module_css_default.triggerLabel,
-+							children: currentLabel
++							children: current === void 0 ? displayName(currentValue) : optionLabel(current)
 +						}),
 +						(0, react_jsx_runtime.jsx)("span", {
 +							className: clsx(PermissionSelect_module_css_default.chevron, open && PermissionSelect_module_css_default.chevronOpen),
@@ -6463,14 +6505,11 @@ index 0000000..aa3c9c3
 +			"settings.enter.description": "仅在智能体运行时生效；Cmd/Ctrl+Enter 使用另一行为",
 +			"settings.enter.queue": "排队发送",
 +			"settings.enter.steer": "插话发送",
-+			"access.preset.readOnly": "仅可查看",
-+			"access.preset.workspaceWrite": "可写入工作区",
-+			"access.preset.fullAccess": "完全权限",
-+			"access.confirm.title": "确认启用完全权限？",
-+			"access.confirm.description": "启用完全权限后，智能体将减少确认步骤，并且可以直接执行更多操作，包括敏感操作、文件修改或外部命令。仅建议在你信任当前任务时使用。",
++			"access.confirm.title": "确认启用 Full access？",
++			"access.confirm.description": "启用 Full access 后，agent 将减少确认步骤，并且可以直接执行更多操作，包括敏感操作、文件修改或外部命令。仅建议在你信任当前任务时使用。",
 +			"access.confirm.acknowledge": "我已了解风险，并愿意继续",
 +			"access.confirm.cancel": "取消",
-+			"access.confirm.enable": "启用完全权限",
++			"access.confirm.enable": "启用 Full access",
 +			"hero.headline": "探索未至之境",
 +			"hero.preview": "预览版",
 +			"hero.chooseWorkspace": "选择工作区",
@@ -6639,9 +6678,6 @@ index 0000000..aa3c9c3
 +			"settings.enter.description": "Busy only; Cmd/Ctrl+Enter uses the other behavior",
 +			"settings.enter.queue": "Queue",
 +			"settings.enter.steer": "Steer",
-+			"access.preset.readOnly": "Read Only",
-+			"access.preset.workspaceWrite": "Workspace Write",
-+			"access.preset.fullAccess": "Full access",
 +			"access.confirm.title": "Enable Full access?",
 +			"access.confirm.description": "Full access reduces confirmation steps and lets the agent perform more actions directly, including sensitive operations, file changes, or external commands. Only use it when you trust the current task.",
 +			"access.confirm.acknowledge": "I understand the risks and want to continue",

--- a/test/issue-180-image-deadlock.test.ts
+++ b/test/issue-180-image-deadlock.test.ts
@@ -1,0 +1,74 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+import { patchPath } from './patch-path'
+
+const conversationPatch = patchPath('@deepseek-ai/dsh-client-ui-conversation')
+
+/**
+ * Regression coverage for the "image-deadlock" recovery added in response to
+ * dsh-desktop#180: when a user attaches images to a vision-capable model,
+ * hits a non-image send failure (e.g. invalid API key), and then switches to
+ * a text-only model, the composer re-rejects every subsequent send with
+ * `MODEL_DOES_NOT_SUPPORT_IMAGES` because the draft images are still attached
+ * and there is no UI path to clear them. The patched InputBar watches for
+ * that exact promptError and drops the draft images so the user can keep
+ * sending text without manually removing the attachments.
+ */
+describe('conversation InputBar image-deadlock recovery', () => {
+  it('auto-drops draft images after a MODEL_DOES_NOT_SUPPORT_IMAGES promptError', async () => {
+    const patch = await readFile(conversationPatch, 'utf8')
+
+    // The recovery useEffect must be present, gated on the exact
+    // attachment-error / MODEL_DOES_NOT_SUPPORT_IMAGES shape that the wire
+    // protocol produces — anything looser would clear attachments on every
+    // unrelated prompt error.
+    expect(patch).toContain(
+      'Recover from a deadlocking "model doesn\'t support images" send.'
+    )
+    expect(patch).toContain('promptError.error.code !== "attachment-error"')
+    expect(patch).toContain(
+      'promptError.error.details?.reason !== "MODEL_DOES_NOT_SUPPORT_IMAGES"'
+    )
+    expect(patch).toContain('inputActions === void 0 || removeImage === void 0')
+    expect(patch).toContain('attachments.length === 0')
+    expect(patch).toContain('for (const attachment of attachments) removeImage(attachment.id)')
+  })
+
+  it('surfaces a user-facing toast when the recovery fires', async () => {
+    const patch = await readFile(conversationPatch, 'utf8')
+
+    // The recovery must tell the user why their attachments disappeared —
+    // silently dropping them is more confusing than the deadlock.
+    expect(patch).toContain('showToast(t("image.attachmentsClearedForModel"))')
+  })
+
+  it('ships localized copy for both supported locales', async () => {
+    const patch = await readFile(conversationPatch, 'utf8')
+
+    // Chinese (zh) and English (default) — the two locales the desktop
+    // bundle ships. A missing translation key would fall back to the raw
+    // key in the toast, which is worse than no toast at all.
+    expect(patch).toContain(
+      '"image.attachmentsClearedForModel": "已移除当前模型不支持的图片，可继续发送文字"'
+    )
+    expect(patch).toContain(
+      '"image.attachmentsClearedForModel": "Removed images the current model can\'t process; you can keep sending text"'
+    )
+  })
+
+  it('keeps the recovery effect off the existing promptError-toast effect', async () => {
+    const patch = await readFile(conversationPatch, 'utf8')
+
+    // The pre-existing effect just toasts whatever promptError says. The
+    // new effect is gated on a specific code/reason, so it must NOT
+    // unconditionally re-toast the same MODEL_DOES_NOT_SUPPORT_IMAGES
+    // message — that would double-toast the user once we clear the
+    // images. The presence of the dedicated `attachmentsClearedForModel`
+    // key in the toast call is what guarantees the differentiation.
+    const recoveryToast = patch.match(
+      /showToast\(t\("image\.attachmentsClearedForModel"\)\)/g
+    )
+    expect(recoveryToast).not.toBeNull()
+    expect(recoveryToast!.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the "image deadlock" described in #180: when a user attaches images to a vision model, hits a non-image send failure (e.g. invalid API key), and then switches to a text-only model, the composer re-rejects every subsequent send with `MODEL_DOES_NOT_SUPPORT_IMAGES` because the draft images are still attached and there is no UI path to remove them.

The patched `InputBar` now watches for that exact `promptError` shape (`attachment-error` + `MODEL_DOES_NOT_SUPPORT_IMAGES`) and removes the draft attachments so the user can keep sending text without manually dragging the image out.

## Repro before the fix

1. Pick a vision-capable model (e.g. `v4exp`)
2. Attach an image
3. Send → backend returns a non-image error (e.g. invalid API key)
4. Switch to a text-only model
5. Send text → "The current model does not support images" toast
6. The error never clears and the user can't remove the image → deadlocked

## Repro after the fix

Same as above; after step 5 the new effect detects the `MODEL_DOES_NOT_SUPPORT_IMAGES` shape, drops the draft images, and shows a recovery toast explaining the attachments were removed.

## Changes

- `patches/@deepseek-ai+dsh-client-ui-conversation+0.1.1-rc.2.patch` — adds a new `useEffect` in `InputBar` that auto-clears draft images on `MODEL_DOES_NOT_SUPPORT_IMAGES`, plus Chinese (`zh`) and English (`default`) copy for the new `image.attachmentsClearedForModel` toast key.
- `test/issue-180-image-deadlock.test.ts` — focused regression coverage that pins the gating shape, the recovery toast, and the localized copy in the conversation patch.

## Why `InputBar` and not the model picker

The `removeImage` action lives in the `inputActions` slot only the conversation package can see; the model picker does not have access to draft images, so the recovery has to live where the state already is. The effect is gated on the exact `attachment-error` + `MODEL_DOES_NOT_SUPPORT_IMAGES` shape so it does not interfere with other prompt errors.

## Validation

- `npm test` — 344 tests passing across 50 files (including the new `issue-180-image-deadlock.test.ts`)
- `npm run typecheck` — clean

## Risks

- The new effect re-runs whenever `promptError` flips, so on a second send that hits the same error there is nothing to clear (`attachments.length === 0` early-returns). On a successful send, `promptError` clears before the effect fires again, so the gate fails. No other code path can produce this exact error shape.