### PR TITLE
fix(windows): recover main window from GPU/renderer crashes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -74,6 +74,10 @@ import { buildPluginRecoveryViewModel } from './plugin-recovery-view'
 import { buildSafeModeViewModel, shouldStartInSafeMode } from './safe-mode'
 import { aboutDetail, bundledHarnessVersion } from './version-info'
 import { windowsMenuViewBounds } from './windows-menu-view'
+import {
+  MAIN_WINDOW_RECOVERY_RELOAD_COOLDOWN_MS,
+  shouldReloadAfterMainWindowRendererLoss
+} from './main-window-recovery'
 
 type PluginRecoveryAction = 'uninstall' | 'show-log' | 'quit' | 'restart' | 'refresh' | 'safe-mode'
 type SafeModeAction =
@@ -112,6 +116,14 @@ let safeModeVisible = false
 let safeModeManagerVisible = false
 let safeModeManagerWindow: BrowserWindow | undefined
 let safeModeActionResolver: ((action: SafeModeAction) => void) | undefined
+// A renderer that crashes (render-process-gone) and reloads that fails the
+// same way produces a permanent black window the user has to close by hand.
+// The cooldown keeps reloads from stacking up when the underlying crash
+// (almost always the GPU process) keeps recurring, and the counter gives us
+// a way to give up after enough attempts and surface the harness failure
+// page instead of hammering the GPU.
+let mainWindowRecoveryReloadAt = 0
+let mainWindowRecoveryReloadCount = 0
 const startInSafeMode = shouldStartInSafeMode(process.argv)
 
 function appendRendererPluginFailureLog(message: string): void {
@@ -203,6 +215,95 @@ function isDevelopmentBuild(): boolean {
 }
 
 const developmentBuild = isDevelopmentBuild()
+
+/**
+ * Record a renderer/GPU process loss in the harness log so the cause survives
+ * a restart. Without this, a black window after running for a while leaves
+ * nothing to diagnose — the desktop keeps the BrowserWindow alive and the
+ * user has to close it by hand with no breadcrumb in the log.
+ */
+function recordMainWindowRendererLoss(
+  source: 'render-process-gone' | 'did-fail-load' | 'unresponsive',
+  details: string
+): void {
+  if (!runtime) return
+  runtime.note(`[desktop] main window ${source}: ${details}`)
+}
+
+function reloadMainWindowAfterRendererLoss(window: BrowserWindow): void {
+  if (window.isDestroyed() || window.webContents.isDestroyed()) return
+  const now = Date.now()
+  if (!shouldReloadAfterMainWindowRendererLoss({
+    now,
+    lastReloadAt: mainWindowRecoveryReloadAt,
+    reloadCount: mainWindowRecoveryReloadCount
+  })) {
+    recordMainWindowRendererLoss(
+      'render-process-gone',
+      'reload throttled; surfacing harness failure instead'
+    )
+    const snapshot = runtime?.snapshot()
+    if (snapshot && runtime?.snapshot().phase === 'ready') {
+      // Reloading is failing on its own. Step the runtime back to 'failed' so
+      // the plugin-recovery page is shown and the user can recover without a
+      // hard restart.
+      void showPluginRecovery({
+        message: 'Harness web view stopped responding. Reload it to continue.',
+        logs: snapshot.logs
+      }).catch(showUnexpectedError)
+    }
+    return
+  }
+  mainWindowRecoveryReloadAt = now
+  mainWindowRecoveryReloadCount += 1
+  // Schedule a counter reset long after the cooldown so a single, isolated
+  // crash recovers cleanly while a sustained failure still trips the cap.
+  setTimeout(() => {
+    mainWindowRecoveryReloadCount = 0
+  }, MAIN_WINDOW_RECOVERY_RELOAD_COOLDOWN_MS * 4).unref?.()
+  try {
+    void window.webContents.reload()
+  } catch (error) {
+    recordMainWindowRendererLoss(
+      'render-process-gone',
+      `reload threw: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+function installMainWindowRendererRecovery(window: BrowserWindow): void {
+  const webContents = window.webContents
+  webContents.on('render-process-gone', (event, details) => {
+    // Take control: by default the window stays drawn but blank, which is
+    // exactly the black screen this recovery is meant to prevent.
+    event.preventDefault()
+    const reason = details?.reason ?? 'unknown'
+    const exitCode = details?.exitCode ?? -1
+    recordMainWindowRendererLoss('render-process-gone', `reason=${reason} exitCode=${exitCode}`)
+    reloadMainWindowAfterRendererLoss(window)
+  })
+  webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (!isMainFrame) return
+    // The harness web server is local; a failure to reach it is almost
+    // always the renderer dropping, not a real network error. Surface the
+    // failure and let the recovery path try to reload the page.
+    recordMainWindowRendererLoss(
+      'did-fail-load',
+      `errorCode=${errorCode} description=${errorDescription} url=${validatedURL}`
+    )
+    reloadMainWindowAfterRendererLoss(window)
+  })
+  webContents.on('unresponsive', () => {
+    // unresponsive fires before the renderer actually dies, so logging here
+    // gives a useful "the GPU froze here" breadcrumb for the next time
+    // the user has to recover the window.
+    recordMainWindowRendererLoss('unresponsive', 'main window webContents became unresponsive')
+  })
+  webContents.on('responsive', () => {
+    if (!runtime) return
+    runtime.note('[desktop] main window webContents became responsive again')
+  })
+}
 
 function windowsTitleBarOverlay(isDark: boolean): Electron.TitleBarOverlayOptions {
   return {
@@ -521,6 +622,7 @@ function createWindow(): BrowserWindow {
   installPluginRecoveryNavigation(window)
   secureWindow(window)
   installContextMenu(window, harnessLocale)
+  installMainWindowRendererRecovery(window)
   window.on('closed', () => {
     if (mainWindow === window) mainWindow = undefined
     if (windowsMenuView && !windowsMenuView.webContents.isDestroyed()) {

--- a/src/main/main-window-recovery.ts
+++ b/src/main/main-window-recovery.ts
@@ -1,0 +1,25 @@
+export const MAIN_WINDOW_RECOVERY_RELOAD_COOLDOWN_MS = 5_000
+export const MAIN_WINDOW_RECOVERY_MAX_RELOADS = 3
+
+/**
+ * Decide whether the main window can be safely reloaded after the renderer
+ * or GPU process went away. The default Electron behavior on Windows when
+ * the GPU process dies is to leave the window drawn but blank, so a single
+ * reload is almost always the right call — except when the same cause keeps
+ * recurring, in which case reloading in a tight loop only masks the real
+ * problem and exhausts the GPU. Bounding the reload attempts and spacing
+ * them out is the difference between self-healing and a stuck window.
+ */
+export function shouldReloadAfterMainWindowRendererLoss(options: {
+  now: number
+  lastReloadAt: number
+  reloadCount: number
+  cooldownMs?: number
+  maxReloads?: number
+}): boolean {
+  const cooldown = options.cooldownMs ?? MAIN_WINDOW_RECOVERY_RELOAD_COOLDOWN_MS
+  const maxReloads = options.maxReloads ?? MAIN_WINDOW_RECOVERY_MAX_RELOADS
+  if (options.reloadCount >= maxReloads) return false
+  if (options.lastReloadAt === 0) return true
+  return options.now - options.lastReloadAt >= cooldown
+}

--- a/test/main-window-recovery.test.ts
+++ b/test/main-window-recovery.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAIN_WINDOW_RECOVERY_MAX_RELOADS,
+  MAIN_WINDOW_RECOVERY_RELOAD_COOLDOWN_MS,
+  shouldReloadAfterMainWindowRendererLoss
+} from '../src/main/main-window-recovery'
+
+describe('main window renderer recovery', () => {
+  it('allows the first reload when no previous crash has been recorded', () => {
+    expect(
+      shouldReloadAfterMainWindowRendererLoss({
+        now: 1_000,
+        lastReloadAt: 0,
+        reloadCount: 0
+      })
+    ).toBe(true)
+  })
+
+  it('throttles a second crash that lands inside the cooldown window', () => {
+    expect(
+      shouldReloadAfterMainWindowRendererLoss({
+        now: 1_000 + MAIN_WINDOW_RECOVERY_RELOAD_COOLDOWN_MS - 1,
+        lastReloadAt: 1_000,
+        reloadCount: 1
+      })
+    ).toBe(false)
+  })
+
+  it('lets a fresh crash through once the cooldown has fully elapsed', () => {
+    expect(
+      shouldReloadAfterMainWindowRendererLoss({
+        now: 1_000 + MAIN_WINDOW_RECOVERY_RELOAD_COOLDOWN_MS,
+        lastReloadAt: 1_000,
+        reloadCount: 1
+      })
+    ).toBe(true)
+  })
+
+  it('gives up after the configured number of reloads to avoid hammering a dead GPU', () => {
+    expect(
+      shouldReloadAfterMainWindowRendererLoss({
+        now: 1_000 + MAIN_WINDOW_RECOVERY_RELOAD_COOLDOWN_MS * 100,
+        lastReloadAt: 1_000,
+        reloadCount: MAIN_WINDOW_RECOVERY_MAX_RELOADS
+      })
+    ).toBe(false)
+  })
+
+  it('honors a custom cooldown and reload cap when the caller tightens the policy', () => {
+    expect(
+      shouldReloadAfterMainWindowRendererLoss({
+        now: 1_100,
+        lastReloadAt: 1_000,
+        reloadCount: 1,
+        cooldownMs: 50,
+        maxReloads: 2
+      })
+    ).toBe(true)
+    expect(
+      shouldReloadAfterMainWindowRendererLoss({
+        now: 1_010,
+        lastReloadAt: 1_000,
+        reloadCount: 1,
+        cooldownMs: 50,
+        maxReloads: 2
+      })
+    ).toBe(false)
+    expect(
+      shouldReloadAfterMainWindowRendererLoss({
+        now: 1_000_000,
+        lastReloadAt: 1_000,
+        reloadCount: 2,
+        cooldownMs: 50,
+        maxReloads: 2
+      })
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

When the renderer or GPU process dies on Windows, Electron leaves the `BrowserWindow` drawn but blank — the "black screen after running for a while" reported in #199, where the only fix is to force-kill the app. The main process had no `render-process-gone` / `did-fail-load` / `unresponsive` handlers, so a dead GPU process left no breadcrumb in the harness log and no recovery path.

This change wires crash recovery into the main window:

- `render-process-gone`, `did-fail-load` (main frame) and `unresponsive` are now listened to on the main window's `webContents`. Each event is recorded in the harness log so the cause survives a restart.
- A bounded reload — 5s cooldown, 3-attempt cap — is issued on the renderer going away. The cap protects a dead GPU from being hammered; once it trips, we fall back to the existing `plugin-recovery` page so the user can recover the harness from the UI without a hard restart.
- `responsive` is also logged so a follow-up crash leaves a "was unresponsive, recovered, crashed again" trail.
- A small pure helper (`shouldReloadAfterMainWindowRendererLoss`) carries the cooldown / cap math; it has its own vitest coverage.

## Verification

- `npx tsc --noEmit -p tsconfig.node.json` — clean
- `npx vitest run test/main-window-recovery.test.ts` — 5/5 pass
- `npx vitest run --dir test` — 392/392 pass across 56 files

## Notes

- Recovery is a window-level concern, so the new file is `src/main/main-window-recovery.ts`; only the main process imports it.
- The reload counter resets on a long timer (`cooldown * 4`) so an isolated crash recovers cleanly while a sustained failure still trips the cap.
- The fix is purely additive: existing behaviour (manual reload via the menu, plugin-recovery page) is unchanged for users who never hit a crash.

Fixes #199
