### PR TITLE
fix(ui): migrate Desktop branding to Harness slots

### DIFF
--- a/build/dsh-desktop.patch.yml
+++ b/build/dsh-desktop.patch.yml
@@ -2,7 +2,18 @@
 # serves ctx.directoryPicker, so host-side consumers (host.pickDirectory,
 # plugins reading the seam) work unmodified. The client surface keeps its
 # Electron-dialog bridge via the client-ui patch in patches/.
+
+# Disable the stock single-slot occupant before mounting Desktop's equivalent;
+# two occupants cannot share either brand seat. The Desktop plugin preserves
+# the stock conversation mark and owns the phone action through the public
+# sidebar footer slot. Window chrome geometry remains a native-shell concern.
+- id: ui-brand-official
+  disabled: true
+
 - insert:
+    - id: dsh-desktop-client-ui
+      name: dsh-desktop-client-ui
+
     # DSH Desktop owns the fixed-target dsh-market installer and its lightweight
     # settings entry. After dshmarket is installed and Harness restarts, the
     # community plugin replaces the placeholder with its complete market UI.

--- a/docs/harness-0.1.2-upgrade.md
+++ b/docs/harness-0.1.2-upgrade.md
@@ -10,8 +10,8 @@
 ```
 npm ci（含 postinstall）  → 0
 npm run build             → ok
-实际启动 Electron          → 正常运行，profile 三个插件全部挂载
-npm test                  → 60 files / 453 tests 全通过
+实际启动 Electron          → 正常运行，profile 四个插件全部挂载
+npm test                  → 61 files / 454 tests 通过；已有 WebSocket teardown 异常使进程退出 1
 tsc --noEmit              → 0 错误
 verify-harness-auth.mjs   → 401 → 303 → 200 全通过
 ```
@@ -122,7 +122,7 @@ POST /api/session/list                       ← <namespace>/<method>，不是�
 | `ui-directory-picker-native` | 上游把 `ctx.workspaces` 改名 `ctx.uiWorkspace` |
 | `ui-model-selection` | CSS hash `_7KE1Ra_` → `_2WBGbq_` |
 | `ui-settings-models` | hash `GL8Viq_`→`oGvYtW_`、`zGbnIq_`→`uVX9wq_`；`EditorFooter` 属性改名 `submitLabel*` → `submitLabelKey*`；服务商下拉改为可搜索卡片网格 |
-| `ui-sidebar` | hash `hHd-Xa_` → `iFWS7G_`；品牌锁定与红绿灯留白上游未采纳，保留 |
+| `ui-sidebar` | 不再改写品牌结构；仅保留红绿灯顶部留白和 Desktop 稳定状态标记 |
 | `ui-workspace` | hash `YDXeBa_` → `koIWyW_`；`SessionTree`/`FlatList` 上游新增 `useSessionPendingInteraction` 参数 |
 | `ui-agent-preset` | hash `cubgiG_` → `_4FiJda_`；菜单 `onSelect` 上游新增 toast，需绕开 |
 | **新增** `ui-chat`、`ui-trajectory` | 承接被删的 `client-runtime` 的 provider 错误提示，改为 i18n 并中文化 |
@@ -143,6 +143,13 @@ POST /api/session/list                       ← <namespace>/<method>，不是�
   Cordis 会直接不挂载该控制器。再打补丁等于重写上游。
 
 ### 从补丁改为插件
+
+Sidebar 品牌原先直接改写构建后的组件和 CSS Module 映射。0.1.2 已正式提供
+`sidebar.brand.mark`、`sidebar.brand.name` 与 `conversation.hero.brand.mark`，现在由
+[`packages/dsh-desktop-client-ui/`](../packages/dsh-desktop-client-ui/) 接管这些 single slot：
+Desktop 图标与 `includeMark: false` 的原生字标分别注册，conversation hero 继续使用上游
+FishLogo。手机入口也迁到 `sidebar.footer.action`，preload 只保留受控 IPC bridge。
+macOS 无边框窗口、traffic lights、拖动区和折叠栏 80px 仍属于宿主/布局几何，不交给品牌 slot。
 
 预设导入导出（`/api/agent-preset.export` / `.import`）原本寄生在 apiproxy 补丁里。
 上游没有等价能力（`agentPresets` 只有 copy/delete/list/read/select），所以功能仍归桌面端，

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,6 +260,7 @@
         "@deepseek-ai/dsh-workflow-worker-thread": "file:packages/harness-0.1.2-alpha.1/npm-dsh/deepseek-ai-dsh-workflow-worker-thread-0.1.2-alpha.1.tgz",
         "@deepseek-ai/dsh-workspace": "file:packages/harness-0.1.2-alpha.1/npm-dsh/deepseek-ai-dsh-workspace-0.1.2-alpha.1.tgz",
         "@deepseek-ai/schemastery": "file:packages/harness-0.1.2-alpha.1/npm-vendor/deepseek-ai-schemastery-3.18.1.tgz",
+        "dsh-desktop-client-ui": "file:packages/dsh-desktop-client-ui",
         "dsh-desktop-hmr-fallback": "file:packages/dsh-desktop-hmr-fallback",
         "dsh-desktop-market-installer": "file:packages/dsh-desktop-market-installer",
         "dsh-desktop-preset-transfer": "file:packages/dsh-desktop-preset-transfer",
