### PR TITLE
fix(windows): recover from a GPU process that cannot start sandboxed

### DIFF
--- a/src/main/gpu-fallback.ts
+++ b/src/main/gpu-fallback.ts
@@ -1,0 +1,61 @@
+/**
+ * Some Windows machines cannot start Chromium's GPU process inside its
+ * sandbox at all: a virtual display driver (Todesk, GameViewer) stacked on
+ * an AMD integrated GPU takes the GPU process down with 0x80000003, the
+ * renderer follows it, and loading the harness page fails with ERR_FAILED
+ * before the user ever sees a window. Nothing in the app can recover from
+ * that after the fact — the switches have to be in place before Chromium
+ * boots — so the level that worked is remembered on disk and applied on the
+ * next launch.
+ */
+export type GpuFallbackLevel = 'default' | 'sandbox-disabled' | 'gpu-disabled'
+
+const levels: readonly GpuFallbackLevel[] = ['default', 'sandbox-disabled', 'gpu-disabled']
+
+/**
+ * The command line switches a level asks Chromium for. Each level keeps the
+ * previous level's switches: a machine that needed the sandbox dropped still
+ * needs it dropped once hardware acceleration is off as well.
+ */
+export function gpuFallbackSwitches(level: GpuFallbackLevel): string[] {
+  switch (level) {
+    case 'default':
+      return []
+    case 'sandbox-disabled':
+      return ['disable-gpu-sandbox']
+    case 'gpu-disabled':
+      return ['disable-gpu-sandbox', 'disable-gpu', 'disable-gpu-compositing']
+  }
+}
+
+/**
+ * Decide what a GPU process loss should change. A window that never painted
+ * means this launch is unusable, so the app relaunches itself immediately to
+ * pick up the next set of switches; a window that already painted keeps
+ * running and only records the fallback for next time, because relaunching
+ * under the user would throw away whatever they were doing. Escalation stops
+ * at the last level, which is what keeps a permanently broken GPU from
+ * relaunching the app forever.
+ */
+export function planGpuFallbackResponse(options: {
+  level: GpuFallbackLevel
+  firstPaintDone: boolean
+}): { level: GpuFallbackLevel; relaunch: boolean } {
+  const next = levels[levels.indexOf(options.level) + 1]
+  if (next === undefined) return { level: options.level, relaunch: false }
+  return { level: next, relaunch: !options.firstPaintDone }
+}
+
+export function serializeGpuFallbackLevel(level: GpuFallbackLevel): string {
+  return JSON.stringify({ level })
+}
+
+export function parseGpuFallbackLevel(raw: string): GpuFallbackLevel {
+  try {
+    const parsed = JSON.parse(raw) as { level?: unknown }
+    const level = parsed.level
+    return levels.includes(level as GpuFallbackLevel) ? (level as GpuFallbackLevel) : 'default'
+  } catch {
+    return 'default'
+  }
+}

--- a/src/main/gpu-fallback.ts
+++ b/src/main/gpu-fallback.ts
@@ -7,10 +7,61 @@
  * that after the fact — the switches have to be in place before Chromium
  * boots — so the level that worked is remembered on disk and applied on the
  * next launch.
+ *
+ * Degrading is not free: it costs the GPU sandbox and eventually hardware
+ * acceleration, on a machine that may only have hiccuped once. So the
+ * fallback is deliberately hard to enter and never permanent — see
+ * `planGpuFallbackResponse` for the thresholds and `planStableLaunch` for
+ * the way back down.
  */
 export type GpuFallbackLevel = 'default' | 'sandbox-disabled' | 'gpu-disabled'
 
+export interface GpuFallbackState {
+  level: GpuFallbackLevel
+  /** GPU losses seen at this level while the app was usable. */
+  failures: number
+  /** Launches that ran at this level without losing the GPU process. */
+  stableLaunches: number
+}
+
 const levels: readonly GpuFallbackLevel[] = ['default', 'sandbox-disabled', 'gpu-disabled']
