### PR TITLE
fix: 提升插件卸载和 Windows 启动恢复可靠性

### DIFF
--- a/build/harness-node-entry.mjs
+++ b/build/harness-node-entry.mjs
@@ -1,5 +1,7 @@
 import childProcess from 'node:child_process'
+import { syncBuiltinESMExports } from 'node:module'
 import { pathToFileURL } from 'node:url'
+import { enforceWindowsChildProcessHide } from './windows-child-process-hide.mjs'
 
 // On macOS Harness runs inside an Electron utility process (TCC responsibility
 // isolation), so `process.execPath` and `argv0` point at the Electron helper
@@ -39,72 +41,7 @@ process.stdout.write(`[harness-node] DSH_HOME=${process.env.DSH_HOME ?? ''}\n`)
 // third-party plugins alike — without needing an upstream fix in each of
 // them. A caller that explicitly sets windowsHide keeps its own choice.
 if (process.platform === 'win32') {
-  const originalSpawn = childProcess.spawn
-  const originalSpawnSync = childProcess.spawnSync
-  const originalExec = childProcess.exec
-  const originalExecSync = childProcess.execSync
-  const originalExecFile = childProcess.execFile
-  const originalExecFileSync = childProcess.execFileSync
-  const originalFork = childProcess.fork
-
-  function applyWindowsHide(options) {
-    if (options && typeof options === 'object' && options.windowsHide !== undefined) {
-      return options
-    }
-    if (options && typeof options === 'object') {
-      return { ...options, windowsHide: true }
-    }
-    return { windowsHide: true }
-  }
-
-  childProcess.spawn = function patchedSpawn(command, args, options) {
-    if (Array.isArray(args)) {
-      return originalSpawn.call(this, command, args, applyWindowsHide(options))
-    }
-    return originalSpawn.call(this, command, applyWindowsHide(args))
-  }
-
-  childProcess.spawnSync = function patchedSpawnSync(command, args, options) {
-    if (Array.isArray(args)) {
-      return originalSpawnSync.call(this, command, args, applyWindowsHide(options))
-    }
-    return originalSpawnSync.call(this, command, applyWindowsHide(args))
-  }
-
-  childProcess.exec = function patchedExec(command, options, callback) {
-    if (typeof options === 'function') {
-      return originalExec.call(this, command, applyWindowsHide(undefined), options)
-    }
-    return originalExec.call(this, command, applyWindowsHide(options), callback)
-  }
-
-  childProcess.execSync = function patchedExecSync(command, options) {
-    return originalExecSync.call(this, command, applyWindowsHide(options))
-  }
-
-  childProcess.execFile = function patchedExecFile(file, args, options, callback) {
-    if (typeof args === 'function') {
-      return originalExecFile.call(this, file, applyWindowsHide(undefined), undefined, args)
-    }
-    if (typeof options === 'function') {
-      return originalExecFile.call(this, file, args, applyWindowsHide(undefined), options)
-    }
-    return originalExecFile.call(this, file, args, applyWindowsHide(options), callback)
-  }
-
-  childProcess.execFileSync = function patchedExecFileSync(file, args, options) {
-    if (args && !Array.isArray(args)) {
-      return originalExecFileSync.call(this, file, applyWindowsHide(args))
-    }
-    return originalExecFileSync.call(this, file, args, applyWindowsHide(options))
-  }
-
-  childProcess.fork = function patchedFork(modulePath, args, options) {
-    if (Array.isArray(args)) {
-      return originalFork.call(this, modulePath, args, applyWindowsHide(options))
-    }
-    return originalFork.call(this, modulePath, applyWindowsHide(args))
-  }
+  enforceWindowsChildProcessHide(childProcess, syncBuiltinESMExports)
 
   process.stdout.write('[harness-node] windowsHide enforcement enabled for child processes\n')
 }

--- a/build/windows-child-process-hide.d.mts
+++ b/build/windows-child-process-hide.d.mts
@@ -1,0 +1,8 @@
+import type childProcess from 'node:child_process'
+
+export function applyWindowsHide<T>(options: T): T & { windowsHide: true }
+
+export function enforceWindowsChildProcessHide(
+  childProcessModule: typeof childProcess,
+  syncBuiltinESMExports: () => void
+): void

--- a/build/windows-child-process-hide.mjs
+++ b/build/windows-child-process-hide.mjs
@@ -1,0 +1,80 @@
+/** Add the Windows no-console flag without overriding an explicit choice. */
+export function applyWindowsHide(options) {
+  if (options && typeof options === 'object' && options.windowsHide !== undefined) {
+    return options
+  }
+  if (options && typeof options === 'object') {
+    return { ...options, windowsHide: true }
+  }
+  return { windowsHide: true }
+}
+
+/**
+ * Hide every child process launched from Harness on Windows.
+ *
+ * Node's ESM named exports for built-ins are not updated when the mutable
+ * default export is patched. Calling syncBuiltinESMExports after replacing
+ * the methods is therefore essential: Harness packages commonly use
+ * `import { spawn } from 'node:child_process'` and would otherwise keep the
+ * original, window-creating function.
+ */
+export function enforceWindowsChildProcessHide(childProcess, syncBuiltinESMExports) {
+  const originalSpawn = childProcess.spawn
+  const originalSpawnSync = childProcess.spawnSync
+  const originalExec = childProcess.exec
+  const originalExecSync = childProcess.execSync
+  const originalExecFile = childProcess.execFile
+  const originalExecFileSync = childProcess.execFileSync
+  const originalFork = childProcess.fork
+
+  childProcess.spawn = function patchedSpawn(command, args, options) {
+    if (Array.isArray(args)) {
+      return originalSpawn.call(this, command, args, applyWindowsHide(options))
+    }
+    return originalSpawn.call(this, command, applyWindowsHide(args))
+  }
+
+  childProcess.spawnSync = function patchedSpawnSync(command, args, options) {
+    if (Array.isArray(args)) {
+      return originalSpawnSync.call(this, command, args, applyWindowsHide(options))
+    }
+    return originalSpawnSync.call(this, command, applyWindowsHide(args))
+  }
+
+  childProcess.exec = function patchedExec(command, options, callback) {
+    if (typeof options === 'function') {
+      return originalExec.call(this, command, applyWindowsHide(undefined), options)
+    }
+    return originalExec.call(this, command, applyWindowsHide(options), callback)
+  }
+
+  childProcess.execSync = function patchedExecSync(command, options) {
+    return originalExecSync.call(this, command, applyWindowsHide(options))
+  }
+
+  childProcess.execFile = function patchedExecFile(file, args, options, callback) {
+    if (typeof args === 'function') {
+      return originalExecFile.call(this, file, applyWindowsHide(undefined), undefined, args)
+    }
+    if (typeof options === 'function') {
+      return originalExecFile.call(this, file, args, applyWindowsHide(undefined), options)
+    }
+    return originalExecFile.call(this, file, args, applyWindowsHide(options), callback)
+  }
+
+  childProcess.execFileSync = function patchedExecFileSync(file, args, options) {
+    if (args && !Array.isArray(args)) {
+      return originalExecFileSync.call(this, file, applyWindowsHide(args))
+    }
+    return originalExecFileSync.call(this, file, args, applyWindowsHide(options))
+  }
+
+  childProcess.fork = function patchedFork(modulePath, args, options) {
+    if (Array.isArray(args)) {
+      return originalFork.call(this, modulePath, args, applyWindowsHide(options))
+    }
+    return originalFork.call(this, modulePath, applyWindowsHide(args))
+  }
+
+  syncBuiltinESMExports()
+}

