### PR TITLE
fix(win32): stop forcing pnpm clone-or-copy on plugin installs

### DIFF
--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -231,19 +231,19 @@ export async function ensurePnpmShim(home = dshHome()) {
     await chmod(nodePath, 0o755)
   }
 
-  // Also write .npmrc in profiles/web to prevent Windows file lock conflicts and racing worker threads
+  // Also write .npmrc in profiles/web. package-import-method/child-concurrency
+  // are intentionally left at pnpm's defaults (hardlink, auto concurrency):
+  // forcing clone-or-copy made every install do a full physical file copy
+  // across the profile's 150+ packages, turning installs that should take
+  // seconds into multi-minute (up to 30-minute) waits on Windows. The
+  // Windows locked-rename problem this was meant to route around is handled
+  // by the dedicated lock-recovery runner instead (see pnpm-runner.mjs).
   const profileDir = profileDirectory(home)
   await mkdir(profileDir, { recursive: true })
   const npmrcPath = join(profileDir, '.npmrc')
-  const npmrcContent = [
-    'package-import-method=clone-or-copy',
-    'child-concurrency=1',
-    'side-effects-cache=false'
-  ].join('\n') + '\n'
+  const npmrcContent = ['side-effects-cache=false'].join('\n') + '\n'
   try {
-    if (!existsSync(npmrcPath)) {
-      await writeFile(npmrcPath, npmrcContent, 'utf8')
-    }
+    await writeFile(npmrcPath, npmrcContent, 'utf8')
   } catch {
     // ignore
   }
@@ -301,12 +301,7 @@ export function buildPnpmEnvironment(
   if (process.platform === 'win32') result.Path = value
   result.CI = 'true'
   result.NO_COLOR = '1'
-  result.PNPM_MAX_WORKERS = '1'
-  result.npm_config_child_concurrency = '1'
-  result.npm_config_package_import_method = 'clone-or-copy'
   result.npm_config_side_effects_cache = 'false'
-  result.PNPM_CONFIG_CHILD_CONCURRENCY = '1'
-  result.PNPM_CONFIG_PACKAGE_IMPORT_METHOD = 'clone-or-copy'
   result.PNPM_CONFIG_SIDE_EFFECTS_CACHE = 'false'
   return result
 }

--- a/src/main/runtime/harness-runtime.ts
+++ b/src/main/runtime/harness-runtime.ts
@@ -192,12 +192,14 @@ export function buildHarnessSpawnOptions(
       ...parentEnvironment,
       DSH_HOME: dshHome,
       NO_COLOR: '1',
-      PNPM_MAX_WORKERS: '1',
-      npm_config_child_concurrency: '1',
-      npm_config_package_import_method: 'clone-or-copy',
+      // package-import-method/child-concurrency are left at pnpm's defaults
+      // (hardlink, auto concurrency): forcing clone-or-copy made every
+      // install do a full physical file copy across the profile's 150+
+      // packages, which is what turned installs that should take seconds
+      // into multi-minute (up to 30-minute) waits on Windows. The Windows
+      // locked-rename problem this was meant to route around is handled by
+      // the dedicated lock-recovery runner instead (see pnpm-runner.mjs).
       npm_config_side_effects_cache: 'false',
-      PNPM_CONFIG_CHILD_CONCURRENCY: '1',
-      PNPM_CONFIG_PACKAGE_IMPORT_METHOD: 'clone-or-copy',
       PNPM_CONFIG_SIDE_EFFECTS_CACHE: 'false',
       [pathKey]: environment[pathKey] ?? environment.PATH ?? ''
     },

--- a/src/main/runtime/profile-plugin-command.ts
+++ b/src/main/runtime/profile-plugin-command.ts
@@ -152,12 +152,7 @@ export function buildProfilePluginCommandEnvironment(
   result.DSH_HOME = result.DSH_HOME ?? ''
   result.CI = 'true'
   result.NO_COLOR = '1'
-  result.PNPM_MAX_WORKERS = '1'
-  result.npm_config_child_concurrency = '1'
-  result.npm_config_package_import_method = 'clone-or-copy'
   result.npm_config_side_effects_cache = 'false'
-  result.PNPM_CONFIG_CHILD_CONCURRENCY = '1'
-  result.PNPM_CONFIG_PACKAGE_IMPORT_METHOD = 'clone-or-copy'
   result.PNPM_CONFIG_SIDE_EFFECTS_CACHE = 'false'
   return result
 }

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -85,8 +85,9 @@ describe('desktop plugin market installer', () => {
     }
 
     const npmrc = await readFile(join(home, 'profiles', 'web', '.npmrc'), 'utf8')
-    expect(npmrc).toContain('package-import-method=clone-or-copy')
-    expect(npmrc).toContain('child-concurrency=1')
+    expect(npmrc).toContain('side-effects-cache=false')
+    expect(npmrc).not.toContain('package-import-method')
+    expect(npmrc).not.toContain('child-concurrency')
   })
 
   it('cleans up staging and sidelined directories left by interrupted installations', async () => {
@@ -215,10 +216,9 @@ describe('desktop plugin market installer', () => {
     // entry declares it for its children, so the environment must pass it
     // through rather than stripping it.
     expect(pnpmEnv.ELECTRON_RUN_AS_NODE).toBe('1')
-    expect(pnpmEnv.PNPM_MAX_WORKERS).toBe('1')
-    expect(pnpmEnv.npm_config_child_concurrency).toBe('1')
-    expect(pnpmEnv.npm_config_package_import_method).toBe('clone-or-copy')
     expect(pnpmEnv.npm_config_side_effects_cache).toBe('false')
+    expect(pnpmEnv.npm_config_child_concurrency).toBeUndefined()
+    expect(pnpmEnv.npm_config_package_import_method).toBeUndefined()
 
     const next = service.runPlugin(['install'], root)
     await expect(next.done).resolves.toEqual({ exitCode: 0, signal: null })

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -162,12 +162,7 @@ describe('Harness launch contract', () => {
           PATH: '/usr/bin',
           DSH_HOME: '/Users/tester/Library/Application Support/dsh-desktop/harness',
           NO_COLOR: '1',
-          PNPM_MAX_WORKERS: '1',
-          npm_config_child_concurrency: '1',
-          npm_config_package_import_method: 'clone-or-copy',
           npm_config_side_effects_cache: 'false',
-          PNPM_CONFIG_CHILD_CONCURRENCY: '1',
-          PNPM_CONFIG_PACKAGE_IMPORT_METHOD: 'clone-or-copy',
           PNPM_CONFIG_SIDE_EFFECTS_CACHE: 'false'
         },
         execArgv: ['--expose-internals'],


### PR DESCRIPTION
package-import-method=clone-or-copy plus child-concurrency=1 was forcing every pnpm install to do a full physical file copy of every file in every package instead of the default hardlink, serialized to one package at a time. On a profile with 150+ packages this turned installs that should take seconds into multi-minute (up to 30-minute, per user reports) waits on Windows, especially with AV real-time scanning in the mix.

The setting was added to route around a different Windows problem — a locked rename when Harness (or a scanner) holds a handle inside the directory pnpm is replacing — but that is now handled by the dedicated lock-recovery pnpm-runner.mjs shim (retry, sideline, prune), which is copy-method agnostic. Reverting to pnpm's defaults is a straight win.

Also fixes the .npmrc so it's rewritten on every launch instead of only when absent — previously an install already affected by this on a given machine would keep the stale clone-or-copy pin forever even after the code was fixed.