@@ -11497,6 +11498,10 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dsh-desktop-client-ui": {
+      "resolved": "packages/dsh-desktop-client-ui",
+      "link": true
+    },
     "node_modules/dsh-desktop-hmr-fallback": {
       "resolved": "packages/dsh-desktop-hmr-fallback",
       "link": true
@@ -19175,6 +19180,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/dsh-desktop-client-ui": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.2-alpha.1",
+        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.2-alpha.1",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.2-alpha.1"
       }
     },
     "packages/dsh-desktop-hmr-fallback": {

--- a/package.json
+++ b/package.json
@@ -292,6 +292,7 @@
     "@deepseek-ai/dsh-workflow-worker-thread": "file:packages/harness-0.1.2-alpha.1/npm-dsh/deepseek-ai-dsh-workflow-worker-thread-0.1.2-alpha.1.tgz",
     "@deepseek-ai/dsh-workspace": "file:packages/harness-0.1.2-alpha.1/npm-dsh/deepseek-ai-dsh-workspace-0.1.2-alpha.1.tgz",
     "@deepseek-ai/schemastery": "file:packages/harness-0.1.2-alpha.1/npm-vendor/deepseek-ai-schemastery-3.18.1.tgz",
+    "dsh-desktop-client-ui": "file:packages/dsh-desktop-client-ui",
     "dsh-desktop-hmr-fallback": "file:packages/dsh-desktop-hmr-fallback",
     "dsh-desktop-market-installer": "file:packages/dsh-desktop-market-installer",
     "dsh-desktop-preset-transfer": "file:packages/dsh-desktop-preset-transfer",

--- a/packages/dsh-desktop-client-ui/client.js
+++ b/packages/dsh-desktop-client-ui/client.js
@@ -1,0 +1,173 @@
+window.__ModuleLoader__.load({
+  id: 'dsh-desktop-client-ui',
+  factory: (require) => {
+    const module = { exports: {} }
+    const exports = module.exports
+    Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' })
+
+    const React = require('react')
+    const { BrandWordmark, FishLogo } = require('@deepseek-ai/dsh-client-ui-primitives')
+
+    const LIGHT_LOGO_URL = '/dsh-desktop-logo-light.png'
+    const DARK_LOGO_URL = '/dsh-desktop-logo-dark.png'
+    const STYLE_ID = 'dsh-desktop-client-ui-style'
+
+    function installStyles() {
+      if (document.getElementById(STYLE_ID)) return
+      const style = document.createElement('style')
+      style.id = STYLE_ID
+      style.dataset.plugin = 'dsh-desktop-client-ui'
+      style.textContent = `
+        .dshDesktopBrandDark{display:none}
+        body[data-ds-dark-theme] .dshDesktopBrandLight{display:none}
+        body[data-ds-dark-theme] .dshDesktopBrandDark{display:block}
+        .dshDesktopMobileButton{appearance:none;position:relative;width:32px;height:32px;color:var(--dsw-alias-label-secondary,#73777f);background:transparent;border:0;border-radius:9px;display:inline-flex;align-items:center;justify-content:center;cursor:pointer}
+        .dshDesktopMobileButton:hover{color:var(--dsw-alias-label-primary,#202124);background:var(--dsw-alias-interactive-bg-hover,rgba(32,33,36,.08))}
+        .dshDesktopMobileButton:focus-visible{outline:2px solid #4d6bfe;outline-offset:1px}
+        .dshDesktopMobileButtonDot{position:absolute;top:4px;right:4px;width:7px;height:7px;border:1.5px solid var(--dsw-specific-sidebar-fill,#fff);border-radius:50%;background:#4da66d}
+      `
+      document.head.appendChild(style)
+    }
+
+    function DesktopBrandMark() {
+      const height = 17
+      return React.createElement(
+        'svg',
+        {
+          width: height * 1030 / 590,
+          height,
+          viewBox: '150 330 1030 590',
+          fill: 'none',
+          'aria-hidden': 'true'
+        },
+        React.createElement('image', {
+          className: 'dshDesktopBrandLight',
+          href: LIGHT_LOGO_URL,
+          x: 150,
+          y: 330,
+          width: 1030,
+          height: 590,
+          preserveAspectRatio: 'xMidYMid meet'
+        }),
+        React.createElement('image', {
+          className: 'dshDesktopBrandDark',
+          href: DARK_LOGO_URL,
+          x: 150,
+          y: 330,
+          width: 1030,
+          height: 590,
+          preserveAspectRatio: 'xMidYMid meet'
+        })
+      )
+    }
+
+    function DesktopBrandName() {
+      return React.createElement(BrandWordmark, { includeMark: false })
+    }
+
+    function ConversationBrandMark(props) {
+      return React.createElement(FishLogo, props)
+    }
+
+    function PhoneIcon() {
+      return React.createElement(
+        'svg',
+        { viewBox: '0 0 24 24', width: 19, height: 19, fill: 'none', 'aria-hidden': 'true' },
+        React.createElement('rect', {
+          x: 7,
+          y: 2.75,
+          width: 10,
+          height: 18.5,
+          rx: 2.25,
+          stroke: 'currentColor',
+          strokeWidth: 1.7
+        }),
+        React.createElement('path', {
+          d: 'M10.2 5.5h3.6M10.5 18.35h3',
+          stroke: 'currentColor',
+          strokeWidth: 1.7,
+          strokeLinecap: 'round'
+        })
+      )
+    }
+
+    function MobileButton({ wide }) {
+      const [connected, setConnected] = React.useState(false)
+      React.useEffect(() => {
+        const bridge = globalThis.dshDesktop
+        let mounted = true
+        const status = bridge?.getMobileStatus?.()
+        if (status) {
+          void status.then((next) => {
+            if (mounted) setConnected(next?.connected === true)
+          }).catch(() => undefined)
+        }
+        const dispose = bridge?.onMobileStatusChanged?.((next) => {
+          if (mounted) setConnected(next === true)
+        })
+        return () => {
+          mounted = false
+          if (typeof dispose === 'function') dispose()
+        }
+      }, [])
+
+      if (!wide && !connected) return null
+      const zh = navigator.language.toLowerCase().startsWith('zh')
+      const label = connected
+        ? zh ? '管理手机连接' : 'Manage phone connection'
+        : zh ? '连接手机' : 'Connect phone'
+      return React.createElement(
+        'button',
+        {
+          type: 'button',
+          className: 'dshDesktopMobileButton',
+          title: label,
+          'aria-label': label,
+          onClick: () => {
+            const opening = globalThis.dshDesktop?.openMobilePairing?.()
+            if (opening) void opening.catch(() => undefined)
+          }
+        },
+        React.createElement(PhoneIcon),
+        connected
+          ? React.createElement('span', {
+              className: 'dshDesktopMobileButtonDot',
+              'aria-hidden': 'true'
+            })
+          : null
+      )
+    }
+
+    const inject = ['slots']
+    function apply(ctx) {
+      installStyles()
+      ctx.slots.inject('sidebar.brand.mark', () =>
+        ctx.slots.inject('sidebar.brand.name', () =>
+          ctx.slots.inject('conversation.hero.brand.mark', () =>
+            ctx.slots.inject('sidebar.footer.action', function* () {
+              yield ctx.slots.register({ name: 'sidebar.brand.mark' }, DesktopBrandMark)
+              yield ctx.slots.register({ name: 'sidebar.brand.name' }, DesktopBrandName)
+              yield ctx.slots.register(
+                { name: 'conversation.hero.brand.mark' },
+                ConversationBrandMark
+              )
+              yield ctx.slots.register(
+                {
+                  name: 'sidebar.footer.action',
+                  id: 'dsh-desktop-mobile',
+                  order: 20,
+                  label: 'DSH Desktop mobile pairing'
+                },
+                MobileButton
+              )
+            })
+          )
+        )
+      )
+    }
+
+    exports.apply = apply
+    exports.inject = inject
+    return module.exports
+  }
+})

--- a/packages/dsh-desktop-client-ui/index.js
+++ b/packages/dsh-desktop-client-ui/index.js
@@ -1,0 +1,2 @@
+/** Host half for the browser-only DSH Desktop UI occupants. */
+export function apply() {}

--- a/packages/dsh-desktop-client-ui/package.json
+++ b/packages/dsh-desktop-client-ui/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "dsh-desktop-client-ui",
+  "version": "0.1.0",
+  "description": "DSH Desktop brand and native-shell controls for Harness UI slots.",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./client": "./client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [
+        "@deepseek-ai/dsh-client-ui-conversation",
+        "@deepseek-ai/dsh-client-ui-renderer",
+        "@deepseek-ai/dsh-client-ui-sidebar"
+      ],
+      "platform": "web"
+    }
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-client-ui-conversation": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-client-ui-renderer": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.2-alpha.1"
+  }
+}

--- a/patches/@deepseek-ai+dsh+0.1.2-alpha.1.patch
+++ b/patches/@deepseek-ai+dsh+0.1.2-alpha.1.patch
@@ -2,10 +2,11 @@ diff --git a/node_modules/@deepseek-ai/dsh/package.json b/node_modules/@deepseek
 index bfb8e32..dae9f0b 100644
 --- a/node_modules/@deepseek-ai/dsh/package.json
 +++ b/node_modules/@deepseek-ai/dsh/package.json
