### PR TITLE
ci: verify release assets before publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,10 +478,13 @@ jobs:
           path: ${{ runner.temp }}/dsh-windows-${{ github.run_id }}/release
       - name: Download and verify Jsign
         run: |
+          set -euo pipefail
           jsign_jar="$WINDOWS_SIGNING_WORK_DIR/jsign-${JSIGN_VERSION}.jar"
-          curl --fail --location --retry 3 \
+          curl --fail-with-body --location --retry 3 --retry-all-errors \
+            --connect-timeout 15 --max-time 180 \
             --output "$jsign_jar" \
             "https://github.com/ebourg/jsign/releases/download/${JSIGN_VERSION}/jsign-${JSIGN_VERSION}.jar"
+          test -s "$jsign_jar"
           printf '%s  %s\n' "$JSIGN_SHA256" "$jsign_jar" | shasum -a 256 --check
           java -jar "$jsign_jar" --version
           echo "JSIGN_JAR=$jsign_jar" >> "$GITHUB_ENV"
@@ -572,6 +575,7 @@ jobs:
           path: release-assets
       - name: Merge macOS update metadata
         run: |
+          set -euo pipefail
           node scripts/merge-mac-update-metadata.mjs \
             release-assets/latest-mac-arm64.yml \
             release-assets/latest-mac-x64.yml \
@@ -579,6 +583,10 @@ jobs:
           find release-assets -maxdepth 1 \
             \( -name latest-mac-arm64.yml -o -name latest-mac-x64.yml \) \
             -delete
+      - name: Verify release assets before publication
+        run: |
+          set -euo pipefail
+          node scripts/verify-release-assets.mjs release-assets "${GITHUB_REF_NAME#v}"
       - name: Create or update release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/verify-release-assets.mjs