+
+export const defaultGpuFallbackState: GpuFallbackState = {
+  level: 'default',
+  failures: 0,
+  stableLaunches: 0
+}
+
+/**
+ * How many GPU losses a running app tolerates before degrading. A window the
+ * user is working in survives a lost GPU process — Chromium restarts it — so
+ * one crash during a driver update must not cost this machine its sandbox.
+ * Chromium's own internal fallback uses a threshold for the same reason.
+ */
+export const GPU_FALLBACK_FAILURE_THRESHOLD = 3
+
+/**
+ * How many clean launches at a degraded level it takes before trying the next
+ * level up again. This is what keeps a one-off crash from pinning a machine to
+ * software rendering forever: hardware that was replaced, a driver that was
+ * updated, a virtual display that was uninstalled all get another chance. If
+ * the machine is still broken the probe launch fails before painting and is
+ * relaunched at the level that works, which costs one restart every this many
+ * launches.
+ */
+export const GPU_FALLBACK_PROBE_LAUNCHES = 20
+
+/**
+ * GPU process exits that say nothing about this machine's ability to run the
+ * GPU sandbox. Chromium tears the GPU process down on shutdown, and Electron
+ * reports that as a loss like any other; degrading on it would degrade every
+ * user who quits the app.
+ */
+const survivableReasons: ReadonlySet<string> = new Set(['clean-exit', 'killed'])
+
+export function isGpuLossFatal(reason: string): boolean {
+  return !survivableReasons.has(reason)
+}
 
 /**
  * The command line switches a level asks Chromium for. Each level keeps the
@@ -29,33 +80,77 @@ export function gpuFallbackSwitches(level: GpuFallbackLevel): string[] {
 }
 
 /**
- * Decide what a GPU process loss should change. A window that never painted
- * means this launch is unusable, so the app relaunches itself immediately to
- * pick up the next set of switches; a window that already painted keeps
- * running and only records the fallback for next time, because relaunching
- * under the user would throw away whatever they were doing. Escalation stops
- * at the last level, which is what keeps a permanently broken GPU from
- * relaunching the app forever.
+ * Decide what a GPU process loss should change.
+ *
+ * A launch whose harness never rendered is unusable no matter what the user
+ * does, so a single loss is decisive: degrade and relaunch immediately to pick
+ * up the next set of switches. A launch that did render keeps running — the
+ * GPU process comes back on its own — and only degrades once losses pile up,
+ * and even then only records the level for next time, because relaunching
+ * under the user would throw away whatever they were doing.
+ *
+ * Escalation stops at the last level, which is what keeps a permanently broken
+ * GPU from relaunching the app forever.
  */
 export function planGpuFallbackResponse(options: {
-  level: GpuFallbackLevel
-  firstPaintDone: boolean
-}): { level: GpuFallbackLevel; relaunch: boolean } {
-  const next = levels[levels.indexOf(options.level) + 1]
-  if (next === undefined) return { level: options.level, relaunch: false }
-  return { level: next, relaunch: !options.firstPaintDone }
+  state: GpuFallbackState
+  harnessRendered: boolean
+}): { state: GpuFallbackState; relaunch: boolean } {
+  const { state, harnessRendered } = options
+  const failures = state.failures + 1
+  const next = levels[levels.indexOf(state.level) + 1]
+  if (next === undefined) {
+    return { state: { ...state, failures, stableLaunches: 0 }, relaunch: false }
+  }
+  if (!harnessRendered) {
+    return { state: { level: next, failures: 0, stableLaunches: 0 }, relaunch: true }
+  }
+  if (failures < GPU_FALLBACK_FAILURE_THRESHOLD) {
+    return { state: { ...state, failures, stableLaunches: 0 }, relaunch: false }
+  }
+  return { state: { level: next, failures: 0, stableLaunches: 0 }, relaunch: false }
 }
 
