### PR TITLE
fix(market): preserve pinned pnpm store config

### DIFF
--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -30,6 +30,34 @@ export function profileDirectory(home = dshHome()) {
   return join(home, 'profiles', MARKET_PROFILE)
 }
 
+const OBSOLETE_PROFILE_NPMRC_KEYS = new Set(['package-import-method', 'child-concurrency'])
+
+/**
+ * Update the settings Desktop owns without discarding profile-specific pnpm
+ * configuration. In particular, `store-dir` records where the existing
+ * node_modules tree was linked from; losing it makes pnpm reject every later
+ * plugin operation with ERR_PNPM_UNEXPECTED_STORE.
+ */
+export function updateProfileNpmrc(npmrc) {
+  const lines = npmrc.replaceAll('\r\n', '\n').split('\n')
+  if (lines.at(-1) === '') lines.pop()
+
+  const updated = []
+  let wroteSideEffectsCache = false
+  for (const line of lines) {
+    const key = /^\s*([^#;\s=]+)\s*=/u.exec(line)?.[1]?.toLowerCase()
+    if (key === 'side-effects-cache') {
+      if (!wroteSideEffectsCache) updated.push('side-effects-cache=false')
+      wroteSideEffectsCache = true
+      continue
+    }
+    if (key !== undefined && OBSOLETE_PROFILE_NPMRC_KEYS.has(key)) continue
+    updated.push(line)
+  }
+  if (!wroteSideEffectsCache) updated.push('side-effects-cache=false')
+  return `${updated.join('\n')}\n`
+}
+
 /** Leftovers of an interrupted pnpm run, or of a Windows locked-rename recovery. */
 export function isDisposableModuleDirectory(name) {
   return name.includes('_tmp_') || name.includes(SIDELINE_MARKER)
@@ -231,8 +259,8 @@ export async function ensurePnpmShim(home = dshHome()) {
     await chmod(nodePath, 0o755)
   }
 
-  // Also write .npmrc in profiles/web. package-import-method/child-concurrency
-  // are intentionally left at pnpm's defaults (hardlink, auto concurrency):
+  // Also update .npmrc in profiles/web. package-import-method/child-concurrency
+  // are intentionally removed so pnpm uses its defaults (hardlink, auto concurrency):
   // forcing clone-or-copy made every install do a full physical file copy
   // across the profile's 150+ packages, turning installs that should take
   // seconds into multi-minute (up to 30-minute) waits on Windows. The
@@ -241,9 +269,17 @@ export async function ensurePnpmShim(home = dshHome()) {
   const profileDir = profileDirectory(home)
   await mkdir(profileDir, { recursive: true })
   const npmrcPath = join(profileDir, '.npmrc')
-  const npmrcContent = ['side-effects-cache=false'].join('\n') + '\n'
+  let npmrcContent
   try {
-    await writeFile(npmrcPath, npmrcContent, 'utf8')
+    npmrcContent = await readFile(npmrcPath, 'utf8')
+  } catch (error) {
+    if (error?.code === 'ENOENT') npmrcContent = ''
+  }
+  try {
+    if (npmrcContent !== undefined) {
+      const updatedNpmrc = updateProfileNpmrc(npmrcContent)
+      if (updatedNpmrc !== npmrcContent) await writeFile(npmrcPath, updatedNpmrc, 'utf8')
+    }
   } catch {
     // ignore
   }

--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -30,32 +30,27 @@ export function profileDirectory(home = dshHome()) {
   return join(home, 'profiles', MARKET_PROFILE)
 }
 
-const OBSOLETE_PROFILE_NPMRC_KEYS = new Set(['package-import-method', 'child-concurrency'])
+const LEGACY_PACKAGE_IMPORT_METHOD = /^package-import-method=clone-or-copy(?:\r?\n|$)/mu
+const LEGACY_CHILD_CONCURRENCY = /^child-concurrency=1(?:\r?\n|$)/mu
 
 /**
- * Update the settings Desktop owns without discarding profile-specific pnpm
- * configuration. In particular, `store-dir` records where the existing
- * node_modules tree was linked from; losing it makes pnpm reject every later
- * plugin operation with ERR_PNPM_UNEXPECTED_STORE.
+ * Remove only the exact pair of slow Windows settings written by older
+ * Desktop releases. Treat every other byte as profile-owned: this file can
+ * carry the store pin, registries, proxies, certificates, and credentials.
  */
 export function updateProfileNpmrc(npmrc) {
-  const lines = npmrc.replaceAll('\r\n', '\n').split('\n')
-  if (lines.at(-1) === '') lines.pop()
+  const newline = npmrc.includes('\r\n') ? '\r\n' : '\n'
+  if (npmrc === '') return `side-effects-cache=false${newline}`
 
-  const updated = []
-  let wroteSideEffectsCache = false
-  for (const line of lines) {
-    const key = /^\s*([^#;\s=]+)\s*=/u.exec(line)?.[1]?.toLowerCase()
-    if (key === 'side-effects-cache') {
-      if (!wroteSideEffectsCache) updated.push('side-effects-cache=false')
-      wroteSideEffectsCache = true
-      continue
-    }
-    if (key !== undefined && OBSOLETE_PROFILE_NPMRC_KEYS.has(key)) continue
-    updated.push(line)
+  // Requiring the pair distinguishes Desktop's historical block from a user
+  // who deliberately chose just one of these otherwise valid pnpm settings.
+  if (!LEGACY_PACKAGE_IMPORT_METHOD.test(npmrc) || !LEGACY_CHILD_CONCURRENCY.test(npmrc)) {
+    return npmrc
   }
-  if (!wroteSideEffectsCache) updated.push('side-effects-cache=false')
-  return `${updated.join('\n')}\n`
+  const updated = npmrc
+    .replace(LEGACY_PACKAGE_IMPORT_METHOD, '')
+    .replace(LEGACY_CHILD_CONCURRENCY, '')
+  return updated === '' ? `side-effects-cache=false${newline}` : updated
 }
 
 /** Leftovers of an interrupted pnpm run, or of a Windows locked-rename recovery. */
@@ -259,8 +254,9 @@ export async function ensurePnpmShim(home = dshHome()) {
     await chmod(nodePath, 0o755)
   }
 
-  // Also update .npmrc in profiles/web. package-import-method/child-concurrency
-  // are intentionally removed so pnpm uses its defaults (hardlink, auto concurrency):
+  // Migrate only the exact package-import-method/child-concurrency pair that
+  // older Desktop releases wrote. pnpm then uses its defaults (hardlink, auto
+  // concurrency), while user configuration and the profile store pin survive:
   // forcing clone-or-copy made every install do a full physical file copy
   // across the profile's 150+ packages, turning installs that should take
   // seconds into multi-minute (up to 30-minute) waits on Windows. The
@@ -278,7 +274,7 @@ export async function ensurePnpmShim(home = dshHome()) {
   try {
     if (npmrcContent !== undefined) {
       const updatedNpmrc = updateProfileNpmrc(npmrcContent)
-      if (updatedNpmrc !== npmrcContent) await writeFile(npmrcPath, updatedNpmrc, 'utf8')
+      if (updatedNpmrc !== npmrcContent) await atomicWrite(npmrcPath, updatedNpmrc)
     }
   } catch {
     // ignore
@@ -464,8 +460,12 @@ export function buildUninstallArguments(dshEntry = resolveDshEntry()) {
 
 async function atomicWrite(path, contents) {
   const temporary = `${path}.dsh-desktop-${process.pid}-${Date.now()}.tmp`
-  await writeFile(temporary, contents, 'utf8')
-  await rename(temporary, path)
+  try {
+    await writeFile(temporary, contents, 'utf8')
+    await rename(temporary, path)
+  } finally {
+    await rm(temporary, { force: true }).catch(() => undefined)
+  }
 }
 
 function killProcessTree(child) {

--- a/src/main/state/profile-store.ts
+++ b/src/main/state/profile-store.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { profilePackageJsonPath } from './plugin-recovery'
 
@@ -48,11 +48,24 @@ export function configuredStoreDir(npmrc: string): string | undefined {
 export function pinStoreDir(npmrc: string, storeDir: string): string | undefined {
   const configured = configuredStoreDir(npmrc)
   if (configured === storeDir) return undefined
+  const newline = npmrc.includes('\r\n') ? '\r\n' : '\n'
   // pnpm strips the trailing store version segment from what it records, so
   // the pinned value is the directory that contains it.
-  const body = configured === undefined ? npmrc : npmrc.replace(/^\s*store-dir\s*=.*$\n?/mu, '')
-  const separator = body.length === 0 || body.endsWith('\n') ? '' : '\n'
-  return `${body}${separator}store-dir=${storeDir}\n`
+  const body = configured === undefined
+    ? npmrc
+    : npmrc.replace(/^\s*store-dir\s*=.*(?:\r?\n|$)/mu, '')
+  const separator = body.length === 0 || body.endsWith('\n') ? '' : newline
+  return `${body}${separator}store-dir=${storeDir}${newline}`
+}
+
+async function writeFileAtomically(path: string, contents: string): Promise<void> {
+  const temporary = `${path}.dsh-desktop-${process.pid}-${Date.now()}.tmp`
+  try {
+    await writeFile(temporary, contents, 'utf8')
+    await rename(temporary, path)
+  } finally {
+    await rm(temporary, { force: true }).catch(() => undefined)
+  }
 }
 
 /**
@@ -91,7 +104,7 @@ export async function ensureStoreDirPinned(dshHome: string): Promise<string | un
   if (pinned === undefined) return undefined
 
   try {
-    await writeFile(npmrcPath, pinned, 'utf8')
+    await writeFileAtomically(npmrcPath, pinned)
     return expected
   } catch {
     return undefined

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -2,6 +2,7 @@ import { mkdtemp, mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { ensureStoreDirPinned, inspectStoreConsistency } from '../src/main/state/profile-store'
 import {
   INSTALL_PATH,
   MARKET_PACKAGE,
@@ -51,41 +52,64 @@ describe('desktop plugin market installer', () => {
     expect(resolvePnpmEntry()).toMatch(/node_modules[/\\]pnpm[/\\]bin[/\\]pnpm\.(c|m)js$/u)
   })
 
-  it('updates Desktop pnpm settings without discarding the pinned profile store', () => {
+  it('removes only Desktop’s exact legacy pnpm settings and preserves sensitive config bytes', () => {
     const npmrc = [
       '# user configuration',
       'registry=https://registry.example.test/',
+      '//registry.example.test/:_authToken=${NPM_TOKEN}',
+      'cafile=/profile/private-ca.pem',
       'store-dir=/profile/.pnpm-store',
       'package-import-method=clone-or-copy',
       'child-concurrency=1',
       'side-effects-cache=true',
       ''
-    ].join('\n')
+    ].join('\r\n')
 
-    expect(updateProfileNpmrc(npmrc)).toBe([
+    const expected = [
       '# user configuration',
       'registry=https://registry.example.test/',
+      '//registry.example.test/:_authToken=${NPM_TOKEN}',
+      'cafile=/profile/private-ca.pem',
       'store-dir=/profile/.pnpm-store',
-      'side-effects-cache=false',
+      'side-effects-cache=true',
       ''
-    ].join('\n'))
+    ].join('\r\n')
+
+    expect(updateProfileNpmrc(npmrc)).toBe(expected)
+    expect(updateProfileNpmrc(expected)).toBe(expected)
   })
 
-  it('keeps the profile store pin when regenerating packaged pnpm shims', async () => {
+  it('leaves user-selected or partial pnpm tuning untouched', () => {
+    const custom = 'package-import-method=copy\nchild-concurrency=8\nstore-dir=/keep\n'
+    const partialLegacy = 'package-import-method=clone-or-copy\nstore-dir=/keep\n'
+    expect(updateProfileNpmrc(custom)).toBe(custom)
+    expect(updateProfileNpmrc(partialLegacy)).toBe(partialLegacy)
+  })
+
+  it('keeps the store consistent through pinning and packaged shim regeneration', async () => {
     const home = await mkdtemp(join(tmpdir(), 'dsh-market-store-pin-'))
     const profile = join(home, 'profiles', 'web')
-    await mkdir(profile, { recursive: true })
+    const store = join(profile, '.pnpm-store')
+    await mkdir(join(profile, 'node_modules'), { recursive: true })
+    await writeFile(join(profile, 'package.json'), '{}', 'utf8')
+    await writeFile(
+      join(profile, 'node_modules', '.modules.yaml'),
+      `  "storeDir": "${store}/v10",\n`,
+      'utf8'
+    )
     await writeFile(
       join(profile, '.npmrc'),
-      'store-dir=/profile/.pnpm-store\npackage-import-method=clone-or-copy\n',
+      'package-import-method=clone-or-copy\nchild-concurrency=1\nside-effects-cache=false\n',
       'utf8'
     )
 
+    await expect(ensureStoreDirPinned(home)).resolves.toBe(store)
     await ensurePnpmShim(home)
 
     expect(await readFile(join(profile, '.npmrc'), 'utf8')).toBe(
-      'store-dir=/profile/.pnpm-store\nside-effects-cache=false\n'
+      `side-effects-cache=false\nstore-dir=${store}\n`
     )
+    await expect(inspectStoreConsistency(home)).resolves.toBeUndefined()
   })
 
   it('generates packaged node and pnpm shims in desktop-bin', async () => {

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -18,7 +18,8 @@ import {
   isTrustedRequest,
   readMarketInstallation,
   resolvePnpmEntry,
-  stagePnpmRunner
+  stagePnpmRunner,
+  updateProfileNpmrc
 } from '../packages/dsh-desktop-market-installer/index.js'
 
 describe('desktop plugin market installer', () => {
@@ -48,6 +49,43 @@ describe('desktop plugin market installer', () => {
 
   it('ships a resolvable pnpm binary instead of relying on the user PATH', () => {
     expect(resolvePnpmEntry()).toMatch(/node_modules[/\\]pnpm[/\\]bin[/\\]pnpm\.(c|m)js$/u)
+  })
+
+  it('updates Desktop pnpm settings without discarding the pinned profile store', () => {
+    const npmrc = [
+      '# user configuration',
+      'registry=https://registry.example.test/',
+      'store-dir=/profile/.pnpm-store',
+      'package-import-method=clone-or-copy',
+      'child-concurrency=1',
+      'side-effects-cache=true',
+      ''
+    ].join('\n')
+
+    expect(updateProfileNpmrc(npmrc)).toBe([
+      '# user configuration',
+      'registry=https://registry.example.test/',
+      'store-dir=/profile/.pnpm-store',
+      'side-effects-cache=false',
+      ''
+    ].join('\n'))
+  })
+
+  it('keeps the profile store pin when regenerating packaged pnpm shims', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-market-store-pin-'))
+    const profile = join(home, 'profiles', 'web')
+    await mkdir(profile, { recursive: true })
+    await writeFile(
+      join(profile, '.npmrc'),
+      'store-dir=/profile/.pnpm-store\npackage-import-method=clone-or-copy\n',
+      'utf8'
+    )
+
+    await ensurePnpmShim(home)
+
+    expect(await readFile(join(profile, '.npmrc'), 'utf8')).toBe(
+      'store-dir=/profile/.pnpm-store\nside-effects-cache=false\n'
+    )
   })
 
   it('generates packaged node and pnpm shims in desktop-bin', async () => {

--- a/test/profile-store.test.ts
+++ b/test/profile-store.test.ts
@@ -59,6 +59,9 @@ describe('the profile’s pnpm store', () => {
     // Already correct: the file is not rewritten on every launch.
     expect(pinStoreDir(`${NPMRC}store-dir=/store\n`, '/store')).toBeUndefined()
     expect(pinStoreDir('', '/store')).toBe('store-dir=/store\n')
+    expect(pinStoreDir('registry=https://example.test/\r\n', '/store')).toBe(
+      'registry=https://example.test/\r\nstore-dir=/store\r\n'
+    )
   })
 
   it('states the recorded store in the profile’s config', async () => {


### PR DESCRIPTION
## Summary

- preserve every existing profile `.npmrc` byte except the exact historical Desktop pair `package-import-method=clone-or-copy` plus `child-concurrency=1`
- retain user-selected pnpm values, `store-dir`, `side-effects-cache`, registry/auth/proxy/certificate configuration, and CRLF line endings
- write both the store pin and shim migration atomically
- add regression coverage for exact migration, custom/partial values, auth placeholders, idempotence, CRLF, and the complete store-pin to shim-regeneration flow

## Root cause

PR #204 changed `.npmrc` creation into an unconditional rewrite so old Windows performance overrides would be removed. That rewrite also deleted the `store-dir` pin written by Desktop. Existing `node_modules` remained linked to the profile-local store while pnpm resolved the global store, causing every plugin mutation to fail with `ERR_PNPM_UNEXPECTED_STORE`.

## Safety boundary

The migration does not parse and rebuild the file. It removes only the two exact legacy lines when both are present; all other content is returned unchanged. A user-selected value or a partial match is left alone.

## Validation

- `npm test -- --run test/market-installer.test.js test/profile-store.test.ts` (2 files, 21 tests passed)
- `npm test` (59 files, 455 tests passed)
- `npm run typecheck`
- `git diff --check`