+++ b/scripts/verify-release-assets.mjs
@@ -1,0 +1,126 @@
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { open, readFile, stat } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse } from 'yaml'
+
+const REQUIRED_ASSETS = [
+  'dsh-desktop-mac-arm64.dmg',
+  'dsh-desktop-mac-arm64.zip',
+  'dsh-desktop-mac-arm64.zip.blockmap',
+  'dsh-desktop-mac-x64.dmg',
+  'dsh-desktop-mac-x64.zip',
+  'dsh-desktop-mac-x64.zip.blockmap',
+  'dsh-desktop-windows-x64-setup.exe',
+  'dsh-desktop-windows-x64-setup.exe.blockmap',
+  'latest-mac.yml',
+  'latest.yml'
+]
+
+// A complete DSH Desktop runtime is substantially larger than these floors.
+// These catch truncated/corrupt artifacts without pinning normal release sizes.
+const DEFAULT_MINIMUM_BYTES = {
+  dmg: 100 * 1024 * 1024,
+  zip: 100 * 1024 * 1024,
+  exe: 100 * 1024 * 1024,
+  blockmap: 1024,
+  yml: 64
+}
+
+async function sha512(file) {
+  const hash = createHash('sha512')
+  await new Promise((resolvePromise, rejectPromise) => {
+    const stream = createReadStream(file)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('error', rejectPromise)
+    stream.on('end', resolvePromise)
+  })
+  return hash.digest('base64')
+}
+
+function assetKind(name) {
+  if (name.endsWith('.zip.blockmap') || name.endsWith('.exe.blockmap')) return 'blockmap'
+  if (name.endsWith('.dmg')) return 'dmg'
+  if (name.endsWith('.zip')) return 'zip'
+  if (name.endsWith('.exe')) return 'exe'
+  if (name.endsWith('.yml')) return 'yml'
+  throw new Error(`Unsupported release asset: ${name}`)
+}
+
+async function assertFileHeader(file, kind, size) {
+  if (kind !== 'exe' && kind !== 'zip' && kind !== 'dmg') return
+  const handle = await open(file, 'r')
+  try {
+    if (kind === 'exe' || kind === 'zip') {
+      const header = Buffer.alloc(2)
+      const { bytesRead } = await handle.read(header, 0, header.length, 0)
+      const expected = kind === 'exe' ? 'MZ' : 'PK'
+      if (bytesRead !== header.length || !header.equals(Buffer.from(expected))) {
+        throw new Error(
+          `${basename(file)} is not a ${kind === 'exe' ? 'PE executable' : 'ZIP archive'}`
+        )
+      }
+      return
+    }
+
+    const trailerSize = Math.min(512, size)
+    const trailer = Buffer.alloc(trailerSize)
+    const { bytesRead } = await handle.read(trailer, 0, trailer.length, size - trailerSize)
+    if (bytesRead !== trailer.length || !trailer.includes(Buffer.from('koly'))) {
+      throw new Error(`${basename(file)} is not a UDIF disk image`)
+    }
+  } finally {
+    await handle.close()
+  }
+}
+
+async function assertUpdateEntry(root, metadataName, version, assetName) {
+  const metadata = parse(await readFile(join(root, metadataName), 'utf8'))
+  if (!metadata || metadata.version !== version || !Array.isArray(metadata.files)) {
+    throw new Error(`${metadataName} does not describe release ${version}`)
+  }
+
+  const entry = metadata.files.find((file) => file?.url === assetName)
+  if (!entry || typeof entry.sha512 !== 'string' || typeof entry.size !== 'number') {
+    throw new Error(`${metadataName} has no valid entry for ${assetName}`)
+  }
+
+  const file = join(root, assetName)
+  const fileStat = await stat(file)
+  const digest = await sha512(file)
+  if (entry.size !== fileStat.size || entry.sha512 !== digest) {
+    throw new Error(`${metadataName} checksum or size does not match ${assetName}`)
+  }
+}
+
+export async function verifyReleaseAssets(releaseDir, version, options = {}) {
+  const root = resolve(releaseDir)
+  const minimumBytes = { ...DEFAULT_MINIMUM_BYTES, ...options.minimumBytes }
+
+  for (const name of REQUIRED_ASSETS) {
+    const kind = assetKind(name)
+    const file = join(root, name)
+    const fileStat = await stat(file).catch(() => undefined)
+    if (!fileStat?.isFile()) throw new Error(`Missing required release asset: ${name}`)
+    if (fileStat.size < minimumBytes[kind]) {
+      throw new Error(`${name} is unexpectedly small (${fileStat.size} bytes)`)
+    }
+    await assertFileHeader(file, kind, fileStat.size)
+  }
+
+  await assertUpdateEntry(root, 'latest.yml', version, 'dsh-desktop-windows-x64-setup.exe')
+  await assertUpdateEntry(root, 'latest-mac.yml', version, 'dsh-desktop-mac-arm64.zip')
+  await assertUpdateEntry(root, 'latest-mac.yml', version, 'dsh-desktop-mac-x64.zip')
+}
+
+async function main() {
+  const [releaseDir, version] = process.argv.slice(2)
+  if (!releaseDir || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version ?? '')) {
+    throw new Error('Usage: node scripts/verify-release-assets.mjs <release-dir> <semver>')
+  }
+  await verifyReleaseAssets(releaseDir, version)
+  console.log(`Verified release assets for ${version}.`)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main()

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -185,6 +185,8 @@ describe('GitHub release contract', () => {
       expect(workflow).toContain(asset)
     }
     expect(workflow).toContain('merge-mac-update-metadata.mjs')
+    expect(workflow).toContain('Verify release assets before publication')
+    expect(workflow).toContain('verify-release-assets.mjs release-assets')
   })
 
   it('keeps builder jobs from attempting implicit tag publishing', async () => {

--- a/test/verify-release-assets.test.mjs
+++ b/test/verify-release-assets.test.mjs
@@ -1,0 +1,106 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { stringify } from 'yaml'
+import { describe, expect, it } from 'vitest'
+import { verifyReleaseAssets } from '../scripts/verify-release-assets.mjs'
+
+const minimumBytes = { dmg: 1, zip: 1, exe: 1, blockmap: 1, yml: 1 }
+
+async function digest(content) {
+  return createHash('sha512').update(content).digest('base64')
+}
+
+async function writeFixture(root, name, content) {
+  await writeFile(path.join(root, name), content)
+  return { url: name, size: content.length, sha512: await digest(content) }
+}
+
+async function createFixture(root) {
+  const armZip = await writeFixture(root, 'dsh-desktop-mac-arm64.zip', Buffer.from('PK-arm'))
+  const x64Zip = await writeFixture(root, 'dsh-desktop-mac-x64.zip', Buffer.from('PK-x64'))
+  const windows = await writeFixture(root, 'dsh-desktop-windows-x64-setup.exe', Buffer.from('MZ-win'))
+  await Promise.all([
+    writeFile(path.join(root, 'dsh-desktop-mac-arm64.dmg'), Buffer.concat([Buffer.alloc(512), Buffer.from('koly')])),
+    writeFile(path.join(root, 'dsh-desktop-mac-x64.dmg'), Buffer.concat([Buffer.alloc(512), Buffer.from('koly')])),
+    writeFile(path.join(root, 'dsh-desktop-mac-arm64.zip.blockmap'), 'blockmap'),
+    writeFile(path.join(root, 'dsh-desktop-mac-x64.zip.blockmap'), 'blockmap'),
+    writeFile(path.join(root, 'dsh-desktop-windows-x64-setup.exe.blockmap'), 'blockmap'),
+    writeFile(path.join(root, 'latest-mac.yml'), stringify({ version: '1.2.3', files: [armZip, x64Zip] })),
+    writeFile(path.join(root, 'latest.yml'), stringify({ version: '1.2.3', files: [windows] }))
+  ])
+}
+
+describe('release asset verification', () => {
+  it('accepts complete assets whose update metadata matches', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dsh-release-assets-'))
+    try {
+      await createFixture(root)
+      await expect(verifyReleaseAssets(root, '1.2.3', { minimumBytes })).resolves.toBeUndefined()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an unexpectedly small Windows installer before publication', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dsh-release-assets-'))
+    try {
+      await createFixture(root)
+      await expect(verifyReleaseAssets(root, '1.2.3')).rejects.toThrow('unexpectedly small')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a missing release asset', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dsh-release-assets-'))
+    try {
+      await createFixture(root)
+      await rm(path.join(root, 'dsh-desktop-mac-x64.dmg'))
+      await expect(
+        verifyReleaseAssets(root, '1.2.3', { minimumBytes })
+      ).rejects.toThrow('Missing required release asset: dsh-desktop-mac-x64.dmg')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an installer whose file signature is invalid', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dsh-release-assets-'))
+    try {
+      await createFixture(root)
+      await writeFile(path.join(root, 'dsh-desktop-windows-x64-setup.exe'), 'not-an-exe')
+      await expect(
+        verifyReleaseAssets(root, '1.2.3', { minimumBytes })
+      ).rejects.toThrow('is not a PE executable')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects update metadata whose digest or size does not match the package', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'dsh-release-assets-'))
+    try {
+      await createFixture(root)
+      await writeFile(
+        path.join(root, 'latest.yml'),
+        stringify({
+          version: '1.2.3',
+          files: [
+            {
+              url: 'dsh-desktop-windows-x64-setup.exe',
+              size: 6,
+              sha512: 'wrong-digest'
+            }
+          ]
+        })
+      )
+      await expect(
+        verifyReleaseAssets(root, '1.2.3', { minimumBytes })
+      ).rejects.toThrow('latest.yml checksum or size does not match')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- fail closed before publishing a GitHub release when any expected macOS or Windows artifact is missing or unexpectedly small
- verify DMG, ZIP, and EXE signatures plus updater metadata version, size, and SHA-512 values
- harden the Jsign download step and stream large package checks to avoid excessive memory use

## Validation

- `npx vitest run test/verify-release-assets.test.mjs test/release.test.ts` (19 passed)
- `npm test -- --run` (457 passed)
- `npm run typecheck`
- `npm run build`