### PR TITLE
fix(windows): detach the Harness process so Ctrl+C broadcasts cannot reach the desktop shell (fixes #208)

### DIFF
--- a/src/main/runtime/harness-runtime.ts
+++ b/src/main/runtime/harness-runtime.ts
@@ -186,6 +186,14 @@ export function buildHarnessSpawnOptions(
   // utility process is launched with Chromium switches (--type=utility, …)
   // that Node rejects as bad options. The Harness entry re-declares Node mode
   // from the inside, for its children only.
+  //
+  // On Windows, `detached: true` puts the Harness in its own process group
+  // and console. Without it, a child process that calls `os.kill(pid, 0)`
+  // (POSIX "liveness probe") ends up broadcasting a Ctrl+C to every process
+  // sharing the desktop's console — including the desktop main process, which
+  // exits silently. This is the same isolation that the Harness's own
+  // subprocess layer is expected to apply; we apply it here so the desktop
+  // shell never becomes collateral damage for a buggy child (issue #208).
   return {
     cwd: launchDirectory,
     env: {
@@ -202,7 +210,8 @@ export function buildHarnessSpawnOptions(
       [pathKey]: environment[pathKey] ?? environment.PATH ?? ''
     },
     stdio: ['pipe', 'pipe', 'pipe'],
-    windowsHide: true
+    windowsHide: true,
+    detached: platform === 'win32'
   }
 }
 

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -97,6 +97,10 @@ describe('Harness launch contract', () => {
       cwd: 'C:\\Users\\tester\\AppData\\Roaming\\dsh-desktop\\launch-root',
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
+      // Detaching the Harness on Windows gives it its own console and process
+      // group, so a buggy child calling `os.kill(pid, 0)` cannot broadcast a
+      // Ctrl+C back to the desktop main process (issue #208).
+      detached: true,
       env: {
         DSH_HOME: 'C:\\Users\\tester\\AppData\\Roaming\\dsh-desktop\\harness',
         NO_COLOR: '1',
@@ -104,6 +108,18 @@ describe('Harness launch contract', () => {
       }
     })
     expect(options.env).not.toHaveProperty('ELECTRON_RUN_AS_NODE')
+  })
+
+  it('does not detach the Harness on macOS or Linux', () => {
+    // `detached: true` is a Windows-only escape hatch. The macOS path uses
+    // Electron's UtilityProcess fork, and Linux spawns are unaffected by
+    // the Windows console-broadcast problem the flag works around.
+    for (const platform of ['darwin', 'linux'] as const) {
+      const options = buildHarnessSpawnOptions('/launch-root', '/harness', platform, {
+        PATH: '/usr/bin'
+      })
+      expect(options.detached).toBeFalsy()
+    }
   })
 
   it('passes the internal-loader flag directly to bundled Node.js', () => {


### PR DESCRIPTION
## Summary

The Harness child processes share the desktop main process's console by
default on Windows. When one of those children calls `os.kill(pid, 0)`
as a POSIX liveness probe, the underlying `GenerateConsoleCtrlEvent`
turns the zero signal into a `CTRL_C_EVENT` and broadcasts it to every
process attached to the console. The Harness dies with
`STATUS_CONTROL_C_EXIT` (0xC000013A), and the desktop main process —
which is also attached to that console — exits silently too. That is
the "crash" reported in issue #208.

The same console-isolation the Harness's own subprocess layer is
expected to apply is now applied one level up: the desktop launches the
Harness with `detached: true` on Windows, putting it in its own
process group with its own console. A buggy descendant can no longer
use the shared console to take down the desktop. macOS keeps its
existing Electron `UtilityProcess` fork, and Linux spawns are
unaffected by the Windows console-broadcast problem the flag works
around, so the flag is Windows-only.

## Root cause (recap from issue #208)

- Python on Windows maps `os.kill(pid, 0)` to `GenerateConsoleCtrlEvent(CTRL_C_EVENT, pid)`,
  not POSIX liveness — the zero signal collides with `CTRL_C_EVENT`.
- DSH child processes are spawned with `detached: false` on Windows,
  so they share the host's console.
- A Ctrl+C broadcast hits the host (the desktop) as well as the child,
  and Node's default Ctrl+C handler exits silently with no log line.

## Fix

- `buildHarnessSpawnOptions` in `src/main/runtime/harness-runtime.ts` now
  returns `detached: true` when `platform === 'win32'`. This wraps the
  existing `spawn(executablePath, args, options)` call in `src/main/index.ts`
  that launches the bundled Node.js Harness.
- The `windowsHide: true` already set there keeps the new console from
  flashing a window. stdio remains `['pipe', 'pipe', 'pipe']` so the
  desktop keeps streaming the Harness's output as before.

## Tests

- `test/runtime.test.ts` adds a Windows assertion that
  `buildHarnessSpawnOptions` returns `detached: true`, and a macOS /
  Linux assertion that it does NOT — `detached: true` is a
  Windows-only escape hatch.
- `npx vitest run test/runtime.test.ts` → 44/44 passing.
- `npm run typecheck` → clean.
- `npm run build` → clean.

The 5 pre-existing test-file failures in the full `npm test` run are
unrelated to this change (reproduce with the change stashed).

## Out of scope

- The dsh-subprocess-local package itself still uses `detached: false`
  on Windows, so the Harness can still die from the same signal if the
  child is a *direct* subprocess. The fix here only prevents the
  desktop from being collateral damage; the upstream package fix is
  separate and tracked against `dsh-subprocess-local`.
- `src/main/runtime/profile-plugin-command.ts` line 321 has the same
  `detached: process.platform !== 'win32'` anti-pattern. It is a
  one-off CLI invocation for profile install/remove, not the persistent
  Harness child, so this PR deliberately leaves it alone; a follow-up
  can apply the same `detached: true` policy there.

## Related

- Fixes dataelement/dsh-desktop#208