--- a/package.json
+++ b/package.json
@@ -326,6 +326,10 @@
         "to": "harness-node-entry.mjs"
       },
       {
+        "from": "build/windows-child-process-hide.mjs",
+        "to": "windows-child-process-hide.mjs"
+      },
+      {
         "from": "build/dsh-desktop.patch.yml",
         "to": "dsh-desktop.patch.yml"
       },

--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -549,13 +549,30 @@ export function buildInstallArguments(dshEntry = resolveDshEntry()) {
     'plugin',
     '--profile',
     MARKET_PROFILE,
-    'add',
-    `${MARKET_PACKAGE}@${RECOMMENDED_MARKET_VERSION}`
+    ...buildMarketInstallArguments()
   ]
 }
 
 export function buildUninstallArguments(dshEntry = resolveDshEntry()) {
-  return [dshEntry, 'plugin', '--profile', MARKET_PROFILE, 'remove', MARKET_PACKAGE]
+  return [
+    dshEntry,
+    'plugin',
+    '--profile',
+    MARKET_PROFILE,
+    ...buildMarketUninstallArguments()
+  ]
+}
+
+function buildMarketInstallArguments() {
+  return [
+    'add',
+    '--workspace-root',
+    `${MARKET_PACKAGE}@${RECOMMENDED_MARKET_VERSION}`
+  ]
+}
+
+function buildMarketUninstallArguments() {
+  return ['remove', '--workspace-root', MARKET_PACKAGE]
 }
 
 async function atomicWrite(path, contents) {
@@ -702,10 +719,7 @@ export async function apply(ctx) {
     }
 
     try {
-      await runProfileCommand(
-        ['add', `${MARKET_PACKAGE}@${RECOMMENDED_MARKET_VERSION}`],
-        'Installation'
-      )
+      await runProfileCommand(buildMarketInstallArguments(), 'Installation')
 
       const installed = await readMarketInstallation(home)
       if (!installed.installedVersion) {
@@ -748,7 +762,7 @@ export async function apply(ctx) {
     }
 
     try {
-      await runProfileCommand(['remove', MARKET_PACKAGE], 'Uninstallation')
+      await runProfileCommand(buildMarketUninstallArguments(), 'Uninstallation')
 
       const removed = await readMarketInstallation(home)
       if (removed.dependency || removed.installedVersion) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,12 +16,9 @@ import {
   type IpcMainInvokeEvent,
   type MessageBoxOptions
 } from 'electron'
-import { extractFailureCause, HarnessRuntime, resolveShellEnvironment } from './runtime/harness-runtime'
+import { extractFailureCause, HarnessRuntime } from './runtime/harness-runtime'
 import { launchDisclaimedUtilityProcess } from './runtime/disclaimed-utility-process'
-import {
-  installProfileDependenciesWithDsh,
-  removeProfilePluginWithDsh
-} from './runtime/profile-plugin-command'
+import { installProfileDependenciesWithDsh } from './runtime/profile-plugin-command'
 import { clearDamagedPackageDirectories, hasProfile } from './state/profile-repair'
 import {
   clearProfileInstallMarker,
@@ -59,8 +56,7 @@ import { ensureLaunchRoot } from './state/launch-root'
 import {
   listInstalledProfilePlugins,
   pruneMissingProfileBundles,
-  resetPluginProfile,
-  uninstallPluginFromProfile
+  resetPluginProfile
 } from './state/plugin-recovery'
 import { ensureSafeModeProfile, SAFE_MODE_PROFILE } from './state/safe-mode-profile'
 import {
@@ -78,6 +74,14 @@ import {
   rollBackMigration
 } from './state/generation-migration'
 import { cleanupPluginOwnedComponents } from './state/plugin-component-cleanup'
+import {
+  confirmPluginRemovalsBooted,
+  enforcePendingPluginRemovals,
+  listPendingPluginRemovals,
+  removePluginSafely,
+  shouldDeferProfileMaintenance,
+  type PluginRemovalResult
+} from './state/plugin-removal'
 import {
   appBundlePathFromExecutable,
   auditLaunchAgents,
@@ -171,6 +175,7 @@ const startInSafeMode = shouldStartInSafeMode(process.argv)
 // the recovery page do not count: both are local pages that render on a
 // machine whose harness never will.
 let harnessRendered = false
+let pluginRemovalsConfirmedThisProcess = false
 let gpuFallbackState: GpuFallbackState = defaultGpuFallbackState
 let gpuFallbackRelaunching = false
 let gpuStableLaunchTimer: NodeJS.Timeout | undefined
@@ -878,6 +883,14 @@ async function openHarness(
     if (navigationVersion !== mainWindowNavigationVersion) return
   }
   markHarnessRendered()
+  // Safe Mode proves only the isolated recovery profile. Confirm an uninstall
+  // against the normal web profile once per app process, so its backup gets a
+  // full later launch before it is garbage-collected.
+  if (!safeModeVisible && !pluginRemovalsConfirmedThisProcess) {
+    pluginRemovalsConfirmedThisProcess = true
+    const dshHome = join(app.getPath('userData'), 'harness')
+    void confirmPluginRemovalsBooted(dshHome, (line) => runtime?.note(line)).catch(() => undefined)
+  }
   if (runtime.snapshot().url !== url || window.isDestroyed()) return
   await syncNativeTheme(window)
   raiseWindowWithoutStealingFocus(
@@ -1037,34 +1050,45 @@ function launchHarness(): Promise<void> {
     // Restore its snapshot before projection or package repair can observe the
     // partially switched profile.
     await recoverInterruptedMigration(dshHome, (line) => runtime.note(line))
+    // A removal tombstone is authoritative even if its later cleanup failed.
+    // Enforce it before and after projection so a generation pointer cannot
+    // silently add the disabled bundle back during a recovery launch.
+    await enforcePendingPluginRemovals(dshHome, (line) => runtime.note(line))
     // Cold start, Harness stopped: sweep unreferenced plugin generations and
     // reproject so the profile's links match `desired`. A no-op on a profile
     // that has never used a generation.
     await prepareGenerationsForLaunch(dshHome, (line) => runtime.note(line))
+    await enforcePendingPluginRemovals(dshHome, (line) => runtime.note(line))
     // One-time move of a pre-upgrade profile (community plugins in the shared
     // tree) onto the generation model. Runs before the shared-tree repair and,
     // when it succeeds, replaces it — the migration has already rebuilt the
     // tree down to what stays there.
-    const migrated = await migrateProfileToGenerations({
-      dshHome,
-      nodeExecutablePath: bundledNodePath(),
-      pnpmEntryPath: bundledPnpmEntryPath(),
-      dshEntryPath: dshEntryPath(),
-      note: (line) => runtime.note(line),
-      reinstallSharedTree: async () => {
-        await clearProfileInstallMarker(dshHome)
-        const result = await installProfileDependenciesWithDsh({
-          dshHome,
-          dshEntryPath: dshEntryPath(),
-          nodeExecutablePath: bundledNodePath(),
-          pnpmEntryPath: bundledPnpmEntryPath(),
-          pnpmRunnerPath: bundledPnpmRunnerPath()
-        })
-        if (result.ok) await markProfileInstallComplete(dshHome)
-        return result
-      }
-    })
-    if (!migrated) await repairProfilePackages(dshHome)
+    const deferMaintenance = await shouldDeferProfileMaintenance(dshHome).catch(() => false)
+    let migrated = false
+    if (deferMaintenance) {
+      runtime.note('[desktop] profile package maintenance deferred while plugin removal is pending verification')
+    } else {
+      migrated = await migrateProfileToGenerations({
+        dshHome,
+        nodeExecutablePath: bundledNodePath(),
+        pnpmEntryPath: bundledPnpmEntryPath(),
+        dshEntryPath: dshEntryPath(),
+        note: (line) => runtime.note(line),
+        reinstallSharedTree: async () => {
+          await clearProfileInstallMarker(dshHome)
+          const result = await installProfileDependenciesWithDsh({
+            dshHome,
+            dshEntryPath: dshEntryPath(),
+            nodeExecutablePath: bundledNodePath(),
+            pnpmEntryPath: bundledPnpmEntryPath(),
+            pnpmRunnerPath: bundledPnpmRunnerPath()
+          })
+          if (result.ok) await markProfileInstallComplete(dshHome)
+          return result
+        }
+      })
+      if (!migrated) await repairProfilePackages(dshHome)
+    }
     await pruneMissingProfileBundles(dshHome).catch(() => false)
     await reportProfileConsistency(dshHome)
     await auditInstalledLaunchAgents(dshHome)
@@ -1417,15 +1441,14 @@ async function showPluginRecovery(options?: {
         applyPendingFrontendEvidence()
         continue
       } else if (action === 'uninstall' && detection.plugins.length > 0) {
+        // The normal web Harness may still have the failing plugin imported.
+        // macOS permits renaming an open directory, but Windows does not; stop
+        // the process before quarantine so both platforms use the same path.
+        await runtime.stop()
         const failedPlugins: string[] = []
         for (const plugin of detection.plugins) {
-          const removed = await removeProfilePluginCompletely(
-            dshHome,
-            plugin,
-            resolveShellEnvironment(),
-            'plugin-recovery'
-          )
-          if (removed) {
+          const removal = await removeProfilePluginCompletely(dshHome, plugin, 'plugin-recovery')
+          if (removal.disabled) {
             if (!removedPlugins.includes(plugin)) removedPlugins.push(plugin)
           } else {
             failedPlugins.push(plugin)
@@ -1566,13 +1589,11 @@ async function waitForSafeModeAction(options: {
   return actionPromise
 }
 
-async function removeSafeModePlugin(dshHome: string, pluginName: string): Promise<boolean> {
-  return removeProfilePluginCompletely(
-    dshHome,
-    pluginName,
-    process.env,
-    'safe-mode'
-  )
+async function removeSafeModePlugin(
+  dshHome: string,
+  pluginName: string
+): Promise<PluginRemovalResult> {
+  return removeProfilePluginCompletely(dshHome, pluginName, 'safe-mode')
 }
 
 async function repairSafeModeCompatibilityIssues(
@@ -1633,61 +1654,27 @@ async function repairSafeModeCompatibilityIssues(
 async function removeProfilePluginCompletely(
   dshHome: string,
   pluginName: string,
-  environment: NodeJS.ProcessEnv,
   logPrefix: string
-): Promise<boolean> {
-  // A generation plugin is uninstalled by dropping it from `desired` and
-  // reprojecting — a `pnpm remove` on its `link:` dep is undone by the next
-  // projection, which re-derives the profile from `desired`.
-  if (
-    await uninstallGenerationPlugin(dshHome, pluginName, (line) => runtime.note(line)).catch(
-      () => false
-    )
-  ) {
-    await cleanupPluginOwnedComponents({
+): Promise<PluginRemovalResult> {
+  const result = await removePluginSafely({
+    dshHome,
+    pluginName,
+    cleanupOwnedComponents: () => cleanupPluginOwnedComponents({
       dshHome,
       pluginName,
       log: (message) => runtime.note(`[${logPrefix}] ${message}`)
-    }).catch(() => undefined)
-    return !(await listInstalledProfilePlugins(dshHome)).includes(pluginName)
-  }
-
-  const cleanup = await cleanupPluginOwnedComponents({
-    dshHome,
-    pluginName,
-    log: (message) => runtime.note(`[${logPrefix}] ${message}`)
+    }),
+    uninstallGeneration: () => uninstallGenerationPlugin(
+      dshHome,
+      pluginName,
+      (line) => runtime.note(line)
+    ),
+    note: (line) => runtime.note(`[${logPrefix}] ${line}`)
   })
-  if (!cleanup.ok) {
-    for (const failure of cleanup.failures) {
-      runtime.note(`[${logPrefix}] failed to clean components for ${pluginName}: ${failure}`)
-    }
-    return false
+  for (const failure of result.failures) {
+    runtime.note(`[${logPrefix}] ${pluginName} remains disabled; cleanup pending: ${failure}`)
   }
-
-  const removed = await uninstallPluginFromProfile(dshHome, pluginName, async (name) => {
-    const result = await removeProfilePluginWithDsh(
-      {
-        dshHome,
-        dshEntryPath: dshEntryPath(),
-        nodeExecutablePath: bundledNodePath(),
-        pnpmEntryPath: bundledPnpmEntryPath(),
-        pnpmRunnerPath: bundledPnpmRunnerPath(),
-        environment
-      },
-      name
-    )
-    if (!result.ok) {
-      runtime.note(`[${logPrefix}] failed to remove ${name}: ${result.detail ?? 'unknown error'}`)
-    }
-    return result.ok
-  })
-  // Both recovery paths pass an exact configured root bundle. The fallback
-  // must not widen that ownership to similarly-named or same-scope siblings.
-  if (removed || await resetPluginProfile(dshHome, pluginName, false)) return true
-  // A package command can finish the profile edit but fail its own final
-  // verification (for example after a lockfile cleanup). Treat the observable
-  // profile state as authoritative instead of reporting a false failure.
-  return !(await listInstalledProfilePlugins(dshHome)).includes(pluginName)
+  return result
 }
 
 async function showSafeMode(): Promise<void> {
@@ -1713,7 +1700,9 @@ async function showSafeModeManager(): Promise<void> {
 
   try {
     while (!quitting) {
-      const installed = await listInstalledProfilePlugins(dshHome)
+      const active = await listInstalledProfilePlugins(dshHome)
+      const pendingRemovals = await listPendingPluginRemovals(dshHome)
+      const installed = [...new Set([...active, ...pendingRemovals])]
       const compatibility = await inspectProfileCompatibility(
         dshHome,
         join(app.getAppPath(), 'node_modules')
@@ -1776,18 +1765,25 @@ async function showSafeModeManager(): Promise<void> {
       }
 
       const failedPlugins: string[] = []
+      const pendingPlugins: string[] = []
       for (const plugin of selectedPlugins) {
-        if (!(await removeSafeModePlugin(dshHome, plugin))) failedPlugins.push(plugin)
+        const removal = await removeSafeModePlugin(dshHome, plugin)
+        if (!removal.disabled) failedPlugins.push(plugin)
+        else if (removal.pending) pendingPlugins.push(plugin)
       }
       const failed = repairFailures + failedPlugins.length
-      notice = failed === 0
+      notice = pendingPlugins.length > 0
+        ? isChinese
+          ? `已禁用 ${pendingPlugins.length} 个插件；物理清理待重试。插件不会在后续启动中重新启用。`
+          : `Disabled ${pendingPlugins.length} plugin${pendingPlugins.length === 1 ? '' : 's'}; physical cleanup is pending. They will stay disabled on later launches.`
+        : failed === 0
         ? isChinese
           ? `处理完成：修复 ${repaired} 项，卸载 ${selectedPlugins.length} 个插件。`
           : `Completed: ${repaired} repair${repaired === 1 ? '' : 's'} and ${selectedPlugins.length} plugin removal${selectedPlugins.length === 1 ? '' : 's'}.`
         : isChinese
           ? `已修复 ${repaired} 项、卸载 ${selectedPlugins.length - failedPlugins.length} 个插件；${failed} 项未能处理。`
           : `Completed ${repaired} repairs and removed ${selectedPlugins.length - failedPlugins.length} plugins; ${failed} items could not be processed.`
-      noticeTone = failed === 0 ? 'success' : 'error'
+      noticeTone = failed === 0 && pendingPlugins.length === 0 ? 'success' : 'error'
     }
   } finally {
     safeModeActionResolver = undefined

--- a/src/main/state/generation-launch.ts
+++ b/src/main/state/generation-launch.ts
@@ -11,6 +11,7 @@ import {
   isGenerationPlugin,
   readDesired,
   readLastKnownGood,
+  resolveEnabledGenerations,
   revertToLastKnownGood,
   sweepRegistry
 } from 'dsh-desktop-market-installer/generations/registry'
@@ -110,14 +111,27 @@ export async function uninstallGenerationPlugin(
   note: Note
 ): Promise<boolean> {
   if (!(await isGenerationPlugin(dshHome, pluginName).catch(() => false))) return false
-  const removed = await disableGeneration(dshHome, pluginName).catch(() => false)
-  await projectGenerations(dshHome).catch(() => undefined)
-  note(
-    removed
-      ? `[desktop] disabled the ${pluginName} generation; it will be swept on a later cold start`
-      : `[desktop] ${pluginName} was already not an enabled generation`
-  )
-  return true
+  try {
+    const removed = await disableGeneration(dshHome, pluginName)
+    await projectGenerations(dshHome)
+    const stillEnabled = (await resolveEnabledGenerations(dshHome)).has(pluginName)
+    if (stillEnabled) {
+      note(`[desktop] failed to disable the ${pluginName} generation`)
+      return false
+    }
+    note(
+      removed
+        ? `[desktop] disabled the ${pluginName} generation; it will be swept on a later cold start`
+        : `[desktop] ${pluginName} was already not an enabled generation`
+    )
+    return true
+  } catch (error) {
+    note(
+      `[desktop] failed to disable the ${pluginName} generation: ` +
+        `${error instanceof Error ? error.message : error}`
+    )
+    return false
+  }
 }
 
 /**

--- a/src/main/state/plugin-removal.ts
+++ b/src/main/state/plugin-removal.ts
@@ -1,0 +1,402 @@
+import { existsSync } from 'node:fs'
+import { copyFile, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import {
+  disableGeneration,
+  isGenerationPlugin
+} from 'dsh-desktop-market-installer/generations/registry'
+import {
+  isThirdPartyPackageName,
+  pluginDeclaredEntryIds,
+  profileCordisPatchPath,
+  profilePackageJsonPath,
+  prunePluginPatchLayer
+} from './plugin-recovery'
+
+const PROTOCOL = 1
+
+type RemovalStatus = 'disabled' | 'cleanup-pending' | 'removed'
+
+interface RemovalEntry {
+  pluginName: string
+  status: RemovalStatus
+  disabledAt: string
+  updatedAt: string
+  backupDirectory: string
+  failures: string[]
+  bootVerifiedAt?: string
+  backupDeletedAt?: string
+}
+
+interface RemovalLedger {
+  protocol: number
+  removals: Record<string, RemovalEntry>
+}
+
+interface ProfileManifest {
+  dependencies?: Record<string, string>
+  dsh?: { profile?: { bundles?: string[] } }
+}
+
+export interface PluginRemovalResult {
+  pluginName: string
+  disabled: boolean
+  removed: boolean
+  pending: boolean
+  backupDirectory?: string
+  failures: string[]
+}
+
+export interface PluginRemovalOptions {
+  dshHome: string
+  pluginName: string
+  cleanupOwnedComponents: () => Promise<{ ok: boolean; failures: string[] }>
+  uninstallGeneration: () => Promise<boolean>
+  now?: () => Date
+  note?: (line: string) => void
+}
+
+function ledgerPath(dshHome: string): string {
+  return join(dshHome, 'recovery', 'plugin-removals.json')
+}
+
+function removalRoot(dshHome: string): string {
+  return join(dshHome, 'recovery', 'plugin-removals')
+}
+
+function safePluginName(pluginName: string): string {
+  return pluginName.replace(/^@/u, '').replaceAll('/', '__')
+}
+
+function timestamp(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+async function readLedger(dshHome: string): Promise<RemovalLedger> {
+  try {
+    const parsed = JSON.parse(await readFile(ledgerPath(dshHome), 'utf8')) as RemovalLedger
+    if (parsed.protocol === PROTOCOL && typeof parsed.removals === 'object') return parsed
+  } catch { }
+  return { protocol: PROTOCOL, removals: {} }
+}
+
+async function writeLedger(dshHome: string, ledger: RemovalLedger): Promise<void> {
+  const path = ledgerPath(dshHome)
+  const temporary = `${path}.${process.pid}.${Date.now()}.tmp`
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(temporary, `${JSON.stringify(ledger, undefined, 2)}\n`, 'utf8')
+  await rename(temporary, path)
+}
+
+async function updateEntry(
+  dshHome: string,
+  pluginName: string,
+  update: (entry: RemovalEntry | undefined) => RemovalEntry
+): Promise<RemovalEntry> {
+  const ledger = await readLedger(dshHome)
+  const next = update(ledger.removals[pluginName])
+  ledger.removals[pluginName] = next
+  await writeLedger(dshHome, ledger)
+  return next
+}
+
+async function copyOptional(from: string, to: string): Promise<void> {
+  // The first snapshot is the rollback point. A cleanup retry must not replace
+  // it with the already-disabled or partially-detached profile.
+  if (existsSync(to)) return
+  try {
+    await copyFile(from, to)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+}
+
+async function ensureBackup(entry: RemovalEntry, dshHome: string): Promise<void> {
+  await mkdir(entry.backupDirectory, { recursive: true })
+  const profile = dirname(profilePackageJsonPath(dshHome))
+  await Promise.all([
+    copyOptional(profilePackageJsonPath(dshHome), join(entry.backupDirectory, 'package.json')),
+    copyOptional(join(profile, 'pnpm-lock.yaml'), join(entry.backupDirectory, 'pnpm-lock.yaml')),
+    copyOptional(profileCordisPatchPath(dshHome), join(entry.backupDirectory, 'cordis.patch.yml'))
+  ])
+}
+
+async function disableInManifest(dshHome: string, pluginNames: ReadonlySet<string>): Promise<void> {
+  const path = profilePackageJsonPath(dshHome)
+  const manifest = JSON.parse(await readFile(path, 'utf8')) as ProfileManifest
+  const bundles = manifest.dsh?.profile?.bundles
+  if (!bundles) return
+  const next = bundles.filter((name) => !pluginNames.has(name))
+  if (next.length === bundles.length) return
+  manifest.dsh ??= {}
+  manifest.dsh.profile ??= {}
+  manifest.dsh.profile.bundles = next
+  await writeFile(path, `${JSON.stringify(manifest, undefined, 2)}\n`, 'utf8')
+}
+
+async function markPending(
+  dshHome: string,
+  entry: RemovalEntry,
+  failures: readonly string[]
+): Promise<RemovalEntry> {
+  return updateEntry(dshHome, entry.pluginName, (current) => ({
+    ...(current ?? entry),
+    status: 'cleanup-pending',
+    updatedAt: new Date().toISOString(),
+    failures: [...new Set([...(current?.failures ?? entry.failures), ...failures])]
+  }))
+}
+
+async function beginRemoval(
+  dshHome: string,
+  pluginName: string,
+  now: () => Date
+): Promise<RemovalEntry> {
+  if (!isThirdPartyPackageName(pluginName)) throw new Error(`Refusing to remove core package ${pluginName}`)
+  const started = now()
+  return updateEntry(dshHome, pluginName, (current) => {
+    if (current && current.status !== 'removed') {
+      return { ...current, status: 'disabled', updatedAt: started.toISOString() }
+    }
+    return {
+      pluginName,
+      status: 'disabled',
+      disabledAt: started.toISOString(),
+      updatedAt: started.toISOString(),
+      backupDirectory: join(removalRoot(dshHome), timestamp(started), safePluginName(pluginName)),
+      failures: []
+    }
+  })
+}
+
+async function nextQuarantinePath(base: string): Promise<string> {
+  if (!existsSync(base)) return base
+  for (let index = 2; index < 1000; index += 1) {
+    const candidate = `${base}-${index}`
+    if (!existsSync(candidate)) return candidate
+  }
+  throw new Error(`Too many quarantine copies at ${base}`)
+}
+
+async function quarantinePath(from: string, baseDestination: string): Promise<string | undefined> {
+  if (!existsSync(from)) return undefined
+  const destination = await nextQuarantinePath(baseDestination)
+  await mkdir(dirname(destination), { recursive: true })
+  await rename(from, destination)
+  return destination
+}
+
+async function detachLegacyPlugin(entry: RemovalEntry, dshHome: string): Promise<void> {
+  const manifestPath = profilePackageJsonPath(dshHome)
+  const profile = dirname(manifestPath)
+  const entryIds = await pluginDeclaredEntryIds(profile, entry.pluginName)
+  await quarantinePath(
+    join(profile, 'node_modules', entry.pluginName),
+    join(entry.backupDirectory, 'profile-packages', 'node_modules', safePluginName(entry.pluginName))
+  )
+  await quarantinePath(
+    join(profile, 'packages', entry.pluginName),
+    join(entry.backupDirectory, 'profile-packages', 'workspaces', safePluginName(entry.pluginName))
+  )
+
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as ProfileManifest
+  if (manifest.dependencies) delete manifest.dependencies[entry.pluginName]
+  if (manifest.dsh?.profile?.bundles) {
+    manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter(
+      (name) => name !== entry.pluginName
+    )
+  }
+  await writeFile(manifestPath, `${JSON.stringify(manifest, undefined, 2)}\n`, 'utf8')
+  await prunePluginPatchLayer(dshHome, entry.pluginName, entryIds)
+  // The manifest is authoritative. The saved lockfile remains in recovery;
+  // the next package operation must resolve a new lock without the plugin.
+  await rm(join(profile, 'pnpm-lock.yaml'), { force: true })
+}
+
+async function verifyDetached(dshHome: string, pluginName: string): Promise<boolean> {
+  try {
+    const profile = dirname(profilePackageJsonPath(dshHome))
+    const manifest = JSON.parse(await readFile(profilePackageJsonPath(dshHome), 'utf8')) as ProfileManifest
+    return !Object.hasOwn(manifest.dependencies ?? {}, pluginName) &&
+      !(manifest.dsh?.profile?.bundles ?? []).includes(pluginName) &&
+      !existsSync(join(profile, 'node_modules', pluginName)) &&
+      !existsSync(join(profile, 'packages', pluginName))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Re-apply durable removal tombstones before launch. This is deliberately a
+ * quick manifest/pointer operation: it never invokes pnpm, deletes packages,
+ * or waits for cleanup, so a failed uninstall cannot hold the splash screen.
+ */
+export async function enforcePendingPluginRemovals(
+  dshHome: string,
+  note: (line: string) => void = () => undefined
+): Promise<void> {
+  const ledger = await readLedger(dshHome)
+  const blocked = Object.values(ledger.removals).filter((entry) => entry.status !== 'removed')
+  if (blocked.length === 0) return
+
+  const names = new Set(blocked.map((entry) => entry.pluginName))
+  for (const entry of blocked) {
+    try {
+      if (await isGenerationPlugin(dshHome, entry.pluginName)) {
+        await disableGeneration(dshHome, entry.pluginName)
+      }
+    } catch (error) {
+      note(`[desktop] could not enforce generation removal for ${entry.pluginName}: ${error instanceof Error ? error.message : error}`)
+    }
+  }
+  try {
+    await disableInManifest(dshHome, names)
+  } catch (error) {
+    note(`[desktop] could not enforce disabled plugin manifest: ${error instanceof Error ? error.message : error}`)
+  }
+}
+
+export async function listPendingPluginRemovals(dshHome: string): Promise<string[]> {
+  const ledger = await readLedger(dshHome)
+  return Object.values(ledger.removals)
+    .filter((entry) => entry.status !== 'removed')
+    .map((entry) => entry.pluginName)
+    .sort()
+}
+
+/**
+ * A pending cleanup must never invoke package maintenance during launch. A
+ * completed removal also gets one clean boot before normal maintenance is
+ * allowed again, so unrelated migration work cannot trap the recovery flow.
+ */
+export async function shouldDeferProfileMaintenance(dshHome: string): Promise<boolean> {
+  const ledger = await readLedger(dshHome)
+  return Object.values(ledger.removals).some(
+    (entry) => entry.status !== 'removed' || entry.bootVerifiedAt === undefined
+  )
+}
+
+export async function confirmPluginRemovalsBooted(
+  dshHome: string,
+  note: (line: string) => void = () => undefined
+): Promise<void> {
+  const ledger = await readLedger(dshHome)
+  let changed = false
+  const verifiedAt = new Date().toISOString()
+  for (const entry of Object.values(ledger.removals)) {
+    if (entry.status !== 'removed') continue
+    if (entry.bootVerifiedAt === undefined) {
+      entry.bootVerifiedAt = verifiedAt
+      entry.updatedAt = verifiedAt
+      changed = true
+      continue
+    }
+    if (entry.backupDeletedAt !== undefined) continue
+    try {
+      await rm(entry.backupDirectory, { recursive: true, force: true })
+      entry.backupDeletedAt = verifiedAt
+      entry.updatedAt = verifiedAt
+      changed = true
+      note(`[plugin-removal] deleted verified recovery backup for ${entry.pluginName}`)
+    } catch (error) {
+      const detail = `verified backup cleanup failed: ${error instanceof Error ? error.message : error}`
+      if (!entry.failures.includes(detail)) entry.failures.push(detail)
+      entry.updatedAt = verifiedAt
+      changed = true
+      note(`[plugin-removal] kept recovery backup for ${entry.pluginName}: ${detail}`)
+    }
+  }
+  if (changed) await writeLedger(dshHome, ledger)
+}
+
+/**
+ * Disable first, preserve a recovery copy, then detach the plugin. Every
+ * failure returns cleanup-pending; the durable tombstone keeps the plugin out
+ * of future launches while the user can retry cleanup later.
+ */
+export async function removePluginSafely(options: PluginRemovalOptions): Promise<PluginRemovalResult> {
+  const now = options.now ?? (() => new Date())
+  let entry = await beginRemoval(options.dshHome, options.pluginName, now)
+
+  try {
+    await ensureBackup(entry, options.dshHome)
+    await disableInManifest(options.dshHome, new Set([options.pluginName]))
+  } catch (error) {
+    const detail = `disable/backup failed: ${error instanceof Error ? error.message : error}`
+    entry = await markPending(options.dshHome, entry, [detail]).catch(() => entry)
+    return {
+      pluginName: options.pluginName,
+      disabled: true,
+      removed: false,
+      pending: true,
+      backupDirectory: entry.backupDirectory,
+      failures: [detail]
+    }
+  }
+
+  const cleanup = await options.cleanupOwnedComponents().catch((error) => ({
+    ok: false,
+    failures: [error instanceof Error ? error.message : String(error)]
+  }))
+  if (!cleanup.ok) {
+    entry = await markPending(options.dshHome, entry, cleanup.failures).catch(() => entry)
+    return {
+      pluginName: options.pluginName,
+      disabled: true,
+      removed: false,
+      pending: true,
+      backupDirectory: entry.backupDirectory,
+      failures: cleanup.failures
+    }
+  }
+
+  try {
+    if (await isGenerationPlugin(options.dshHome, options.pluginName)) {
+      if (!await options.uninstallGeneration()) throw new Error('generation pointer could not be disabled')
+    } else {
+      await detachLegacyPlugin(entry, options.dshHome)
+      if (!await verifyDetached(options.dshHome, options.pluginName)) {
+        throw new Error('plugin is still present in the active profile')
+      }
+    }
+  } catch (error) {
+    const detail = `detach failed: ${error instanceof Error ? error.message : error}`
+    entry = await markPending(options.dshHome, entry, [detail]).catch(() => entry)
+    return {
+      pluginName: options.pluginName,
+      disabled: true,
+      removed: false,
+      pending: true,
+      backupDirectory: entry.backupDirectory,
+      failures: [detail]
+    }
+  }
+
+  try {
+    entry = await updateEntry(options.dshHome, options.pluginName, (current) => ({
+      ...(current ?? entry),
+      status: 'removed',
+      updatedAt: now().toISOString(),
+      failures: []
+    }))
+  } catch (error) {
+    const detail = `removal commit failed: ${error instanceof Error ? error.message : error}`
+    return {
+      pluginName: options.pluginName,
+      disabled: true,
+      removed: false,
+      pending: true,
+      backupDirectory: entry.backupDirectory,
+      failures: [detail]
+    }
+  }
+  options.note?.(`[plugin-removal] removed ${options.pluginName}; recovery backup kept at ${entry.backupDirectory}`)
+  return {
+    pluginName: options.pluginName,
+    disabled: true,
+    removed: true,
+    pending: false,
+    backupDirectory: entry.backupDirectory,
+    failures: []
+  }
+}

--- a/test/harness-node-entry.test.ts
+++ b/test/harness-node-entry.test.ts
@@ -1,15 +1,8 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import childProcess from 'node:child_process'
-
-function applyWindowsHide(options: any): any {
-  if (options && typeof options === 'object' && options.windowsHide !== undefined) {
-    return options
-  }
-  if (options && typeof options === 'object') {
-    return { ...options, windowsHide: true }
-  }
-  return { windowsHide: true }
-}
+import { execFileSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+import { join } from 'node:path'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { applyWindowsHide } from '../build/windows-child-process-hide.mjs'
 
 describe('applyWindowsHide helper', () => {
   it('adds windowsHide: true when options is undefined', () => {
@@ -39,6 +32,37 @@ describe('applyWindowsHide helper', () => {
       stdio: 'pipe',
       windowsHide: true
     })
+  })
+})
+
+describe('windowsHide ESM built-in synchronization', () => {
+  it('reaches modules that import spawn as a named ESM export', () => {
+    const helperUrl = pathToFileURL(
+      join(process.cwd(), 'build', 'windows-child-process-hide.mjs')
+    ).href
+    const script = `
+      import childProcess from 'node:child_process'
+      import { syncBuiltinESMExports } from 'node:module'
+      import { enforceWindowsChildProcessHide } from ${JSON.stringify(helperUrl)}
+
+      let observed
+      childProcess.spawn = (_command, _args, options) => {
+        observed = options
+        return { marker: true }
+      }
+      enforceWindowsChildProcessHide(childProcess, syncBuiltinESMExports)
+
+      const fixture = await import('data:text/javascript,' + encodeURIComponent(
+        'import { spawn } from "node:child_process"; export function run() { return spawn("fixture", [], { cwd: "C:/fixture" }) }'
+      ))
+      fixture.run()
+      process.stdout.write(JSON.stringify(observed))
+    `
+    const output = execFileSync(process.execPath, ['--input-type=module', '--eval', script], {
+      encoding: 'utf8'
+    })
+
+    expect(JSON.parse(output)).toEqual({ cwd: 'C:/fixture', windowsHide: true })
   })
 })
 

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -31,6 +31,7 @@ describe('desktop plugin market installer', () => {
       '--profile',
       'web',
       'add',
+      '--workspace-root',
       'dshmarket@latest'
     ])
     expect(MARKET_PACKAGE).toBe('dshmarket')
@@ -44,6 +45,7 @@ describe('desktop plugin market installer', () => {
       '--profile',
       'web',
       'remove',
+      '--workspace-root',
       'dshmarket'
     ])
   })

--- a/test/plugin-removal.test.ts
+++ b/test/plugin-removal.test.ts
@@ -1,0 +1,184 @@
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  disableGeneration,
+  ensureRegistryDirectories,
+  readDesired,
+  writeDesired,
+  writeGenerationMeta
+} from '../packages/dsh-desktop-market-installer/generations/registry'
+import { projectGenerations } from '../packages/dsh-desktop-market-installer/generations/projection'
+import {
+  confirmPluginRemovalsBooted,
+  enforcePendingPluginRemovals,
+  listPendingPluginRemovals,
+  removePluginSafely,
+  shouldDeferProfileMaintenance
+} from '../src/main/state/plugin-removal'
+
+describe('durable plugin removal', () => {
+  const homes: string[] = []
+
+  async function profile(pluginName = '@example/plugin-a'): Promise<{
+    dshHome: string
+    profileDirectory: string
+  }> {
+    const dshHome = await mkdtemp(join(tmpdir(), 'dsh-plugin-removal-'))
+    homes.push(dshHome)
+    const profileDirectory = join(dshHome, 'profiles', 'web')
+    const packageDirectory = join(profileDirectory, 'node_modules', pluginName)
+    await mkdir(packageDirectory, { recursive: true })
+    await writeFile(
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({ name: pluginName, version: '1.0.0', dsh: { bundle: { patch: 'cordis.patch.yml' } } })
+    )
+    await writeFile(join(packageDirectory, 'cordis.patch.yml'), '[]\n')
+    await writeFile(
+      join(profileDirectory, 'package.json'),
+      JSON.stringify({
+        dependencies: { [pluginName]: '1.0.0', '@example/plugin-b': '1.0.0' },
+        dsh: { profile: { bundles: [pluginName, '@example/plugin-b'] } }
+      })
+    )
+    await writeFile(join(profileDirectory, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n')
+    await writeFile(join(profileDirectory, 'cordis.patch.yml'), '[]\n')
+    return { dshHome, profileDirectory }
+  }
+
+  afterEach(async () => {
+    await Promise.all(homes.map((home) => rm(home, { recursive: true, force: true })))
+    homes.length = 0
+  })
+
+  it('backs up and quarantines one exact legacy plugin without invoking pnpm', async () => {
+    const { dshHome, profileDirectory } = await profile()
+    const uninstallGeneration = vi.fn(async () => false)
+
+    const result = await removePluginSafely({
+      dshHome,
+      pluginName: '@example/plugin-a',
+      cleanupOwnedComponents: async () => ({ ok: true, failures: [] }),
+      uninstallGeneration,
+      now: () => new Date('2026-08-29T12:00:00.000Z')
+    })
+
+    expect(result).toMatchObject({ disabled: true, removed: true, pending: false })
+    expect(uninstallGeneration).not.toHaveBeenCalled()
+    const manifest = JSON.parse(await readFile(join(profileDirectory, 'package.json'), 'utf8'))
+    expect(manifest.dependencies).toEqual({ '@example/plugin-b': '1.0.0' })
+    expect(manifest.dsh.profile.bundles).toEqual(['@example/plugin-b'])
+    expect(existsSync(join(profileDirectory, 'node_modules', '@example', 'plugin-a'))).toBe(false)
+    expect(existsSync(join(profileDirectory, 'pnpm-lock.yaml'))).toBe(false)
+    expect(existsSync(join(result.backupDirectory as string, 'package.json'))).toBe(true)
+    expect(existsSync(join(
+      result.backupDirectory as string,
+      'profile-packages',
+      'node_modules',
+      'example__plugin-a',
+      'package.json'
+    ))).toBe(true)
+    expect(await shouldDeferProfileMaintenance(dshHome)).toBe(true)
+    await confirmPluginRemovalsBooted(dshHome)
+    expect(await shouldDeferProfileMaintenance(dshHome)).toBe(false)
+    expect(existsSync(result.backupDirectory as string)).toBe(true)
+    await confirmPluginRemovalsBooted(dshHome)
+    expect(existsSync(result.backupDirectory as string)).toBe(false)
+  })
+
+  it('keeps a failed cleanup disabled and preserves its package for a later retry', async () => {
+    const { dshHome, profileDirectory } = await profile('plugin-one')
+
+    const result = await removePluginSafely({
+      dshHome,
+      pluginName: 'plugin-one',
+      cleanupOwnedComponents: async () => ({ ok: false, failures: ['service is still running'] }),
+      uninstallGeneration: async () => false,
+      now: () => new Date('2026-08-29T12:05:00.000Z')
+    })
+
+    expect(result).toMatchObject({ disabled: true, removed: false, pending: true })
+    const manifest = JSON.parse(await readFile(join(profileDirectory, 'package.json'), 'utf8'))
+    expect(manifest.dependencies['plugin-one']).toBe('1.0.0')
+    expect(manifest.dsh.profile.bundles).not.toContain('plugin-one')
+    expect(existsSync(join(profileDirectory, 'node_modules', 'plugin-one'))).toBe(true)
+    expect(existsSync(join(result.backupDirectory as string, 'package.json'))).toBe(true)
+    expect(await listPendingPluginRemovals(dshHome)).toEqual(['plugin-one'])
+    expect(await shouldDeferProfileMaintenance(dshHome)).toBe(true)
+    await confirmPluginRemovalsBooted(dshHome)
+    expect(await shouldDeferProfileMaintenance(dshHome)).toBe(true)
+
+    const retried = await removePluginSafely({
+      dshHome,
+      pluginName: 'plugin-one',
+      cleanupOwnedComponents: async () => ({ ok: true, failures: [] }),
+      uninstallGeneration: async () => false,
+      now: () => new Date('2026-08-29T12:06:00.000Z')
+    })
+    expect(retried).toMatchObject({ disabled: true, removed: true, pending: false })
+    const originalBackup = JSON.parse(
+      await readFile(join(result.backupDirectory as string, 'package.json'), 'utf8')
+    )
+    expect(originalBackup.dsh.profile.bundles).toContain('plugin-one')
+    expect(await listPendingPluginRemovals(dshHome)).toEqual([])
+  })
+
+  it('uses the durable tombstone to remove a failed generation pointer before launch', async () => {
+    const { dshHome, profileDirectory } = await profile('generation-plugin')
+    const layout = await ensureRegistryDirectories(dshHome)
+    const generationId = 'generation-plugin+1.0.0+fixture'
+    const generationDirectory = join(layout.generations, generationId)
+    await mkdir(generationDirectory, { recursive: true })
+    await writeGenerationMeta(generationDirectory, {
+      pluginName: 'generation-plugin',
+      version: '1.0.0'
+    })
+    await writeDesired(dshHome, [generationId])
+
+    const result = await removePluginSafely({
+      dshHome,
+      pluginName: 'generation-plugin',
+      cleanupOwnedComponents: async () => ({ ok: true, failures: [] }),
+      uninstallGeneration: async () => false,
+      now: () => new Date('2026-08-29T12:10:00.000Z')
+    })
+
+    expect(result).toMatchObject({ disabled: true, removed: false, pending: true })
+    expect(await readDesired(dshHome)).toEqual([generationId])
+    await enforcePendingPluginRemovals(dshHome)
+    expect(await readDesired(dshHome)).toEqual([])
+    const manifest = JSON.parse(await readFile(join(profileDirectory, 'package.json'), 'utf8'))
+    expect(manifest.dsh.profile.bundles).not.toContain('generation-plugin')
+  })
+
+  it('commits a generation removal only after its desired pointer and projection are detached', async () => {
+    const { dshHome } = await profile('generation-plugin')
+    const layout = await ensureRegistryDirectories(dshHome)
+    const generationId = 'generation-plugin+1.0.0+complete'
+    const generationDirectory = join(layout.generations, generationId)
+    await mkdir(generationDirectory, { recursive: true })
+    await writeGenerationMeta(generationDirectory, {
+      pluginName: 'generation-plugin',
+      version: '1.0.0'
+    })
+    await writeDesired(dshHome, [generationId])
+
+    const result = await removePluginSafely({
+      dshHome,
+      pluginName: 'generation-plugin',
+      cleanupOwnedComponents: async () => ({ ok: true, failures: [] }),
+      uninstallGeneration: async () => {
+        await disableGeneration(dshHome, 'generation-plugin')
+        await projectGenerations(dshHome)
+        return true
+      },
+      now: () => new Date('2026-08-29T12:15:00.000Z')
+    })
+
+    expect(result).toMatchObject({ disabled: true, removed: true, pending: false })
+    expect(await readDesired(dshHome)).toEqual([])
+    expect(await listPendingPluginRemovals(dshHome)).toEqual([])
+  })
+})

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -115,6 +115,10 @@ describe('GitHub release contract', () => {
       to: 'icon.png'
     })
     expect(packageJson.build.extraResources).toContainEqual({
+      from: 'build/windows-child-process-hide.mjs',
+      to: 'windows-child-process-hide.mjs'
+    })
+    expect(packageJson.build.extraResources).toContainEqual({
       from: 'build/splash.html',
       to: 'splash.html'
     })


### PR DESCRIPTION
## Summary

- 新增持久化插件卸载账本：先禁用并保留 profile、lockfile 和 patch 备份，再清理插件自有组件及 generation/legacy 包目录。
- 任一清理阶段失败时保持 tombstone，启动前后重复强制禁用；跳过可能重新引入插件的 profile maintenance，并在 Safe Mode 中提供重试。
- Windows 卸载前先停止 Harness，避免已加载目录无法 rename；generation 卸载增加 pointer 与 projection 的完成验证。
- dshmarket 安装和卸载统一使用 workspace-root 语义。
- 将 Windows child_process 隐藏逻辑拆为随包发布的 helper，并同步 Node ESM builtin exports，覆盖 Harness 使用 named import 启动子进程的场景。

## Failure guarantees

- 卸载失败不会重新启用插件。
- 未完成的物理清理不会阻塞 Desktop 启动。
- 隔离备份在正常 web profile 首次成功启动后仍保留，到下一次成功启动才清理；备份清理失败继续保留并记录。

## Validation

- npm run typecheck
- npm test — 75 files, 556 tests passed
- npm run build
- git diff --check

## Validation boundary

- 当前在 macOS 完成源码、单测和构建验证，尚未做真实 Windows 安装包卸载 smoke test；远端 Windows CI 结果需单独确认。
- 插件自有系统组件清理沿用现有能力：macOS LaunchAgent 可清理，Windows 服务或计划任务目前没有通用 ownership contract，因此本 PR 不宣称可自动删除这类外部组件。