-@@ -28,6 +28,9 @@
+@@ -28,6 +28,10 @@
    },
    "license": "MIT",
    "dependencies": {
++    "dsh-desktop-client-ui": "0.1.0",
 +    "dsh-desktop-hmr-fallback": "0.1.0",
 +    "dsh-desktop-market-installer": "0.1.0",
 +    "dsh-desktop-preset-transfer": "0.1.0",

--- a/patches/@deepseek-ai+dsh-client-ui-sidebar+0.1.2-alpha.1.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-sidebar+0.1.2-alpha.1.patch
@@ -1,76 +1,17 @@
 diff --git a/node_modules/@deepseek-ai/dsh-client-ui-sidebar/lib/client.js b/node_modules/@deepseek-ai/dsh-client-ui-sidebar/lib/client.js
-index 696591c..332e42c 100644
+index 696591c..90c1520 100644
 --- a/node_modules/@deepseek-ai/dsh-client-ui-sidebar/lib/client.js
 +++ b/node_modules/@deepseek-ai/dsh-client-ui-sidebar/lib/client.js
-@@ -23,13 +23,13 @@ window.__ModuleLoader__.load({
- 		}
- 		//#endregion
- 		//#region \0dsh-css:/private/tmp/claude-501/-Users-alex-Documents-Code-dataelem-dsh-desktop/8cafdb41-dc87-41ba-bba5-9afd99a08420/scratchpad/harness/packages/client/ui-sidebar/src/client/SidebarRoot.module.css.mjs
--		const css = ".iFWS7G_root{--dsh-sidebar-inline-padding:12px;height:100%;padding:6px var(--dsh-sidebar-inline-padding);box-sizing:border-box;background:var(--dsw-specific-sidebar-fill);color:var(--dsw-alias-label-primary);--dsh-scrollbar-thumb:var(--dsw-alias-scrollbar-bg-l2);--dsh-scrollbar-thumb-hover:var(--dsw-alias-scrollbar-hover-l2);flex-direction:column;font-size:14px;display:flex}.iFWS7G_root.iFWS7G_collapsed{padding:18px 10px 6px}.iFWS7G_root.iFWS7G_quietBars{--dsh-scrollbar-thumb:transparent;--dsh-scrollbar-thumb-hover:transparent}.iFWS7G_fading>*{opacity:0;transition:opacity .15s var(--ds-ease-in-out)}.iFWS7G_wide{animation:iFWS7G_wide-in .2s var(--ds-ease-in-out)}@keyframes iFWS7G_wide-in{0%{opacity:0}}.iFWS7G_railIn .iFWS7G_iconButton,.iFWS7G_railIn .iFWS7G_newSession,.iFWS7G_railIn .iFWS7G_regionArea{animation:iFWS7G_rail-in .15s var(--ds-ease-in-out) backwards}.iFWS7G_railIn .iFWS7G_footArea{animation:iFWS7G_rail-fade-in .15s var(--ds-ease-in-out) backwards}@keyframes iFWS7G_rail-in{0%{opacity:0;transform:translate(49px)}}@keyframes iFWS7G_rail-fade-in{0%{opacity:0}}.iFWS7G_logoRow{box-sizing:border-box;flex:none;justify-content:flex-end;align-items:center;gap:8px;height:60px;margin-bottom:8px;padding:8px 0 8px 4px;display:flex;overflow:hidden}.iFWS7G_collapsed .iFWS7G_logoRow{justify-content:flex-start;height:36px;margin-bottom:12px;padding:0}.iFWS7G_brand{min-width:0;color:inherit;cursor:pointer;background:0 0;border:none;flex:1;align-items:center;padding:0;display:inline-flex;overflow:hidden}.iFWS7G_brandIdentity{align-items:center;gap:8px;min-width:0;height:24px;display:inline-flex}.iFWS7G_brandMark{flex:none;justify-content:center;align-items:center;display:inline-flex}.iFWS7G_brandName{letter-spacing:.04em;align-items:center;gap:6px;min-width:0;height:24px;font-size:18px;font-weight:600;line-height:24px;display:inline-flex}.iFWS7G_fallbackBrandName{letter-spacing:0;white-space:nowrap;font-size:17px}.iFWS7G_localBuildBrand{white-space:nowrap;flex-direction:column;flex:none;justify-content:center;align-items:flex-start;gap:1px;height:24px;display:inline-flex}.iFWS7G_localBuildTitle{letter-spacing:0;font-size:12px;line-height:13px}.iFWS7G_iconButton{cursor:pointer;width:28px;height:28px;color:var(--dsw-alias-label-secondary);background:0 0;border:none;border-radius:50%;flex:none;justify-content:center;align-items:center;padding:0;display:inline-flex}.iFWS7G_iconButton:hover{background:var(--dsw-alias-interactive-bg-hover)}.iFWS7G_collapsed .iFWS7G_iconButton{width:36px;height:36px}.iFWS7G_collapsed .iFWS7G_toggle .iFWS7G_panelIcon{display:none}.iFWS7G_collapsed .iFWS7G_toggle:hover .iFWS7G_panelIcon{display:inline}.iFWS7G_collapsed .iFWS7G_toggle:hover .iFWS7G_railMark{display:none}.iFWS7G_railMark{justify-content:center;align-items:center;display:inline-flex}.iFWS7G_collapsed .iFWS7G_iconButton{color:var(--dsw-alias-label-primary)}.iFWS7G_buildVersion{height:10px;color:var(--dsw-alias-label-primary-inverted);background:var(--dsw-alias-label-primary);font-family:var(--ds-font-family-code);white-space:nowrap;border-radius:2px;flex:none;align-items:center;padding:0 3px;font-size:6px;font-weight:500;line-height:10px;display:inline-flex}.iFWS7G_newSession{box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-button-elevated-fill);height:38px;color:var(--dsw-alias-label-primary);cursor:pointer;border-radius:12px;flex:none;justify-content:center;align-items:center;gap:6px;margin:0 2px 8px;padding:8px 16px;font-size:14px;font-weight:500;line-height:22px;display:flex;overflow:hidden}.iFWS7G_newSession:hover{background:var(--dsw-alias-button-floating-hover)}.iFWS7G_collapsed .iFWS7G_newSession{background:0 0;border-color:#0000;align-self:flex-start;gap:0;width:36px;height:36px;margin:0 0 12px;padding:0}.iFWS7G_collapsed .iFWS7G_newSession:hover{background:var(--dsw-alias-interactive-bg-hover)}.iFWS7G_newSessionLabel{white-space:nowrap;max-width:200px;overflow:hidden}.iFWS7G_collapsed .iFWS7G_newSessionLabel{max-width:0}.iFWS7G_regionArea{min-height:0;margin-left:-4px;margin-right:calc(-1 * var(--dsh-sidebar-inline-padding));flex-direction:column;flex:1;padding-left:4px;display:flex;overflow:hidden}.iFWS7G_collapsed .iFWS7G_regionArea{margin-left:0;margin-right:0;padding-left:0}.iFWS7G_footArea{flex-direction:column;flex:none;display:flex}.iFWS7G_settingsArea,.iFWS7G_footerActions{flex:none;width:100%;min-width:0}.iFWS7G_footerActions{display:flex}.iFWS7G_collapsed .iFWS7G_footArea{align-items:center}.iFWS7G_collapsed .iFWS7G_settingsArea,.iFWS7G_collapsed .iFWS7G_footerActions{justify-content:center;width:auto;display:flex}@media (prefers-reduced-motion:reduce){.iFWS7G_wide,.iFWS7G_fading>*,.iFWS7G_railIn .iFWS7G_iconButton,.iFWS7G_railIn .iFWS7G_newSession,.iFWS7G_railIn .iFWS7G_footArea,.iFWS7G_railIn .iFWS7G_regionArea{transition:none;animation:none}}";
-+		const css = ".iFWS7G_root{--dsh-sidebar-inline-padding:12px;height:100%;padding:6px var(--dsh-sidebar-inline-padding);box-sizing:border-box;background:var(--dsw-specific-sidebar-fill);color:var(--dsw-alias-label-primary);--dsh-scrollbar-thumb:var(--dsw-alias-scrollbar-bg-l2);--dsh-scrollbar-thumb-hover:var(--dsw-alias-scrollbar-hover-l2);flex-direction:column;font-size:14px;display:flex}.iFWS7G_root.iFWS7G_collapsed{padding:18px 10px 6px}.iFWS7G_root.iFWS7G_quietBars{--dsh-scrollbar-thumb:transparent;--dsh-scrollbar-thumb-hover:transparent}.iFWS7G_fading>*{opacity:0;transition:opacity .15s var(--ds-ease-in-out)}.iFWS7G_wide{animation:iFWS7G_wide-in .2s var(--ds-ease-in-out)}@keyframes iFWS7G_wide-in{0%{opacity:0}}.iFWS7G_railIn .iFWS7G_iconButton,.iFWS7G_railIn .iFWS7G_newSession,.iFWS7G_railIn .iFWS7G_regionArea{animation:iFWS7G_rail-in .15s var(--ds-ease-in-out) backwards}.iFWS7G_railIn .iFWS7G_footArea{animation:iFWS7G_rail-fade-in .15s var(--ds-ease-in-out) backwards}@keyframes iFWS7G_rail-in{0%{opacity:0;transform:translate(49px)}}@keyframes iFWS7G_rail-fade-in{0%{opacity:0}}.iFWS7G_logoRow{box-sizing:border-box;flex:none;justify-content:flex-end;align-items:center;gap:8px;height:56px;margin-bottom:8px;padding:8px 2px;display:flex;overflow:hidden}.iFWS7G_collapsed .iFWS7G_logoRow{justify-content:flex-start;height:36px;margin-bottom:12px;padding:0}.iFWS7G_brand{min-width:0;height:40px;color:inherit;cursor:pointer;background:0 0;border:none;border-radius:10px;flex:1;align-items:center;padding:3px 6px;display:inline-flex;overflow:hidden}.iFWS7G_brand:hover{background:var(--dsw-alias-interactive-bg-hover)}.iFWS7G_brandLockup{min-width:0;align-items:center;gap:4px;display:inline-flex}.iFWS7G_brandIdentity{align-items:center;gap:8px;min-width:0;height:24px;display:inline-flex}.iFWS7G_brandMark{width:27px;height:23.4px;flex:none;justify-content:center;align-items:center;display:inline-flex}.iFWS7G_brandWordmark{width:158px;height:24px;color:var(--dsw-alias-label-primary);flex:none;display:inline-flex;overflow:hidden}.iFWS7G_brandWordmark>svg{max-width:none;flex:none;transform:translateX(-24px)}.iFWS7G_brandName{letter-spacing:.04em;align-items:center;gap:6px;min-width:0;height:24px;font-size:18px;font-weight:600;line-height:24px;display:inline-flex}.iFWS7G_fallbackBrandName{letter-spacing:0;white-space:nowrap;font-size:17px}.iFWS7G_localBuildBrand{white-space:nowrap;flex-direction:column;flex:none;justify-content:center;align-items:flex-start;gap:1px;height:24px;display:inline-flex}.iFWS7G_localBuildTitle{letter-spacing:0;font-size:12px;line-height:13px}.iFWS7G_iconButton{cursor:pointer;width:28px;height:28px;color:var(--dsw-alias-label-secondary);background:0 0;border:none;border-radius:50%;flex:none;justify-content:center;align-items:center;padding:0;display:inline-flex}.iFWS7G_iconButton:hover{background:var(--dsw-alias-interactive-bg-hover)}.iFWS7G_collapsed .iFWS7G_iconButton{width:36px;height:36px}.iFWS7G_collapsed .iFWS7G_toggle .iFWS7G_panelIcon{display:none}.iFWS7G_collapsed .iFWS7G_toggle:hover .iFWS7G_panelIcon{display:inline}.iFWS7G_collapsed .iFWS7G_toggle:hover .iFWS7G_railFish{display:none}.iFWS7G_collapsed .iFWS7G_toggle:hover .iFWS7G_railMark{display:none}.iFWS7G_railMark{justify-content:center;align-items:center;display:inline-flex}.iFWS7G_collapsed .iFWS7G_iconButton{width:36px;height:36px}.iFWS7G_buildVersion{height:10px;color:var(--dsw-alias-label-primary-inverted);background:var(--dsw-alias-label-primary);font-family:var(--ds-font-family-code);white-space:nowrap;border-radius:2px;flex:none;align-items:center;padding:0 3px;font-size:6px;font-weight:500;line-height:10px;display:inline-flex}.iFWS7G_newSession{box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-button-elevated-fill);height:38px;color:var(--dsw-alias-label-primary);cursor:pointer;border-radius:12px;flex:none;justify-content:center;align-items:center;gap:6px;margin:0 2px 8px;padding:8px 16px;font-size:14px;font-weight:500;line-height:22px;display:flex;overflow:hidden}.iFWS7G_newSession:hover{background:var(--dsw-alias-button-floating-hover)}.iFWS7G_collapsed .iFWS7G_newSession{background:0 0;border-color:#0000;align-self:flex-start;gap:0;width:36px;height:36px;margin:0 0 12px;padding:0}.iFWS7G_collapsed .iFWS7G_newSession:hover{background:var(--dsw-alias-interactive-bg-hover)}.iFWS7G_newSessionLabel{white-space:nowrap;max-width:200px;overflow:hidden}.iFWS7G_collapsed .iFWS7G_newSessionLabel{max-width:0}.iFWS7G_regionArea{min-height:0;margin-left:-4px;margin-right:calc(-1 * var(--dsh-sidebar-inline-padding));flex-direction:column;flex:1;padding-left:4px;display:flex;overflow:hidden}.iFWS7G_collapsed .iFWS7G_regionArea{margin-left:0;margin-right:0;padding-left:0}.iFWS7G_footArea{flex-direction:column;flex:none;display:flex}.iFWS7G_settingsArea,.iFWS7G_footerActions{flex:none;width:100%;min-width:0}.iFWS7G_footerActions{display:flex}.iFWS7G_collapsed .iFWS7G_footArea{align-items:center}.iFWS7G_collapsed .iFWS7G_settingsArea,.iFWS7G_collapsed .iFWS7G_footerActions{justify-content:center;width:auto;display:flex}@media (prefers-reduced-motion:reduce){.iFWS7G_wide,.iFWS7G_fading>*,.iFWS7G_railIn .iFWS7G_iconButton,.iFWS7G_railIn .iFWS7G_newSession,.iFWS7G_railIn .iFWS7G_footArea,.iFWS7G_railIn .iFWS7G_regionArea{transition:none;animation:none}}";
- 		const tagId = "@deepseek-ai/dsh-client-ui-sidebar/SidebarRoot.module.css";
- 		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId) + "]") === null) {
+@@ -29,7 +29,7 @@ window.__ModuleLoader__.load({
  			const tag = document.createElement("style");
  			tag.dataset.plugin = "@deepseek-ai/dsh-client-ui-sidebar";
  			tag.dataset.pluginCss = tagId;
 -			tag.textContent = css;
-+			tag.textContent = css + ".iFWS7G_root:not(.iFWS7G_collapsed){padding-top:32px}" + (navigator.userAgent.includes("Macintosh") ? ".iFWS7G_root.iFWS7G_collapsed{padding:46px 22px 6px}" : "");
++			tag.textContent = css + "[data-dsh-sidebar-root][data-dsh-sidebar-wide=\"true\"]{padding-top:32px}" + (navigator.userAgent.includes("Macintosh") ? "[data-dsh-sidebar-root][data-dsh-sidebar-wide=\"false\"]{padding:46px 22px 6px}" : "");
  			document.head.appendChild(tag);
  		}
  		var SidebarRoot_module_css_default = {
-@@ -63,6 +63,51 @@ window.__ModuleLoader__.load({
- 			"wide-in": "iFWS7G_wide-in"
- 		};
- 		//#endregion
-+		//#region lib/types/client/DshDesktopLogo.js
-+		const DSH_DESKTOP_LIGHT_LOGO_URL = "/dsh-desktop-logo-light.png";
-+		const DSH_DESKTOP_DARK_LOGO_URL = "/dsh-desktop-logo-dark.png";
-+		function DshDesktopLogo({ height = 18, className }) {
-+			return (0, react_jsx_runtime.jsxs)("svg", {
-+				width: height * 1030 / 590,
-+				height,
-+				className,
-+				viewBox: "150 330 1030 590",
-+				fill: "none",
-+				"aria-hidden": "true",
-+				children: [(0, react_jsx_runtime.jsx)("style", {
-+					children: ".dshDesktopLogoDark{display:none}body[data-ds-dark-theme] .dshDesktopLogoLight{display:none}body[data-ds-dark-theme] .dshDesktopLogoDark{display:block}"
-+				}), (0, react_jsx_runtime.jsx)("image", {
-+					className: "dshDesktopLogoLight",
-+					href: DSH_DESKTOP_LIGHT_LOGO_URL,
-+					x: 150,
-+					y: 330,
-+					width: 1030,
-+					height: 590,
-+					preserveAspectRatio: "xMidYMid meet"
-+				}), (0, react_jsx_runtime.jsx)("image", {
-+					className: "dshDesktopLogoDark",
-+					href: DSH_DESKTOP_DARK_LOGO_URL,
-+					x: 150,
-+					y: 330,
-+					width: 1030,
-+					height: 590,
-+					preserveAspectRatio: "xMidYMid meet"
-+				})]
-+			});
-+		}
-+		function DshDesktopBrand() {
-+			return (0, react_jsx_runtime.jsxs)("span", {
-+				className: SidebarRoot_module_css_default.brandLockup,
-+				children: [(0, react_jsx_runtime.jsx)("span", {
-+					className: SidebarRoot_module_css_default.brandMark,
-+					children: (0, react_jsx_runtime.jsx)(DshDesktopLogo, {})
-+				}), (0, react_jsx_runtime.jsx)("span", {
-+					className: SidebarRoot_module_css_default.brandWordmark,
-+					children: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.BrandWordmark, {})
-+				})]
-+			});
-+		}
-+		//#endregion
- 		//#region lib/types/client/SidebarRoot.js
- 		/**
- 		* Sidebar shell: column geometry only. Collapse is a slide plus crossfade:
-@@ -150,6 +195,8 @@ window.__ModuleLoader__.load({
+@@ -150,6 +150,8 @@ window.__ModuleLoader__.load({
  			const buildVersion = localBuildVersion();
  			return (0, react_jsx_runtime.jsxs)("div", {
  				ref: column,
@@ -79,62 +20,3 @@ index 696591c..332e42c 100644
  				className: clsx(SidebarRoot_module_css_default.root, !wide && SidebarRoot_module_css_default.collapsed, !wide && everWide.current && SidebarRoot_module_css_default.railIn, collapsed && wide && SidebarRoot_module_css_default.fading, !pointerInside && SidebarRoot_module_css_default.quietBars),
  				style: wide ? { width: collapsed ? lastWideWidth.current : width } : void 0,
  				onPointerEnter: () => {
-@@ -169,29 +216,7 @@ window.__ModuleLoader__.load({
- 							onClick: () => {
- 								startSession();
- 							},
--							children: (0, react_jsx_runtime.jsxs)("span", {
--								className: SidebarRoot_module_css_default.brandIdentity,
--								"aria-hidden": "true",
--								children: [(0, react_jsx_runtime.jsx)("span", {
--									className: SidebarRoot_module_css_default.brandMark,
--									children: renderSlot("sidebar.brand.mark", { size: 24 }, { fallback: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.FishLogo, { size: 24 }) })
--								}), (0, react_jsx_runtime.jsx)("span", {
--									className: SidebarRoot_module_css_default.brandName,
--									children: renderSlot("sidebar.brand.name", {}, { fallback: buildVersion === void 0 ? (0, react_jsx_runtime.jsx)("span", {
--										className: SidebarRoot_module_css_default.fallbackBrandName,
--										children: t("brand.localBuild")
--									}) : (0, react_jsx_runtime.jsxs)("span", {
--										className: SidebarRoot_module_css_default.localBuildBrand,
--										children: [(0, react_jsx_runtime.jsx)("span", {
--											className: SidebarRoot_module_css_default.localBuildTitle,
--											children: t("brand.localBuild")
--										}), (0, react_jsx_runtime.jsx)("span", {
--											className: SidebarRoot_module_css_default.buildVersion,
--											children: buildVersion
--										})]
--									}) })
--								})]
--							})
-+							children: (0, react_jsx_runtime.jsx)(DshDesktopBrand, {})
- 						}), (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Tooltip, {
- 							label: collapsed ? t("toggle.open") : t("toggle.collapse"),
- 							delayMs: 500,
-@@ -202,10 +227,9 @@ window.__ModuleLoader__.load({
- 								onClick: () => {
- 									toggleSidebar();
- 								},
--								children: [!wide && (0, react_jsx_runtime.jsx)("span", {
--									className: SidebarRoot_module_css_default.railMark,
--									"aria-hidden": "true",
--									children: renderSlot("sidebar.brand.mark", { size: 24 }, { fallback: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.FishLogo, { size: 24 }) })
-+								children: [!wide && (0, react_jsx_runtime.jsx)(DshDesktopLogo, {
-+									className: SidebarRoot_module_css_default.railFish,
-+									height: 17
- 								}), (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconPanelLeftOutline16, {
- 									className: SidebarRoot_module_css_default.panelIcon,
- 									size: wide ? 16 : 18
-@@ -240,11 +264,13 @@ window.__ModuleLoader__.load({
- 						})
- 					}),
- 					(0, react_jsx_runtime.jsxs)("div", {
-+						"data-dsh-sidebar-footer": "",
- 						className: SidebarRoot_module_css_default.footArea,
- 						children: [(0, react_jsx_runtime.jsx)("div", {
- 							className: SidebarRoot_module_css_default.footerActions,
- 							children: renderSlot("sidebar.footer.action", { wide })
- 						}), (0, react_jsx_runtime.jsx)("div", {
-+							"data-dsh-sidebar-settings": "",
- 							className: SidebarRoot_module_css_default.settingsArea,
- 							children: renderSlot("sidebar.settings", { wide })
- 						})]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import type { UpdateStatus } from '../shared/contracts'
 import {
   isUpdateDismissed,
@@ -11,7 +11,6 @@ import { findBootFailureText } from './boot-failure'
 import { mountWindowsTitlebarLayout } from './windows-titlebar'
 
 const ROOT_ID = 'dsh-desktop-update-root'
-const MOBILE_BUTTON_ID = 'dsh-desktop-mobile-button'
 const SAFE_MODE_BANNER_ID = 'dsh-desktop-safe-mode-banner'
 const locale: UpdateLocale = navigator.language.toLowerCase().startsWith('zh') ? 'zh' : 'en'
 
@@ -23,10 +22,7 @@ let dismissedTransientPhase: UpdateStatus['phase'] | null = null
 let installing = false
 let accepting = false
 let receivedStatusEvent = false
-let phoneConnected = false
-let sidebarSettingsArea: HTMLElement | undefined
 let sidebarRoot: HTMLElement | undefined
-let mobileButton: HTMLButtonElement | undefined
 let domSyncScheduled = false
 let bootScanSettled = false
 let bootFailureTriggered = false
@@ -95,12 +91,12 @@ function scheduleDomSync(): void {
 
 function runDomSync(): void {
   domSyncScheduled = false
-  mountMobileButton()
   if (bootScanSettled) return
   // The boot screen only exists until Harness renders its own UI, and the
   // sidebar appearing is that moment. Past it the selector can never match
   // again, so scanning on would walk the conversation tree every frame for a
   // guaranteed miss. The window error handlers stay as the real backstop.
+  sidebarRoot = liveElement(sidebarRoot, '[data-dsh-sidebar-root]')
   if (sidebarRoot?.isConnected) bootScanSettled = true
   else checkBootFailureInDom()
 }
@@ -117,58 +113,6 @@ contextBridge.exposeInMainWorld('dshDesktopDirectoryPicker', {
 function liveElement<T extends Element>(cached: T | undefined, selector: string): T | undefined {
   if (cached?.isConnected) return cached
   return document.querySelector<T>(selector) ?? undefined
-}
-
-function mountMobileButton(): void {
-  if (!document.getElementById(`${MOBILE_BUTTON_ID}-style`)) {
-    const style = document.createElement('style')
-    style.id = `${MOBILE_BUTTON_ID}-style`
-    style.textContent = mobileButtonStyles
-    document.head.appendChild(style)
-  }
-  sidebarSettingsArea = liveElement(sidebarSettingsArea, '[data-dsh-sidebar-settings]')
-  const settingsArea = sidebarSettingsArea
-  if (!settingsArea) return
-  if (!mobileButton?.isConnected) {
-    mobileButton =
-      (document.getElementById(MOBILE_BUTTON_ID) as HTMLButtonElement | null) ?? undefined
-  }
-  if (!mobileButton) {
-    const created = document.createElement('button')
-    created.id = MOBILE_BUTTON_ID
-    created.type = 'button'
-    created.innerHTML = `${phoneIcon}<span aria-hidden="true"></span>`
-    created.addEventListener('click', () => {
-      void ipcRenderer.invoke('mobile:open-pairing').catch((error: unknown) => {
-        console.error('[mobile] unable to open pairing window', error)
-      })
-    })
-    mobileButton = created
-  }
-  if (mobileButton.parentElement !== settingsArea) settingsArea.appendChild(mobileButton)
-  renderMobileButton()
-}
-
-function renderMobileButton(): void {
-  const button = mobileButton
-  sidebarRoot = liveElement(sidebarRoot, '[data-dsh-sidebar-root]')
-  const root = sidebarRoot
-  if (!button || !root) return
-  const wide = root.dataset.dshSidebarWide === 'true'
-  const hidden = !wide && !phoneConnected
-  const label = phoneConnected
-    ? locale === 'zh' ? '管理手机连接' : 'Manage phone connection'
-    : locale === 'zh' ? '连接手机' : 'Connect phone'
-  // Writing an attribute invalidates style even when the value is unchanged, so
-  // every skipped write here is a skipped style recalculation each frame.
-  if (button.hidden !== hidden) button.hidden = hidden
-  if (button.classList.contains('is-connected') !== phoneConnected) {
-    button.classList.toggle('is-connected', phoneConnected)
-  }
-  if (button.title !== label) {
-    button.setAttribute('aria-label', label)
-    button.title = label
-  }
 }
 
 async function mountSafeModeBanner(): Promise<void> {
@@ -249,43 +193,16 @@ async function mountSafeModeBanner(): Promise<void> {
   }
 }
 
-function applyMobileStatus(connected: boolean): void {
-  if (phoneConnected === connected) return
-  phoneConnected = connected
-  mountMobileButton()
-}
-
-/**
- * Read once at startup. Afterwards the main process pushes every change, so
- * there is no timer here: `connected` only moves when a phone pairs or drops,
- * and polling it woke both renderers once a second for a value that is almost
- * always the same.
- */
-async function refreshMobileStatus(): Promise<void> {
-  try {
-    const status = (await ipcRenderer.invoke('mobile:status')) as { connected?: boolean }
-    applyMobileStatus(status.connected === true)
-  } catch (error) {
-    console.warn('[mobile] unable to read connection status', error)
-  }
-}
-
-ipcRenderer.on('mobile:status-changed', (_event, status: { connected?: boolean }) => {
-  applyMobileStatus(status?.connected === true)
-})
-
 function initializeUi(): void {
   if (process.platform === 'win32') {
     mountWindowsTitlebarLayout({ document, ipcRenderer })
   }
   mount()
-  mountMobileButton()
   checkBootFailureInDom()
   domObserver.observe(document.documentElement, {
     childList: true,
     subtree: true
   })
-  void refreshMobileStatus()
   void mountSafeModeBanner()
 }
 
@@ -308,7 +225,16 @@ window.addEventListener('unhandledrejection', (event) => {
 contextBridge.exposeInMainWorld(
   'dshDesktop',
   Object.freeze({
-    restartHarness: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('harness:restart')
+    restartHarness: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('harness:restart'),
+    openMobilePairing: (): Promise<void> => ipcRenderer.invoke('mobile:open-pairing'),
+    getMobileStatus: (): Promise<{ connected: boolean }> => ipcRenderer.invoke('mobile:status'),
+    onMobileStatusChanged: (listener: (connected: boolean) => void): (() => void) => {
+      const handler = (_event: IpcRendererEvent, status: { connected?: boolean }): void => {
+        listener(status?.connected === true)
+      }
+      ipcRenderer.on('mobile:status-changed', handler)
+      return () => ipcRenderer.removeListener('mobile:status-changed', handler)
+    }
   })
 )
 
@@ -646,22 +572,6 @@ const styles = `
 `
 
 const updateIcon = `<svg viewBox="0 0 24 24" width="18" height="18" fill="none" aria-hidden="true"><path d="M4.6 12a7.4 7.4 0 0 1 12.6-5.2" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/><path d="M19.4 12a7.4 7.4 0 0 1-12.6 5.2" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/><path d="M17.6 3.5v3.4h-3.4M6.4 20.5v-3.4h3.4" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/></svg>`
-
-const phoneIcon = `<svg viewBox="0 0 24 24" width="19" height="19" fill="none" aria-hidden="true"><rect x="7" y="2.75" width="10" height="18.5" rx="2.25" stroke="currentColor" stroke-width="1.7"/><path d="M10.2 5.5h3.6M10.5 18.35h3" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>`
-
-const mobileButtonStyles = `
-  [data-dsh-sidebar-settings] { position:relative; box-sizing:border-box; }
-  [data-dsh-sidebar-root][data-dsh-sidebar-wide="true"] [data-dsh-sidebar-settings] { padding-right:38px; }
-  #${MOBILE_BUTTON_ID} { appearance:none; position:relative; width:32px; height:32px; color:var(--dsw-alias-label-secondary,#73777f); background:transparent; border:0; border-radius:9px; display:inline-flex; align-items:center; justify-content:center; cursor:pointer; }
-  [data-dsh-sidebar-root][data-dsh-sidebar-wide="true"] #${MOBILE_BUTTON_ID} { position:absolute; right:0; top:50%; transform:translateY(-50%); }
-  [data-dsh-sidebar-root][data-dsh-sidebar-wide="false"] [data-dsh-sidebar-settings] { flex-direction:column; align-items:center; }
-  [data-dsh-sidebar-root][data-dsh-sidebar-wide="false"] #${MOBILE_BUTTON_ID} { flex:none; margin-top:5px; }
-  #${MOBILE_BUTTON_ID}:hover { color:var(--dsw-alias-label-primary,#202124); background:var(--dsw-alias-interactive-bg-hover,rgba(32,33,36,.08)); }
-  #${MOBILE_BUTTON_ID}:focus-visible { outline:2px solid #4d6bfe; outline-offset:1px; }
-  #${MOBILE_BUTTON_ID}[hidden] { display:none; }
-  #${MOBILE_BUTTON_ID} > span { position:absolute; top:4px; right:4px; width:7px; height:7px; border:1.5px solid var(--dsw-specific-sidebar-fill,#fff); border-radius:50%; background:#4da66d; opacity:0; }
-  #${MOBILE_BUTTON_ID}.is-connected > span { opacity:1; }
-`
 
 ipcRenderer.on('updates:status-changed', (_event, status: UpdateStatus) => {
   receivedStatusEvent = true

--- a/test/branding-patch.test.ts
+++ b/test/branding-patch.test.ts
@@ -24,30 +24,47 @@ describe('DSH Desktop sidebar branding', () => {
     expect(main).toContain("height: '24px'")
   })
 
-  it('pairs the DSH logo with the original Harness wordmark in the expanded sidebar', async () => {
-    const patch = await readFile(
-      patchPath('@deepseek-ai/dsh-client-ui-sidebar'),
-      'utf8'
+  it('fills the stock brand slots instead of replacing Sidebar structure', async () => {
+    const [patch, client, composition, installedSidebar] = await Promise.all([
+      readFile(patchPath('@deepseek-ai/dsh-client-ui-sidebar'), 'utf8'),
+      readFile(path.join(projectRoot, 'packages', 'dsh-desktop-client-ui', 'client.js'), 'utf8'),
+      readFile(path.join(projectRoot, 'build', 'dsh-desktop.patch.yml'), 'utf8'),
+      readFile(
+        path.join(
+          projectRoot,
+          'node_modules',
+          '@deepseek-ai',
+          'dsh-client-ui-sidebar',
+          'lib',
+          'client.js'
+        ),
+        'utf8'
+      )
+    ])
+
+    expect(client).toContain("ctx.slots.inject('sidebar.brand.mark'")
+    expect(client).toContain("ctx.slots.inject('sidebar.brand.name'")
+    expect(client).toContain("ctx.slots.inject('conversation.hero.brand.mark'")
+    expect(client).toContain("React.createElement(BrandWordmark, { includeMark: false })")
+    expect(client).toContain('/dsh-desktop-logo-light.png')
+    expect(client).toContain('/dsh-desktop-logo-dark.png')
+    expect(client).not.toContain('translateX')
+    expect(composition).toMatch(/- id: ui-brand-official\n  disabled: true/u)
+    expect(composition).toMatch(
+      /- id: dsh-desktop-client-ui\n      name: dsh-desktop-client-ui/u
     )
 
-    expect(patch).toContain('DshDesktopLogo')
-    expect(patch).toContain('DshDesktopBrand')
-    expect(patch).toContain('BrandWordmark')
-    expect(patch).toContain('/dsh-desktop-logo-light.png')
-    expect(patch).toContain('/dsh-desktop-logo-dark.png')
-    expect(patch).toContain('brandWordmark')
-    expect(patch).toContain('gap:4px')
-    expect(patch).toContain('transform:translateX(-24px)')
-    expect(patch).not.toContain('children: "DSH Desktop"')
-    expect(patch).toContain('height = 18')
-    expect(patch).toContain('brandMark{width:27px;height:23.4px')
-    expect(patch).toMatch(/railFish,[\s\S]{0,80}height: 17/)
-    expect(patch).toContain('.iFWS7G_brand:hover')
+    expect(patch).not.toContain('DshDesktopLogo')
+    expect(patch).not.toContain('DshDesktopBrand')
+    expect(patch).not.toContain('brandWordmark')
+    expect(patch).toContain('[data-dsh-sidebar-root]')
     expect(patch).toContain('padding-top:32px')
     expect(patch).toContain('navigator.userAgent.includes("Macintosh")')
-    expect(patch).toContain('.iFWS7G_root.iFWS7G_collapsed{padding:46px 22px 6px}')
-    expect(patch).toContain('body[data-ds-dark-theme] .dshDesktopLogoLight')
-    expect(patch).toContain('body[data-ds-dark-theme] .dshDesktopLogoDark')
+    expect(patch).toContain('padding:46px 22px 6px')
+    expect(installedSidebar).toContain('renderSlot("sidebar.brand.mark"')
+    expect(installedSidebar).toContain('renderSlot("sidebar.brand.name"')
+    expect(installedSidebar).not.toContain('DshDesktopBrand')
+    expect(installedSidebar).not.toContain('brandWordmark')
   })
 
   it('uses an 80px macOS rail that clears the traffic lights', async () => {
@@ -60,24 +77,26 @@ describe('DSH Desktop sidebar branding', () => {
     expect(patch).toContain('sidebar === 0 ? COLLAPSED_SIDEBAR_WIDTH')
   })
 
-  it('provides a sidebar phone entry that follows expanded and connected state', async () => {
-    const patch = await readFile(
-      patchPath('@deepseek-ai/dsh-client-ui-sidebar'),
-      'utf8'
-    )
-    const preload = await readFile(path.join(projectRoot, 'src', 'preload', 'index.ts'), 'utf8')
-    const main = await readFile(path.join(projectRoot, 'src', 'main', 'index.ts'), 'utf8')
+  it('provides the phone entry through the public footer slot and a narrow bridge', async () => {
+    const [patch, preload, main, client] = await Promise.all([
+      readFile(patchPath('@deepseek-ai/dsh-client-ui-sidebar'), 'utf8'),
+      readFile(path.join(projectRoot, 'src', 'preload', 'index.ts'), 'utf8'),
+      readFile(path.join(projectRoot, 'src', 'main', 'index.ts'), 'utf8'),
+      readFile(path.join(projectRoot, 'packages', 'dsh-desktop-client-ui', 'client.js'), 'utf8')
+    ])
 
     expect(patch).toContain('data-dsh-sidebar-root')
     expect(patch).toContain('data-dsh-sidebar-wide')
-    expect(patch).toContain('data-dsh-sidebar-footer')
-    expect(patch).toContain('data-dsh-sidebar-settings')
-    expect(preload).toContain("liveElement(sidebarSettingsArea, '[data-dsh-sidebar-settings]')")
-    expect(preload).toContain('settingsArea.appendChild(mobileButton)')
-    expect(preload).not.toContain('footer.appendChild(button)')
-    expect(preload).toContain('const hidden = !wide && !phoneConnected')
-    expect(preload).toContain("button.classList.toggle('is-connected', phoneConnected)")
-    expect(preload).toContain("ipcRenderer.invoke('mobile:open-pairing')")
+    expect(patch).not.toContain('data-dsh-sidebar-footer')
+    expect(patch).not.toContain('data-dsh-sidebar-settings')
+    expect(client).toContain("ctx.slots.inject('sidebar.footer.action'")
+    expect(client).toContain("id: 'dsh-desktop-mobile'")
+    expect(client).toContain('order: 20')
+    expect(client).toContain('if (!wide && !connected) return null')
+    expect(preload).toContain('openMobilePairing: (): Promise<void>')
+    expect(preload).toContain('getMobileStatus: (): Promise<{ connected: boolean }>')
+    expect(preload).toContain('onMobileStatusChanged: (listener: (connected: boolean) => void)')
+    expect(preload).not.toContain('settingsArea.appendChild')
     expect(main).toContain("ipcMain.handle('mobile:open-pairing'")
     expect(main).toContain("ipcMain.handle('mobile:status'")
   })

--- a/test/desktop-client-ui.test.ts
+++ b/test/desktop-client-ui.test.ts
@@ -1,0 +1,132 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import vm from 'node:vm'
+import { describe, expect, it, vi } from 'vitest'
+
+const projectRoot = path.resolve(import.meta.dirname, '..')
+
+interface Registration {
+  config: { name: string; id?: string; order?: number }
+  component: (props: Record<string, unknown>) => unknown
+}
+
+describe('DSH Desktop client slot occupants', () => {
+  it('registers one occupant per brand seat and keeps the official name mark-free', async () => {
+    const source = await readFile(
+      path.join(projectRoot, 'packages', 'dsh-desktop-client-ui', 'client.js'),
+      'utf8'
+    )
+    let definition: {
+      factory: (require: (id: string) => unknown) => {
+        apply: (ctx: unknown) => void
+        inject: string[]
+      }
+    } | undefined
+    const appended: Array<{ textContent?: string }> = []
+    const document = {
+      getElementById: vi.fn(() => null),
+      createElement: vi.fn(() => ({ id: '', dataset: {}, textContent: '' })),
+      head: { appendChild: (node: { textContent?: string }) => appended.push(node) }
+    }
+    vm.runInNewContext(source, {
+      document,
+      navigator: { language: 'en-US' },
+      window: {
+        __ModuleLoader__: {
+          load: (value: typeof definition) => {
+            definition = value
+          }
+        }
+      }
+    })
+
+    expect(definition).toBeDefined()
+    const createElement = (
+      type: unknown,
+      props: Record<string, unknown> | null,
+      ...children: unknown[]
+    ): { type: unknown; props: Record<string, unknown> } => ({
+      type,
+      props: { ...props, children }
+    })
+    const BrandWordmark = vi.fn()
+    const FishLogo = vi.fn()
+    const plugin = definition!.factory((id) => {
+      if (id === 'react') {
+        return {
+          createElement,
+          useEffect: (effect: () => void | (() => void)) => effect(),
+          useState: (initial: unknown) => [initial, vi.fn()]
+        }
+      }
+      if (id === '@deepseek-ai/dsh-client-ui-primitives') {
+        return { BrandWordmark, FishLogo }
+      }
+      throw new Error(`Unexpected client dependency: ${id}`)
+    })
+
+    const registrations: Registration[] = []
+    const slots = {
+      inject: (_name: string, callback: () => unknown): unknown => {
+        const result = callback()
+        if (result && typeof result === 'object' && Symbol.iterator in result) {
+          for (const _entry of result as Iterable<unknown>) void _entry
+        }
+        return result
+      },
+      register: (
+        config: Registration['config'],
+        component: Registration['component']
+      ): (() => void) => {
+        if (config.name === 'sidebar.footer.action' && config.id === undefined) {
+          throw new Error('list slots require an id')
+        }
+        registrations.push({ config, component })
+        return () => undefined
+      }
+    }
+    plugin.apply({ slots })
+
+    expect(plugin.inject).toEqual(['slots'])
+    expect(registrations.map(({ config }) => config.name)).toEqual([
+      'sidebar.brand.mark',
+      'sidebar.brand.name',
+      'conversation.hero.brand.mark',
+      'sidebar.footer.action'
+    ])
+    expect(registrations.at(-1)?.config).toMatchObject({
+      id: 'dsh-desktop-mobile',
+      order: 20
+    })
+    expect(appended).toHaveLength(1)
+
+    const sidebarName = registrations.find(
+      ({ config }) => config.name === 'sidebar.brand.name'
+    )!.component({}) as { type: unknown; props: Record<string, unknown> }
+    expect(sidebarName.type).toBe(BrandWordmark)
+    expect(sidebarName.props.includeMark).toBe(false)
+
+    const sidebarMark = registrations.find(
+      ({ config }) => config.name === 'sidebar.brand.mark'
+    )!.component({ size: 24 }) as { type: unknown; props: Record<string, unknown> }
+    expect(sidebarMark.type).toBe('svg')
+    expect(sidebarMark.props.height).toBe(17)
+
+    const heroMark = registrations.find(
+      ({ config }) => config.name === 'conversation.hero.brand.mark'
+    )!.component({ size: 48 }) as { type: unknown; props: Record<string, unknown> }
+    expect(heroMark.type).toBe(FishLogo)
+    expect(heroMark.props.size).toBe(48)
+
+    const phone = registrations.find(
+      ({ config }) => config.name === 'sidebar.footer.action'
+    )!.component
+    expect(phone({ wide: false })).toBeNull()
+    const widePhone = phone({ wide: true }) as {
+      type: unknown
+      props: Record<string, unknown>
+    }
+    expect(widePhone.type).toBe('button')
+    expect(widePhone.props['aria-label']).toBe('Connect phone')
+  })
+})

--- a/test/desktop-plugin-closure.test.ts
+++ b/test/desktop-plugin-closure.test.ts
@@ -21,10 +21,10 @@ describe('desktop plugin closure', () => {
   it('injects every profile-mounted desktop plugin into the dsh dependency closure', async () => {
     const profilePatch = parseYaml(
       await readFile(path.join(projectRoot, 'build', 'dsh-desktop.patch.yml'), 'utf8')
-    ) as { insert?: { name?: string }[] }[]
+    ) as { name?: string; insert?: { name?: string }[] }[]
 
     const mounted = profilePatch
-      .flatMap((row) => row.insert ?? [])
+      .flatMap((row) => [...(row.insert ?? []), row])
       .map((entry) => entry.name)
       .filter((name): name is string => typeof name === 'string' && name.startsWith('dsh-desktop-'))
 
@@ -39,13 +39,13 @@ describe('desktop plugin closure', () => {
   it('declares every profile-mounted desktop plugin as a production dependency', async () => {
     const profilePatch = parseYaml(
       await readFile(path.join(projectRoot, 'build', 'dsh-desktop.patch.yml'), 'utf8')
-    ) as { insert?: { name?: string }[] }[]
+    ) as { name?: string; insert?: { name?: string }[] }[]
 
     const manifest = JSON.parse(
       await readFile(path.join(projectRoot, 'package.json'), 'utf8')
     ) as { dependencies: Record<string, string> }
 
-    for (const row of profilePatch.flatMap((entry) => entry.insert ?? [])) {
+    for (const row of profilePatch.flatMap((entry) => [...(entry.insert ?? []), entry])) {
       if (typeof row.name !== 'string' || !row.name.startsWith('dsh-desktop-')) continue
       expect(manifest.dependencies[row.name]).toBe(`file:packages/${row.name}`)
     }


### PR DESCRIPTION
## 背景

这是基于 #219 的 stacked PR。

升级 Harness 0.1.2-alpha.1 后，Sidebar 补丁仍引用旧 CSS Module 映射，但新 bundle 已不再导出这些类名；同时 BrandWordmark 默认包含图标，导致顶部品牌组合错位、重复。

## 修改

- 新增 dsh-desktop-client-ui 插件，使用公开 slot 接管：
  - sidebar.brand.mark
  - sidebar.brand.name（显式 includeMark: false）
  - conversation.hero.brand.mark
  - sidebar.footer.action（手机连接入口）
- 禁用上游 ui-brand-official，避免 single slot 冲突。
- Sidebar patch 缩减为稳定 data 属性和 macOS traffic lights 顶部留白，不再改写品牌组件或 CSS Module 结构。
- preload 删除 MutationObserver 驱动的手机按钮 DOM 注入，仅暴露受控 IPC bridge。
- 保留宿主职责：macOS 无边框窗口、traffic lights、拖动区和折叠栏 80px 仍由 Electron/layout 控制。
- 测试实际执行 client bundle 并校验 slot 注册；list slot 的稳定 id 也纳入合约检查。

## 验证

通过：

- npm ci（全部 patch-package 补丁成功应用）
- npm test -- --run test/desktop-client-ui.test.ts test/branding-patch.test.ts test/desktop-plugin-closure.test.ts（3 files / 8 tests）
- npm run typecheck
- npm run build
- 使用 Desktop patch 组合实际启动 dsh web，未出现 single-slot 冲突

全量测试中 61 个文件、454 个断言均通过，但命令仍退出 1：test/lan-mobile-tunnel.test.ts 在 teardown 时触发 “WebSocket was closed before the connection was established”。在未修改的 #219 分支单独运行该测试也得到相同结果（20 tests passed + 同一 unhandled error），确认是升级分支已有基线问题，不在本 PR 扩大修复范围。
