### PR TITLE
fix(windows): allow OS shutdown and logoff to close the app while close-to-tray is active

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import {
   ipcMain,
   Menu,
   nativeTheme,
+  powerMonitor,
   shell,
   Tray,
   utilityProcess,
@@ -736,6 +737,18 @@ function ensureTray(): void {
     ])
   )
   tray.on('click', restoreMainWindow)
+}
+
+function installOsShutdownQuitGuard(): void {
+  // While close-to-tray is active the window 'close' handler keeps calling
+  // preventDefault (see shouldKeepRunningInBackground). During a real OS
+  // shutdown or logoff that would make Windows show the "app is preventing
+  // shutdown" screen or force-kill the app after a timeout. Electron emits
+  // powerMonitor 'shutdown' before session end, so flip the existing quitting
+  // flag there and let the close proceed through the normal lifecycle.
+  powerMonitor.on('shutdown', () => {
+    quitting = true
+  })
 }
 
 function createWindow(): BrowserWindow {
@@ -1747,6 +1760,7 @@ async function bootstrap(): Promise<void> {
   registerUpdateHandlers()
   nativeTheme.themeSource = harnessThemePreference()
   ensureTray()
+  installOsShutdownQuitGuard()
   createWindow()
   runtime = new HarnessRuntime({
     dshEntryPath: dshEntryPath(),


### PR DESCRIPTION
## Summary
- set the internal quitting flag when the OS reports an imminent shutdown or logoff (`powerMonitor` `'shutdown'` event)
- without it, the window close handler introduced in #203 keeps calling `preventDefault` during session end, which can make Windows show the "app is preventing shutdown" screen or force-kill the app after a timeout

## Details
The guard only flips the existing `quitting` flag, so explicit tray exit, updater installs, and all other `app.quit()` flows are unchanged. macOS and Linux behavior is untouched (close-to-tray is Windows-only).

## Validation
- `npm run typecheck`
- `npm test -- --run test/close-to-tray.test.ts`
- not runtime-verified against a real Windows shutdown/logoff cycle; the guard follows the documented Electron `powerMonitor` `'shutdown'` pattern