### PR TITLE
fix(market): repair install and uninstall lifecycle

### DIFF
--- a/packages/dsh-desktop-market-installer/client.js
+++ b/packages/dsh-desktop-market-installer/client.js
@@ -270,6 +270,11 @@ window.__ModuleLoader__.load({
         setError(undefined)
         setStatus((current) => ({ ...current, phase: 'uninstalling' }))
         try {
+          const bridge = globalThis.dshDesktop
+          if (bridge && typeof bridge.uninstallMarket === 'function') {
+            await bridge.uninstallMarket()
+            return
+          }
           const response = await fetch(UNINSTALL_PATH, {
             method: 'POST',
             credentials: 'same-origin',

--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -549,13 +549,30 @@ export function buildInstallArguments(dshEntry = resolveDshEntry()) {
     'plugin',
     '--profile',
     MARKET_PROFILE,
-    'add',
-    `${MARKET_PACKAGE}@${RECOMMENDED_MARKET_VERSION}`
+    ...buildMarketInstallArguments()
   ]
 }
 
 export function buildUninstallArguments(dshEntry = resolveDshEntry()) {
-  return [dshEntry, 'plugin', '--profile', MARKET_PROFILE, 'remove', MARKET_PACKAGE]
+  return [
+    dshEntry,
+    'plugin',
+    '--profile',
+    MARKET_PROFILE,
+    ...buildMarketUninstallArguments()
+  ]
+}
+
+function buildMarketInstallArguments() {
+  return [
+    'add',
+    '--workspace-root',
+    `${MARKET_PACKAGE}@${RECOMMENDED_MARKET_VERSION}`
+  ]
+}
+
+function buildMarketUninstallArguments() {
+  return ['remove', '--workspace-root', MARKET_PACKAGE]
 }
 
 async function atomicWrite(path, contents) {
@@ -702,10 +719,7 @@ export async function apply(ctx) {
     }
 
     try {
-      await runProfileCommand(
-        ['add', `${MARKET_PACKAGE}@${RECOMMENDED_MARKET_VERSION}`],
-        'Installation'
-      )
+      await runProfileCommand(buildMarketInstallArguments(), 'Installation')
 
       const installed = await readMarketInstallation(home)
       if (!installed.installedVersion) {
@@ -748,7 +762,7 @@ export async function apply(ctx) {
     }
 
     try {
-      await runProfileCommand(['remove', MARKET_PACKAGE], 'Uninstallation')
+      await runProfileCommand(buildMarketUninstallArguments(), 'Uninstallation')
 
       const removed = await readMarketInstallation(home)
       if (removed.dependency || removed.installedVersion) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1121,6 +1121,28 @@ function restartHarness(): Promise<void> {
   return launchHarness()
 }
 
+async function uninstallMarketAndRestart(): Promise<{ ok: boolean }> {
+  const dshHome = join(app.getPath('userData'), 'harness')
+  await showSplash()
+  await runtime.stop()
+  const result = await removeProfilePluginWithDsh(
+    {
+      dshHome,
+      dshEntryPath: dshEntryPath(),
+      nodeExecutablePath: bundledNodePath(),
+      pnpmEntryPath: bundledPnpmEntryPath(),
+      pnpmRunnerPath: bundledPnpmRunnerPath()
+    },
+    'dshmarket',
+    true
+  )
+  await launchHarness()
+  if (!result.ok) {
+    throw new Error(result.detail ?? 'Plugin market removal failed.')
+  }
+  return { ok: runtime.snapshot().phase === 'ready' }
+}
+
 function registerHarnessHandlers(): void {
   ipcMain.removeHandler('harness:restart')
   ipcMain.handle('harness:restart', async (event) => {
@@ -1133,6 +1155,15 @@ function registerHarnessHandlers(): void {
 
     await restartHarness()
     return { ok: runtime.snapshot().phase === 'ready' }
+  })
+
+  ipcMain.removeHandler('market:uninstall')
+  ipcMain.handle('market:uninstall', async (event) => {
+    assertTrustedMainWindowEvent(event)
+    if (runtime.snapshot().phase !== 'ready') {
+      throw new Error('Harness is not ready to uninstall the plugin market.')
+    }
+    return uninstallMarketAndRestart()
   })
 
   ipcMain.removeHandler('desktop-menu:execute')

--- a/src/main/runtime/profile-plugin-command.ts
+++ b/src/main/runtime/profile-plugin-command.ts
@@ -57,9 +57,18 @@ function shellQuote(value: string): string {
 
 export function buildProfilePluginRemoveArguments(
   dshEntryPath: string,
-  pluginName: string
+  pluginName: string,
+  workspaceRoot = false
 ): string[] {
-  return [dshEntryPath, 'plugin', '--profile', PROFILE, 'remove', pluginName]
+  return [
+    dshEntryPath,
+    'plugin',
+    '--profile',
+    PROFILE,
+    'remove',
+    ...(workspaceRoot ? ['--workspace-root'] : []),
+    pluginName
+  ]
 }
 
 /**
@@ -253,9 +262,15 @@ function killProcessTree(child: ReturnType<typeof spawn>): void {
 
 export async function removeProfilePluginWithDsh(
   options: ProfilePluginCommandOptions,
-  pluginName: string
+  pluginName: string,
+  workspaceRoot = false
 ): Promise<ProfilePluginCommandResult> {
-  return runProfileCommand(options, buildProfilePluginRemoveArguments(options.dshEntryPath, pluginName), 'Plugin removal', OPERATION_TIMEOUT_MS)
+  return runProfileCommand(
+    options,
+    buildProfilePluginRemoveArguments(options.dshEntryPath, pluginName, workspaceRoot),
+    'Plugin removal',
+    OPERATION_TIMEOUT_MS
+  )
 }
 
 /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -309,6 +309,7 @@ contextBridge.exposeInMainWorld(
   'dshDesktop',
   Object.freeze({
     restartHarness: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('harness:restart'),
+    uninstallMarket: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('market:uninstall'),
     openInFinder: (path: string): Promise<{ ok: boolean }> => ipcRenderer.invoke('harness:open-in-finder', path)
   })
 )

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -31,6 +31,7 @@ describe('desktop plugin market installer', () => {
       '--profile',
       'web',
       'add',
+      '--workspace-root',
       'dshmarket@latest'
     ])
     expect(MARKET_PACKAGE).toBe('dshmarket')
@@ -44,6 +45,7 @@ describe('desktop plugin market installer', () => {
       '--profile',
       'web',
       'remove',
+      '--workspace-root',
       'dshmarket'
     ])
   })

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -362,6 +362,7 @@ describe('desktop plugin market installer', () => {
       'utf8'
     )
     const preload = await readFile(join(process.cwd(), 'src', 'preload', 'index.ts'), 'utf8')
+    const main = await readFile(join(process.cwd(), 'src', 'main', 'index.ts'), 'utf8')
 
     expect(client).toContain("entry?.id === 'dshmarket'")
     expect(client).toContain("id: 'market'")
@@ -375,5 +376,10 @@ describe('desktop plugin market installer', () => {
     expect(desktopPatch).toContain('inject: [desktopProfiles]')
     expect(desktopPatch).toContain('allowRestart: false')
     expect(preload).toContain("restartHarness: (): Promise<{ ok: boolean }>")
+    expect(preload).toContain("uninstallMarket: (): Promise<{ ok: boolean }>")
+    expect(client).toContain("typeof bridge.uninstallMarket === 'function'")
+    expect(main).toContain("ipcMain.handle('market:uninstall'")
+    expect(main).toContain("await runtime.stop()")
+    expect(main).toContain("'dshmarket',\n    true")
   })
 })

--- a/test/profile-plugin-command.test.ts
+++ b/test/profile-plugin-command.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   buildPnpmShimCommand,
+  buildProfilePluginRemoveArguments,
   diagnosticLine,
   removeProfilePluginWithDsh
 } from '../src/main/runtime/profile-plugin-command'
@@ -20,6 +21,18 @@ describe('profile-plugin-command', () => {
 
   afterEach(async () => {
     await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('can target a workspace-root package explicitly', () => {
+    expect(buildProfilePluginRemoveArguments('/app/dsh/bin.js', 'dshmarket', true)).toEqual([
+      '/app/dsh/bin.js',
+      'plugin',
+      '--profile',
+      'web',
+      'remove',
+      '--workspace-root',
+      'dshmarket'
+    ])
   })
 
   it('runs the DSH remove command with the bundled pnpm shim on PATH', async () => {


### PR DESCRIPTION
## Summary
- pass `--workspace-root` when installing or removing the core `dshmarket` package
- run market removal through an Electron main-process IPC transaction
- stop Harness before removing its loaded market package, then restart Harness automatically
- keep the Harness HTTP uninstall route as a compatibility fallback
- cover the workspace-root and Desktop IPC contracts with regression tests

## Root causes
1. The web profile contains `pnpm-workspace.yaml`, so `pnpm add dshmarket@latest` without `--workspace-root` fails with `ERR_PNPM_ADDING_TO_ROOT`.
2. The old uninstall was owned by the running Harness. After pnpm removed `dshmarket`, Harness exited and took the status endpoint with it, leaving the renderer polling forever in the uninstalling modal.

## Validation
- `npm ci`
- focused market/profile command tests (20 tests)
- `npm test -- --run` (74 files, 552 tests)
- `npm run typecheck`
- `npm run build`
- real pnpm 10.34.5 workspace reproduction succeeds with `add --workspace-root dshmarket@latest`