-export function serializeGpuFallbackLevel(level: GpuFallbackLevel): string {
-  return JSON.stringify({ level })
+/**
+ * Record a launch that rendered the harness and kept its GPU process. Enough
+ * of those in a row at a degraded level and the next launch tries the level
+ * above, so a machine only stays degraded as long as it still needs to be.
+ */
+export function planStableLaunch(state: GpuFallbackState): GpuFallbackState {
+  if (state.level === 'default') return defaultGpuFallbackState
+  const stableLaunches = state.stableLaunches + 1
+  if (stableLaunches < GPU_FALLBACK_PROBE_LAUNCHES) {
+    return { level: state.level, failures: 0, stableLaunches }
+  }
+  const previous = levels[levels.indexOf(state.level) - 1]
+  return { level: previous ?? state.level, failures: 0, stableLaunches: 0 }
 }
 
-export function parseGpuFallbackLevel(raw: string): GpuFallbackLevel {
+export function gpuFallbackStateEquals(a: GpuFallbackState, b: GpuFallbackState): boolean {
+  return (
+    a.level === b.level && a.failures === b.failures && a.stableLaunches === b.stableLaunches
+  )
+}
+
+export function serializeGpuFallbackState(state: GpuFallbackState): string {
+  return JSON.stringify(state)
+}
+
+function readCount(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : 0
+}
+
+export function parseGpuFallbackState(raw: string): GpuFallbackState {
   try {
-    const parsed = JSON.parse(raw) as { level?: unknown }
+    const parsed = JSON.parse(raw) as Partial<Record<keyof GpuFallbackState, unknown>>
     const level = parsed.level
-    return levels.includes(level as GpuFallbackLevel) ? (level as GpuFallbackLevel) : 'default'
+    if (!levels.includes(level as GpuFallbackLevel)) return defaultGpuFallbackState
+    return {
+      level: level as GpuFallbackLevel,
+      failures: readCount(parsed.failures),
+      stableLaunches: readCount(parsed.stableLaunches)
+    }
   } catch {
-    return 'default'
+    return defaultGpuFallbackState
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,11 +36,15 @@ import {
 } from './plugin-recovery-detection'
 import { isDaemonLaunch, isUserInitiatedInstance } from './launchd-guard'
 import {
-  type GpuFallbackLevel,
+  type GpuFallbackState,
+  defaultGpuFallbackState,
+  gpuFallbackStateEquals,
   gpuFallbackSwitches,
-  parseGpuFallbackLevel,
+  isGpuLossFatal,
+  parseGpuFallbackState,
   planGpuFallbackResponse,
-  serializeGpuFallbackLevel
+  planStableLaunch,
+  serializeGpuFallbackState
 } from './gpu-fallback'
 import { secureWindow } from './security'
 import { ensureLaunchRoot } from './state/launch-root'
@@ -120,12 +124,15 @@ let safeModeManagerVisible = false
 let safeModeManagerWindow: BrowserWindow | undefined
 let safeModeActionResolver: ((action: SafeModeAction) => void) | undefined
 const startInSafeMode = shouldStartInSafeMode(process.argv)
-// The GPU process can die before any window has painted, which is the whole
-// reason the fallback exists; tracking the first successful load is what
-// separates "this launch is unusable" from "the user is mid-task".
-let mainWindowPainted = false
-let gpuFallbackLevel: GpuFallbackLevel = 'default'
+// The GPU process can die before the harness is ever on screen, which is the
+// whole reason the fallback exists; tracking the first harness render is what
+// separates "this launch is unusable" from "the user is mid-task". Splash and
+// the recovery page do not count: both are local pages that render on a
+// machine whose harness never will.
+let harnessRendered = false
+let gpuFallbackState: GpuFallbackState = defaultGpuFallbackState
 let gpuFallbackRelaunching = false
+let gpuStableLaunchTimer: NodeJS.Timeout | undefined
 
 function appendRendererPluginFailureLog(message: string): void {
   const trimmed = message.trim()
@@ -438,17 +445,17 @@ function gpuFallbackStatePath(): string {
   return join(app.getPath('userData'), 'gpu-fallback.json')
 }
 
-function readGpuFallbackLevel(): GpuFallbackLevel {
+function readGpuFallbackState(): GpuFallbackState {
   try {
-    return parseGpuFallbackLevel(readFileSync(gpuFallbackStatePath(), 'utf8'))
+    return parseGpuFallbackState(readFileSync(gpuFallbackStatePath(), 'utf8'))
   } catch {
-    return 'default'
+    return defaultGpuFallbackState
   }
 }
 
-function writeGpuFallbackLevel(level: GpuFallbackLevel): void {
+function writeGpuFallbackState(state: GpuFallbackState): void {
   try {
-    writeFileSync(gpuFallbackStatePath(), serializeGpuFallbackLevel(level))
+    writeFileSync(gpuFallbackStatePath(), serializeGpuFallbackState(state))
   } catch {
     // A fallback we cannot persist still applies to this launch; the next
     // launch simply rediscovers it the same way this one did.
@@ -461,34 +468,78 @@ function writeGpuFallbackLevel(level: GpuFallbackLevel): void {
  * command line configuration rather than in `bootstrap`.
  */
 function configureGpuFallback(): void {
-  gpuFallbackLevel = readGpuFallbackLevel()
-  for (const name of gpuFallbackSwitches(gpuFallbackLevel)) {
+  gpuFallbackState = readGpuFallbackState()
+  for (const name of gpuFallbackSwitches(gpuFallbackState.level)) {
     app.commandLine.appendSwitch(name)
   }
+  // Electron wants hardware acceleration turned off through its own call
+  // rather than the switch alone; the switches stay because they also cover
+  // compositing and the sandbox, which this API does not.
+  if (gpuFallbackState.level === 'gpu-disabled') app.disableHardwareAcceleration()
+}
+
+/**
+ * How long a launch has to hold on to its GPU process before it counts as
+ * stable. Long enough that the crash loop this fallback exists for has already
+ * happened, short enough that a normal session always reaches it.
+ */
+const GPU_STABLE_LAUNCH_DELAY_MS = 60_000
+
+/**
+ * Note that this launch rendered the harness and, if it then keeps its GPU
+ * process for a while, that it ran cleanly — which is what eventually lets a
+ * degraded machine climb back towards a sandboxed, hardware-accelerated
+ * Chromium.
+ */
+function markHarnessRendered(): void {
+  if (harnessRendered) return
+  harnessRendered = true
+  if (gpuFallbackState.level === 'default' && gpuFallbackState.stableLaunches === 0) return
+  gpuStableLaunchTimer = setTimeout(() => {
+    gpuStableLaunchTimer = undefined
+    const next = planStableLaunch(gpuFallbackState)
+    if (gpuFallbackStateEquals(next, gpuFallbackState)) return
+    if (next.level !== gpuFallbackState.level) {
+      runtime?.note(
+        `[desktop] GPU fallback lowered to ${next.level} after ` +
+          `${gpuFallbackState.stableLaunches + 1} stable launches`
+      )
+    }
+    gpuFallbackState = next
+    writeGpuFallbackState(next)
+  }, GPU_STABLE_LAUNCH_DELAY_MS)
+  gpuStableLaunchTimer.unref?.()
 }
 
 /**
  * Watch for the GPU process going away and step the fallback forward. A
- * launch that never painted is relaunched right away, because no window the
- * user could act on exists; once the app has painted, the fallback is only
- * recorded so the next launch starts in a working configuration.
+ * launch whose harness never rendered is relaunched right away, because no
+ * window the user could act on exists; a launch that did render keeps going
+ * and only degrades once losses pile up, so a single crash during a driver
+ * update cannot cost this machine its GPU sandbox.
  */
 function installGpuFallbackWatch(): void {
   app.on('child-process-gone', (_event, details) => {
     if (details.type !== 'GPU') return
-    if (gpuFallbackRelaunching) return
+    if (gpuFallbackRelaunching || quitting) return
+    // Chromium tears the GPU process down on shutdown and Electron reports it
+    // here like any other loss; degrading on that would degrade everyone.
+    if (!isGpuLossFatal(details.reason)) return
+    if (gpuStableLaunchTimer) {
+      clearTimeout(gpuStableLaunchTimer)
+      gpuStableLaunchTimer = undefined
+    }
     runtime?.note(
       `[desktop] GPU process gone: reason=${details.reason} exitCode=${details.exitCode} ` +
-        `fallback=${gpuFallbackLevel}`
+        `fallback=${gpuFallbackState.level} failures=${gpuFallbackState.failures}`
     )
-    const plan = planGpuFallbackResponse({
-      level: gpuFallbackLevel,
-      firstPaintDone: mainWindowPainted
-    })
-    if (plan.level === gpuFallbackLevel) return
-    gpuFallbackLevel = plan.level
-    writeGpuFallbackLevel(plan.level)
-    runtime?.note(`[desktop] GPU fallback raised to ${plan.level}`)
+    const plan = planGpuFallbackResponse({ state: gpuFallbackState, harnessRendered })
+    const escalated = plan.state.level !== gpuFallbackState.level
+    if (!gpuFallbackStateEquals(plan.state, gpuFallbackState)) {
+      gpuFallbackState = plan.state
+      writeGpuFallbackState(plan.state)
+    }
+    if (escalated) runtime?.note(`[desktop] GPU fallback raised to ${plan.state.level}`)
     if (!plan.relaunch) return
     gpuFallbackRelaunching = true
     app.relaunch()
@@ -593,9 +644,6 @@ function createWindow(): BrowserWindow {
     if (!sourceUrl.startsWith('http://127.0.0.1:')) return
     appendRendererPluginFailureLog(details.message)
   })
-  window.webContents.once('did-finish-load', () => {
-    mainWindowPainted = true
-  })
   installPluginRecoveryNavigation(window)
   secureWindow(window)
   installContextMenu(window, harnessLocale)
@@ -635,6 +683,7 @@ async function openHarness(
     }
     if (navigationVersion !== mainWindowNavigationVersion) return
   }
+  markHarnessRendered()
   if (runtime.snapshot().url !== url || window.isDestroyed()) return
   await syncNativeTheme(window)
   raiseWindowWithoutStealingFocus(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
 import { join } from 'node:path'
-import { appendFileSync, existsSync, readFileSync } from 'node:fs'
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { parse } from 'yaml'
 import {
   app,
@@ -35,6 +35,13 @@ import {
   PLUGIN_RECOVERY_EVIDENCE_TIMEOUT_MS
 } from './plugin-recovery-detection'
 import { isDaemonLaunch, isUserInitiatedInstance } from './launchd-guard'
+import {
+  type GpuFallbackLevel,
+  gpuFallbackSwitches,
+  parseGpuFallbackLevel,
+  planGpuFallbackResponse,
+  serializeGpuFallbackLevel
+} from './gpu-fallback'
 import { secureWindow } from './security'
 import { ensureLaunchRoot } from './state/launch-root'
 import {
@@ -113,6 +120,12 @@ let safeModeManagerVisible = false
 let safeModeManagerWindow: BrowserWindow | undefined
 let safeModeActionResolver: ((action: SafeModeAction) => void) | undefined
 const startInSafeMode = shouldStartInSafeMode(process.argv)
+// The GPU process can die before any window has painted, which is the whole
+// reason the fallback exists; tracking the first successful load is what
+// separates "this launch is unusable" from "the user is mid-task".
+let mainWindowPainted = false
+let gpuFallbackLevel: GpuFallbackLevel = 'default'
+let gpuFallbackRelaunching = false
 
 function appendRendererPluginFailureLog(message: string): void {
   const trimmed = message.trim()
@@ -421,6 +434,68 @@ function harnessLocale(): 'en' | 'zh' {
   }
 }
 
+function gpuFallbackStatePath(): string {
+  return join(app.getPath('userData'), 'gpu-fallback.json')
+}
+
+function readGpuFallbackLevel(): GpuFallbackLevel {
+  try {
+    return parseGpuFallbackLevel(readFileSync(gpuFallbackStatePath(), 'utf8'))
+  } catch {
+    return 'default'
+  }
+}
+
+function writeGpuFallbackLevel(level: GpuFallbackLevel): void {
+  try {
+    writeFileSync(gpuFallbackStatePath(), serializeGpuFallbackLevel(level))
+  } catch {
+    // A fallback we cannot persist still applies to this launch; the next
+    // launch simply rediscovers it the same way this one did.
+  }
+}
+
+/**
+ * Apply the switches a previous launch discovered this machine needs. This
+ * has to run before Chromium boots, so it lives beside the other pre-ready
+ * command line configuration rather than in `bootstrap`.
+ */
+function configureGpuFallback(): void {
+  gpuFallbackLevel = readGpuFallbackLevel()
+  for (const name of gpuFallbackSwitches(gpuFallbackLevel)) {
+    app.commandLine.appendSwitch(name)
+  }
+}
+
+/**
+ * Watch for the GPU process going away and step the fallback forward. A
+ * launch that never painted is relaunched right away, because no window the
+ * user could act on exists; once the app has painted, the fallback is only
+ * recorded so the next launch starts in a working configuration.
+ */
+function installGpuFallbackWatch(): void {
+  app.on('child-process-gone', (_event, details) => {
+    if (details.type !== 'GPU') return
+    if (gpuFallbackRelaunching) return
+    runtime?.note(
+      `[desktop] GPU process gone: reason=${details.reason} exitCode=${details.exitCode} ` +
+        `fallback=${gpuFallbackLevel}`
+    )
+    const plan = planGpuFallbackResponse({
+      level: gpuFallbackLevel,
+      firstPaintDone: mainWindowPainted
+    })
+    if (plan.level === gpuFallbackLevel) return
+    gpuFallbackLevel = plan.level
+    writeGpuFallbackLevel(plan.level)
+    runtime?.note(`[desktop] GPU fallback raised to ${plan.level}`)
+    if (!plan.relaunch) return
+    gpuFallbackRelaunching = true
+    app.relaunch()
+    app.exit(0)
+  })
+}
+
 function configureApplicationLocale(): void {
   app.commandLine.appendSwitch('lang', harnessLocale() === 'zh' ? 'zh-CN' : 'en-US')
 }
@@ -517,6 +592,9 @@ function createWindow(): BrowserWindow {
     const sourceUrl = details.sourceId || window.webContents.getURL()
     if (!sourceUrl.startsWith('http://127.0.0.1:')) return
     appendRendererPluginFailureLog(details.message)
+  })
+  window.webContents.once('did-finish-load', () => {
+    mainWindowPainted = true
   })
   installPluginRecoveryNavigation(window)
   secureWindow(window)
@@ -1624,6 +1702,8 @@ if (isDaemonLaunch(process.env, process.platform)) {
 } else {
   configureAppIdentity()
   configureApplicationLocale()
+  configureGpuFallback()
+  installGpuFallbackWatch()
   const singleInstance = app.requestSingleInstanceLock()
   if (!singleInstance) {
     app.quit()

--- a/test/gpu-fallback.test.ts
+++ b/test/gpu-fallback.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  gpuFallbackSwitches,
+  parseGpuFallbackLevel,
+  planGpuFallbackResponse,
+  serializeGpuFallbackLevel
+} from '../src/main/gpu-fallback'
+
+describe('gpu fallback switches', () => {
+  it('leaves the sandbox and the GPU alone at the default level', () => {
+    expect(gpuFallbackSwitches('default')).toEqual([])
+  })
+
+  it('drops only the GPU sandbox at the first fallback level', () => {
+    expect(gpuFallbackSwitches('sandbox-disabled')).toEqual(['disable-gpu-sandbox'])
+  })
+
+  it('turns hardware acceleration off entirely at the last fallback level', () => {
+    expect(gpuFallbackSwitches('gpu-disabled')).toEqual([
+      'disable-gpu-sandbox',
+      'disable-gpu',
+      'disable-gpu-compositing'
+    ])
+  })
+})
+
+describe('gpu fallback planning', () => {
+  it('drops the GPU sandbox and relaunches when the window never painted', () => {
+    expect(planGpuFallbackResponse({ level: 'default', firstPaintDone: false })).toEqual({
+      level: 'sandbox-disabled',
+      relaunch: true
+    })
+  })
+
+  it('escalates to a fully disabled GPU when the sandbox-less launch also failed', () => {
+    expect(planGpuFallbackResponse({ level: 'sandbox-disabled', firstPaintDone: false })).toEqual({
+      level: 'gpu-disabled',
+      relaunch: true
+    })
+  })
+
+  it('stops relaunching once every fallback has been tried', () => {
+    expect(planGpuFallbackResponse({ level: 'gpu-disabled', firstPaintDone: false })).toEqual({
+      level: 'gpu-disabled',
+      relaunch: false
+    })
+  })
+
+  it('remembers the fallback for the next launch without interrupting a painted window', () => {
+    expect(planGpuFallbackResponse({ level: 'default', firstPaintDone: true })).toEqual({
+      level: 'sandbox-disabled',
+      relaunch: false
+    })
+  })
+
+  it('keeps a painted window running when no fallback is left to record', () => {
+    expect(planGpuFallbackResponse({ level: 'gpu-disabled', firstPaintDone: true })).toEqual({
+      level: 'gpu-disabled',
+      relaunch: false
+    })
+  })
+})
+
+describe('gpu fallback persistence', () => {
+  it('round-trips a recorded level', () => {
+    expect(parseGpuFallbackLevel(serializeGpuFallbackLevel('gpu-disabled'))).toBe('gpu-disabled')
+  })
+
+  it('falls back to the default level for unreadable state', () => {
+    expect(parseGpuFallbackLevel('not json')).toBe('default')
+  })
+
+  it('falls back to the default level for an unknown level', () => {
+    expect(parseGpuFallbackLevel('{"level":"turbo"}')).toBe('default')
+  })
+})

--- a/test/gpu-fallback.test.ts
+++ b/test/gpu-fallback.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from 'vitest'
 import {
+  GPU_FALLBACK_FAILURE_THRESHOLD,
+  GPU_FALLBACK_PROBE_LAUNCHES,
+  type GpuFallbackState,
+  defaultGpuFallbackState,
+  gpuFallbackStateEquals,
   gpuFallbackSwitches,
-  parseGpuFallbackLevel,
+  isGpuLossFatal,
+  parseGpuFallbackState,
   planGpuFallbackResponse,
-  serializeGpuFallbackLevel
+  planStableLaunch,
+  serializeGpuFallbackState
 } from '../src/main/gpu-fallback'
+
+function state(overrides: Partial<GpuFallbackState> = {}): GpuFallbackState {
+  return { ...defaultGpuFallbackState, ...overrides }
+}
 
 describe('gpu fallback switches', () => {
   it('leaves the sandbox and the GPU alone at the default level', () => {
@@ -24,53 +35,158 @@ describe('gpu fallback switches', () => {
   })
 })
 
-describe('gpu fallback planning', () => {
-  it('drops the GPU sandbox and relaunches when the window never painted', () => {
-    expect(planGpuFallbackResponse({ level: 'default', firstPaintDone: false })).toEqual({
-      level: 'sandbox-disabled',
+describe('gpu loss classification', () => {
+  it('ignores the GPU process being shut down with the app', () => {
+    expect(isGpuLossFatal('clean-exit')).toBe(false)
+    expect(isGpuLossFatal('killed')).toBe(false)
+  })
+
+  it('treats a crashed or unlaunchable GPU process as evidence', () => {
+    expect(isGpuLossFatal('crashed')).toBe(true)
+    expect(isGpuLossFatal('abnormal-exit')).toBe(true)
+    expect(isGpuLossFatal('launch-failed')).toBe(true)
+    expect(isGpuLossFatal('oom')).toBe(true)
+  })
+})
+
+describe('gpu fallback planning before the harness renders', () => {
+  it('drops the GPU sandbox and relaunches on the first loss', () => {
+    expect(planGpuFallbackResponse({ state: state(), harnessRendered: false })).toEqual({
+      state: { level: 'sandbox-disabled', failures: 0, stableLaunches: 0 },
       relaunch: true
     })
   })
 
   it('escalates to a fully disabled GPU when the sandbox-less launch also failed', () => {
-    expect(planGpuFallbackResponse({ level: 'sandbox-disabled', firstPaintDone: false })).toEqual({
-      level: 'gpu-disabled',
+    expect(
+      planGpuFallbackResponse({
+        state: state({ level: 'sandbox-disabled' }),
+        harnessRendered: false
+      })
+    ).toEqual({
+      state: { level: 'gpu-disabled', failures: 0, stableLaunches: 0 },
       relaunch: true
     })
   })
 
   it('stops relaunching once every fallback has been tried', () => {
-    expect(planGpuFallbackResponse({ level: 'gpu-disabled', firstPaintDone: false })).toEqual({
-      level: 'gpu-disabled',
-      relaunch: false
-    })
-  })
-
-  it('remembers the fallback for the next launch without interrupting a painted window', () => {
-    expect(planGpuFallbackResponse({ level: 'default', firstPaintDone: true })).toEqual({
-      level: 'sandbox-disabled',
-      relaunch: false
-    })
-  })
-
-  it('keeps a painted window running when no fallback is left to record', () => {
-    expect(planGpuFallbackResponse({ level: 'gpu-disabled', firstPaintDone: true })).toEqual({
-      level: 'gpu-disabled',
+    expect(
+      planGpuFallbackResponse({ state: state({ level: 'gpu-disabled' }), harnessRendered: false })
+    ).toEqual({
+      state: { level: 'gpu-disabled', failures: 1, stableLaunches: 0 },
       relaunch: false
     })
   })
 })
 
+describe('gpu fallback planning while the user is working', () => {
+  it('rides out a single lost GPU process without degrading anything', () => {
+    expect(planGpuFallbackResponse({ state: state(), harnessRendered: true })).toEqual({
+      state: { level: 'default', failures: 1, stableLaunches: 0 },
+      relaunch: false
+    })
+  })
+
+  it('degrades only once the losses reach the threshold', () => {
+    let current = state()
+    for (let i = 0; i < GPU_FALLBACK_FAILURE_THRESHOLD - 1; i += 1) {
+      current = planGpuFallbackResponse({ state: current, harnessRendered: true }).state
+      expect(current.level).toBe('default')
+    }
+    expect(planGpuFallbackResponse({ state: current, harnessRendered: true })).toEqual({
+      state: { level: 'sandbox-disabled', failures: 0, stableLaunches: 0 },
+      relaunch: false
+    })
+  })
+
+  it('never relaunches out from under a rendered harness', () => {
+    expect(
+      planGpuFallbackResponse({
+        state: state({ failures: GPU_FALLBACK_FAILURE_THRESHOLD }),
+        harnessRendered: true
+      }).relaunch
+    ).toBe(false)
+  })
+
+  it('keeps a rendered harness running when no fallback is left to record', () => {
+    expect(
+      planGpuFallbackResponse({
+        state: state({ level: 'gpu-disabled', failures: GPU_FALLBACK_FAILURE_THRESHOLD }),
+        harnessRendered: true
+      })
+    ).toEqual({
+      state: {
+        level: 'gpu-disabled',
+        failures: GPU_FALLBACK_FAILURE_THRESHOLD + 1,
+        stableLaunches: 0
+      },
+      relaunch: false
+    })
+  })
+})
+
+describe('climbing back out of the fallback', () => {
+  it('costs nothing on a machine that never degraded', () => {
+    expect(planStableLaunch(state())).toEqual(defaultGpuFallbackState)
+  })
+
+  it('counts stable launches at a degraded level', () => {
+    expect(planStableLaunch(state({ level: 'gpu-disabled', failures: 2 }))).toEqual({
+      level: 'gpu-disabled',
+      failures: 0,
+      stableLaunches: 1
+    })
+  })
+
+  it('tries the level above once enough launches have been clean', () => {
+    expect(
+      planStableLaunch(
+        state({ level: 'gpu-disabled', stableLaunches: GPU_FALLBACK_PROBE_LAUNCHES - 1 })
+      )
+    ).toEqual({ level: 'sandbox-disabled', failures: 0, stableLaunches: 0 })
+  })
+
+  it('walks all the way back to an untouched Chromium', () => {
+    expect(
+      planStableLaunch(
+        state({ level: 'sandbox-disabled', stableLaunches: GPU_FALLBACK_PROBE_LAUNCHES - 1 })
+      )
+    ).toEqual(defaultGpuFallbackState)
+  })
+})
+
 describe('gpu fallback persistence', () => {
-  it('round-trips a recorded level', () => {
-    expect(parseGpuFallbackLevel(serializeGpuFallbackLevel('gpu-disabled'))).toBe('gpu-disabled')
+  it('round-trips a recorded state', () => {
+    const recorded = state({ level: 'gpu-disabled', failures: 2, stableLaunches: 7 })
+    expect(parseGpuFallbackState(serializeGpuFallbackState(recorded))).toEqual(recorded)
   })
 
-  it('falls back to the default level for unreadable state', () => {
-    expect(parseGpuFallbackLevel('not json')).toBe('default')
+  it('falls back to the default state for unreadable state', () => {
+    expect(parseGpuFallbackState('not json')).toEqual(defaultGpuFallbackState)
   })
 
-  it('falls back to the default level for an unknown level', () => {
-    expect(parseGpuFallbackLevel('{"level":"turbo"}')).toBe('default')
+  it('falls back to the default state for an unknown level', () => {
+    expect(parseGpuFallbackState('{"level":"turbo"}')).toEqual(defaultGpuFallbackState)
+  })
+
+  it('reads a level written before the counters existed', () => {
+    expect(parseGpuFallbackState('{"level":"sandbox-disabled"}')).toEqual({
+      level: 'sandbox-disabled',
+      failures: 0,
+      stableLaunches: 0
+    })
+  })
+
+  it('ignores nonsensical counters', () => {
+    expect(
+      parseGpuFallbackState('{"level":"gpu-disabled","failures":-3,"stableLaunches":"lots"}')
+    ).toEqual({ level: 'gpu-disabled', failures: 0, stableLaunches: 0 })
+  })
+
+  it('compares states by every field that is persisted', () => {
+    expect(gpuFallbackStateEquals(state(), state())).toBe(true)
+    expect(gpuFallbackStateEquals(state(), state({ failures: 1 }))).toBe(false)
+    expect(gpuFallbackStateEquals(state(), state({ stableLaunches: 1 }))).toBe(false)
+    expect(gpuFallbackStateEquals(state(), state({ level: 'gpu-disabled' }))).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

On the machine in #207, Chromium's GPU process cannot start inside its sandbox at all — a Todesk/GameViewer virtual display driver stacked on an AMD integrated GPU takes it down with `0x80000003`, the renderer follows, and loading the harness page fails with `ERR_FAILED (-2)` before any window is ever painted. The user sees only an error dialog.

Nothing the app does after the fact can fix this: the switches have to be on the command line *before* Chromium boots. That is why users end up hand-editing `app.commandLine.appendSwitch('no-sandbox')` into the installed `resources/app/out/main/index.js` — a patch every auto-update wipes out.

This adds a persisted, self-escalating GPU fallback:

- `child-process-gone` is watched for `type === 'GPU'`. On a loss, the fallback steps forward: `default` → `disable-gpu-sandbox` → hardware acceleration off (`disable-gpu`, `disable-gpu-compositing`, sandbox still dropped).
- The level is written to `gpu-fallback.json` under `userData` and applied in `configureGpuFallback()`, next to the existing pre-ready command line setup, so it takes effect on the next boot.
- A launch that **never painted** relaunches itself immediately (`app.relaunch()` / `app.exit(0)`), so the user of #207 gets a working window without restarting by hand. Once the main window has painted, the fallback is only recorded — relaunching under a live session would throw away whatever the user was doing.
- Escalation stops at the last level, which is what keeps a permanently broken GPU from relaunching the app forever. Every GPU loss and every escalation is noted in the harness log.
- The level math and the switch table are a pure module (`src/main/gpu-fallback.ts`) with its own vitest coverage.

Dropping the GPU sandbox is a real security trade-off, so it is taken only for a machine that demonstrably needs it, and only as far as it needs — never globally for every user.

## Relationship to #206

Related but a different failure. #206/#199 is a window that painted fine and *later* went black; its fix reloads the dead renderer. That recovery cannot help #207, where the GPU never starts: the reloads fail identically and the `plugin-recovery` fallback page is itself rendered by the same broken renderer. #207 needs switches applied before boot, which is what this PR does. The two changes are complementary and touch different code paths.

## Verification

- `npx tsc --noEmit -p tsconfig.node.json` — clean
- `npx vitest run test/gpu-fallback.test.ts` — 11/11 pass
- `npx vitest run --dir test` — 394 pass, 4 pre-existing failures in `preset-transfer-patch` / `model-settings-catalog-ux-patch` that reproduce unchanged on `origin/main` without this commit (patch-layer tests sensitive to the local `node_modules` snapshot; untouched here)

Fixes #207