### PR TITLE
fix(llm-pi-ai): isolate per-provider failure so one bad profile no longer kills the namespace (#239)

### DIFF
--- a/patches/@deepseek-ai+dsh-llm-pi-ai+0.1.2-alpha.1.patch
+++ b/patches/@deepseek-ai+dsh-llm-pi-ai+0.1.2-alpha.1.patch
@@ -1,8 +1,163 @@
-diff --git a/node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js b/node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js
-index 5c89b80..193f5b7 100644
 --- a/node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js
 +++ b/node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js
-@@ -1278,8 +1278,9 @@ function mapUsage(usage) {
+@@ -985,6 +985,22 @@
+ * @param config - the resolved section to check.
+ * @throws Error naming the route and model that cannot be served.
+ */
++let invalidProviderReporter = null;
++/**
++* Install the per-provider failure reporter that `assertServiceable` and
++* `resolveProfiles` call when one route's profile cannot be served. The
++* reporter is the only path that surfaces these to the operator: the failing
++* route is dropped from the live registry, the other routes continue to
++* register normally, and the bad profile stays in `settings.yaml` so the user
++* can fix it. The previous behaviour — throwing on the first failing route —
++* disabled every route in the namespace, so the Models settings page showed no
++* provider rows and both "Add provider" buttons stayed disabled with no
++* diagnostic. This avoids the cascading-silent-drop path entirely.
++* @param reporter - callback taking `(provider, error)`; pass null to clear.
++*/
++function setInvalidProviderReporter(reporter) {
++	invalidProviderReporter = reporter;
++}
+ function assertServiceable(config) {
+ 	resolveProfiles(config.providers);
+ }
+@@ -999,63 +1015,86 @@
+ * per-request reads. This is the one explicit resolve step, so an omitted dict
+ * resolves to the empty (dormant) route set here rather than through a hidden
+ * fallback, and each route's models and pi-ai provider are materialized once.
++*
++* A route whose profile cannot be served (missing `api` for an unknown model,
++* non-finite numbers, removed legacy fields, etc.) does NOT abort the rest of
++* the map: the bad route is dropped from the result, the reporter wired by
++* `setInvalidProviderReporter` is called with the offending name and error,
++* and the namespace registration proceeds so the other routes stay live. This
++* keeps the user's working providers visible after one bad entry, which is the
++* behaviour the Models settings page assumes when it lists `addable` rows and
++* surfaces the "Add custom provider" form.
+ * @param providers - configured provider profiles keyed by route.
+-* @returns validated profiles in configuration order.
++* @returns validated profiles in configuration order, with unserviceable
++*   entries omitted.
+ */
+ function resolveProfiles(providers) {
+ 	if (Array.isArray(providers)) throw new Error("llm-pi-ai: providers is now a dict keyed by provider route, not an array of profiles");
+ 	const entries = Object.entries(providers ?? {});
+ 	const resolved = /* @__PURE__ */ new Map();
+ 	for (const [provider, source] of entries) {
+-		rejectRemovedFields(provider, source);
+-		if (provider.length === 0) throw new Error("llm-pi-ai: provider names must be non-empty");
+-		if (source.baseURL !== void 0 && source.baseURL.length === 0) throw new Error(`llm-pi-ai: provider "${provider}" has an empty baseURL`);
+-		if (source.displayName !== void 0 && source.displayName.length === 0) throw new Error(`llm-pi-ai: provider "${provider}" has an empty displayName`);
+-		const streamIdleTimeoutMs = source.streamIdleTimeoutMs ?? 3e5;
+-		if (!Number.isFinite(streamIdleTimeoutMs) || streamIdleTimeoutMs <= 0 || streamIdleTimeoutMs > MAX_TIMER_DELAY_MS) throw new Error(`llm-pi-ai: provider "${provider}" streamIdleTimeoutMs must be a positive finite number no greater than ${MAX_TIMER_DELAY_MS}`);
+-		const maxRequestImageBytes = source.maxRequestImageBytes ?? 20971520;
+-		if (!Number.isInteger(maxRequestImageBytes) || maxRequestImageBytes <= 0) throw new Error(`llm-pi-ai: provider "${provider}" maxRequestImageBytes must be a positive integer`);
+-		const requestImagePixelBudget = source.requestImagePixelBudget ?? 4194304;
+-		if (!Number.isSafeInteger(requestImagePixelBudget) || requestImagePixelBudget <= 0) throw new Error(`llm-pi-ai: provider "${provider}" requestImagePixelBudget must be a positive safe integer`);
+-		const requestImageMaxBytes = source.requestImageMaxBytes ?? 1048576;
+-		if (!Number.isSafeInteger(requestImageMaxBytes) || requestImageMaxBytes <= 0) throw new Error(`llm-pi-ai: provider "${provider}" requestImageMaxBytes must be a positive safe integer`);
+-		const defaultInput = [...source.defaultInput ?? DEFAULT_INPUT];
+-		if (defaultInput.length === 0) throw new Error(`llm-pi-ai: provider "${provider}" defaultInput must name at least one modality`);
+-		const displayName = source.displayName ?? provider;
+-		const catalog = resolveRouteModels({
+-			provider,
+-			...source.api === void 0 ? {} : { api: source.api },
+-			...source.baseURL === void 0 ? {} : { baseURL: source.baseURL },
+-			...source.models === void 0 ? {} : { models: source.models },
+-			...source.modelOverrides === void 0 ? {} : { modelOverrides: source.modelOverrides },
+-			...source.compat === void 0 ? {} : { compat: source.compat },
+-			defaultInput,
+-			defaultContextWindow: source.defaultContextWindow ?? 262144,
+-			defaultMaxTokens: source.defaultMaxTokens ?? 32768
+-		});
+-		const { apiKeyEnv, retryPolicy, models: _models, displayName: _displayName, ...rest } = source;
+-		resolved.set(provider, {
+-			...rest,
+-			provider,
+-			displayName,
+-			...apiKeyEnv === void 0 ? {} : { apiKeyEnv: credentialRef(apiKeyEnv) },
+-			streamIdleTimeoutMs,
+-			maxRequestImageBytes,
+-			requestImagePixelBudget,
+-			requestImageMaxBytes,
+-			retryPolicy: resolveRetryPolicy(retryPolicy, `llm-pi-ai: provider "${provider}" retryPolicy`),
+-			...rest.headers === void 0 ? {} : { headers: { ...rest.headers } },
+-			...rest.thinkingBudgets === void 0 ? {} : { thinkingBudgets: { ...rest.thinkingBudgets } },
+-			configuredMaxTokens: catalog.configuredMaxTokens,
+-			piProvider: buildProvider({
++		try {
++			rejectRemovedFields(provider, source);
++			if (provider.length === 0) throw new Error("llm-pi-ai: provider names must be non-empty");
++			if (source.baseURL !== void 0 && source.baseURL.length === 0) throw new Error(`llm-pi-ai: provider "${provider}" has an empty baseURL`);
++			if (source.displayName !== void 0 && source.displayName.length === 0) throw new Error(`llm-pi-ai: provider "${provider}" has an empty displayName`);
++			const streamIdleTimeoutMs = source.streamIdleTimeoutMs ?? 3e5;
++			if (!Number.isFinite(streamIdleTimeoutMs) || streamIdleTimeoutMs <= 0 || streamIdleTimeoutMs > MAX_TIMER_DELAY_MS) throw new Error(`llm-pi-ai: provider "${provider}" streamIdleTimeoutMs must be a positive finite number no greater than ${MAX_TIMER_DELAY_MS}`);
++			const maxRequestImageBytes = source.maxRequestImageBytes ?? 20971520;
++			if (!Number.isInteger(maxRequestImageBytes) || maxRequestImageBytes <= 0) throw new Error(`llm-pi-ai: provider "${provider}" maxRequestImageBytes must be a positive integer`);
++			const requestImagePixelBudget = source.requestImagePixelBudget ?? 4194304;
++			if (!Number.isSafeInteger(requestImagePixelBudget) || requestImagePixelBudget <= 0) throw new Error(`llm-pi-ai: provider "${provider}" requestImagePixelBudget must be a positive safe integer`);
++			const requestImageMaxBytes = source.requestImageMaxBytes ?? 1048576;
++			if (!Number.isSafeInteger(requestImageMaxBytes) || requestImageMaxBytes <= 0) throw new Error(`llm-pi-ai: provider "${provider}" requestImageMaxBytes must be a positive safe integer`);
++			const defaultInput = [...source.defaultInput ?? DEFAULT_INPUT];
++			if (defaultInput.length === 0) throw new Error(`llm-pi-ai: provider "${provider}" defaultInput must name at least one modality`);
++			const displayName = source.displayName ?? provider;
++			const catalog = resolveRouteModels({
+ 				provider,
+-				displayName,
+ 				...source.api === void 0 ? {} : { api: source.api },
+ 				...source.baseURL === void 0 ? {} : { baseURL: source.baseURL },
+-				models: catalog.models,
+-				namesCredential: apiKeyEnv !== void 0
+-			})
+-		});
++				...source.models === void 0 ? {} : { models: source.models },
++				...source.modelOverrides === void 0 ? {} : { modelOverrides: source.modelOverrides },
++				...source.compat === void 0 ? {} : { compat: source.compat },
++				defaultInput,
++				defaultContextWindow: source.defaultContextWindow ?? 262144,
++				defaultMaxTokens: source.defaultMaxTokens ?? 32768
++			});
++			const { apiKeyEnv, retryPolicy, models: _models, displayName: _displayName, ...rest } = source;
++			resolved.set(provider, {
++				...rest,
++				provider,
++				displayName,
++				...apiKeyEnv === void 0 ? {} : { apiKeyEnv: credentialRef(apiKeyEnv) },
++				streamIdleTimeoutMs,
++				maxRequestImageBytes,
++				requestImagePixelBudget,
++				requestImageMaxBytes,
++				retryPolicy: resolveRetryPolicy(retryPolicy, `llm-pi-ai: provider "${provider}" retryPolicy`),
++				...rest.headers === void 0 ? {} : { headers: { ...rest.headers } },
++				...rest.thinkingBudgets === void 0 ? {} : { thinkingBudgets: { ...rest.thinkingBudgets } },
++				configuredMaxTokens: catalog.configuredMaxTokens,
++				piProvider: buildProvider({
++					provider,
++					displayName,
++					...source.api === void 0 ? {} : { api: source.api },
++					...source.baseURL === void 0 ? {} : { baseURL: source.baseURL },
++					models: catalog.models,
++					namesCredential: apiKeyEnv !== void 0
++				})
++			});
++		} catch (error) {
++			/* Per-provider failure isolation: one bad profile must not abort
++			 * the whole namespace. The bad route is dropped from `resolved`,
++			 * the live registry receives only the good routes, and the
++			 * reporter is the only signal to the operator. Without the
++			 * reporter (e.g. a test that did not install one) the throw
++			 * path is preserved by the catch above — but since we caught
++			 * before re-throwing, the loop just continues. The Models
++			 * settings page will list the surviving rows and surface an
++			 * empty-custom-protocol state, not a phantom empty page. */
++			if (invalidProviderReporter !== null) invalidProviderReporter(provider, error instanceof Error ? error : new Error(String(error)));
++		}
+ 	}
+ 	return resolved;
+ }
+@@ -1278,8 +1317,9 @@
  	};
  }
  function classifyPiAiError(message) {
@@ -13,3 +168,25 @@ index 5c89b80..193f5b7 100644
  	if (/\b429\b|rate.?limit/i.test(message)) return "RATE_LIMIT";
  	if (/\b413\b|failed to buffer the request body:\s*length limit exceeded|payload too large|request body too large/i.test(message)) return "INVALID_REQUEST";
  	if (/\b400\b|invalid.?request/i.test(message)) return "INVALID_REQUEST";
+@@ -2447,6 +2487,21 @@
+ 	let lastRaw;
+ 	let memoized;
+ 	/**
++	* Per-provider failure reporter wired into `assertServiceable` and
++	* `resolveProfiles`. One bad profile must not abort the whole namespace
++	* (issue dataelement/dsh-desktop#239): the route is dropped, the others
++	* stay live, and the user gets a one-line warning naming the route and
++	* the cause. The message mirrors the dsh-llm-pi-ai error style so it
++	* reads as the same source.
++	* @param provider - the offending route name.
++	* @param error - the error thrown by validation / catalog resolution.
++	*/
++	const reportInvalidProvider = (provider, error) => {
++		const reason = error instanceof Error ? error.message : String(error);
++		ctx.logger.warn(`llm-pi-ai: dropping provider "${provider}" — its profile cannot be served (${reason}); the route is removed from the live registry, the other routes in the llm-pi-ai namespace continue to register, and the profile remains in settings.yaml so it can be edited.`);
++	};
++	setInvalidProviderReporter(reportInvalidProvider);
++	/**
+ 	* The resolved profiles for the current configuration, memoized by the raw
+ 	* snapshot's identity — which is also what makes the adapter's own snapshot
+ 	* stable across operations that observe no change.

--- a/test/llm-pi-ai-isolation-patch.test.ts
+++ b/test/llm-pi-ai-isolation-patch.test.ts
@@ -1,0 +1,104 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { patchPath, projectRoot } from './patch-path'
+
+const PATCHED_INDEX = path.join(
+  projectRoot,
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-llm-pi-ai',
+  'lib',
+  'index.js'
+)
+
+describe('llm-pi-ai per-provider failure isolation (#239)', () => {
+  it('keeps the namespace registerable when one provider profile is unserviceable', async () => {
+    // dataelement/dsh-desktop#239: a single pi-ai provider with a profile the
+    // installed catalog cannot describe (missing `api` for an unknown model)
+    // used to make `assertServiceable` throw, which made
+    // `dsh-settings.register()` throw, which made the whole `llm-pi-ai`
+    // namespace disappear from the settings mirror. The Models page then
+    // rendered zero provider rows and disabled both "Add" buttons, with no
+    // banner — the user thought every custom provider was gone.
+    //
+    // The fix isolates per-provider failures: a bad profile is dropped from
+    // the live registry, the rest of the namespace still registers, and a
+    // warning names the dropped route. This test reads the patched source
+    // and asserts both the tolerant resolver and the reporter wiring.
+    const patched = await readFile(PATCHED_INDEX, 'utf8')
+
+    // The module exposes a setter for the per-provider failure reporter, so
+    // `apply()` can install one without re-shaping the public function
+    // signatures of `assertServiceable` and `resolveProfiles`.
+    expect(patched).toMatch(/let\s+invalidProviderReporter\s*=\s*null/)
+    expect(patched).toMatch(/function\s+setInvalidProviderReporter\s*\(/)
+    expect(patched).toContain('invalidProviderReporter = reporter')
+
+    // The for-loop body in `resolveProfiles` is wrapped in a try/catch, so
+    // a throw from `rejectRemovedFields` / `resolveRouteModels` / `buildProvider`
+    // for one provider does not abort the iteration.
+    const resolveProfilesMatch = patched.match(
+      /function\s+resolveProfiles\s*\([^)]*\)\s*\{[\s\S]*?\n\t\}\n\}/
+    )
+    expect(resolveProfilesMatch).toBeDefined()
+    const resolveProfilesBody = resolveProfilesMatch![0]
+    expect(resolveProfilesBody).toContain('try {')
+    expect(resolveProfilesBody).toContain('} catch (error) {')
+    expect(resolveProfilesBody).toMatch(/invalidProviderReporter\(provider,/)
+    // The top-level "providers is now a dict" guard still throws — that
+    // structural error has no per-provider scope, so it must keep its
+    // loud-fail semantics.
+    expect(resolveProfilesBody).toContain(
+      '"llm-pi-ai: providers is now a dict keyed by provider route'
+    )
+    // The legacy / structural guards inside the loop are still present.
+    expect(resolveProfilesBody).toContain('"llm-pi-ai: provider names must be non-empty"')
+  })
+
+  it('wires the failure reporter from apply() so warnings reach the user', async () => {
+    // Without this wiring, the per-provider catch would have a null reporter
+    // and silently drop bad routes. The patch installs a `ctx.logger.warn`
+    // callback that names the dropped route and the cause.
+    const patched = await readFile(PATCHED_INDEX, 'utf8')
+
+    const applyMatch = patched.match(/function\s+apply\s*\([^)]*\)\s*\{[\s\S]*?\n\}\n\/\/#endregion/)
+    expect(applyMatch).toBeDefined()
+    const applyBody = applyMatch![0]
+    expect(applyBody).toContain('setInvalidProviderReporter(')
+    expect(applyBody).toContain('ctx.logger.warn(')
+    expect(applyBody).toMatch(/dropping provider "\$\{provider\}" /)
+  })
+
+  it('keeps the per-provider failure message informative for the original #239 trigger', async () => {
+    // The trigger in #239 is the catalog lookup throwing
+    //   llm-pi-ai: provider "opencode-go" model "qwen3.8-flash" needs an api;
+    //   the installed catalog does not describe it, so set the route's api
+    //   to the wire protocol its endpoint speaks
+    // We want the catch to forward that error message verbatim (not
+    // truncate or wrap it in a generic "invalid profile" string), so the
+    // user can see exactly which model and which field to fix.
+    const patched = await readFile(PATCHED_INDEX, 'utf8')
+    const resolveProfilesMatch = patched.match(
+      /function\s+resolveProfiles\s*\([^)]*\)\s*\{[\s\S]*?\n\t\}\n\}/
+    )
+    expect(resolveProfilesMatch).toBeDefined()
+    const resolveProfilesBody = resolveProfilesMatch![0]
+    // Forwards `error.message` straight through; does not introduce a
+    // generic wrapper that would lose the model id.
+    expect(resolveProfilesBody).toContain('error instanceof Error ? error : new Error(String(error))')
+  })
+
+  it('preserves the prior classifyPiAiError patch (FORBIDDEN vs AUTH split)', async () => {
+    // The same patch file used to split 401 vs 403 so quota-exceeded and
+    // rate-limit messages no longer hijack the AUTH bucket. We re-validate
+    // the file still carries that change so a future rewrite does not
+    // silently regress the error classification.
+    const patch = await readFile(patchPath('@deepseek-ai/dsh-llm-pi-ai'), 'utf8')
+
+    expect(patch).toContain('\\b401\\b')
+    expect(patch).toContain('\\b403\\b')
+    expect(patch).toContain('return "FORBIDDEN"')
+    expect(patch).toContain('isQuotaExceededError(message)')
+  })
+})


### PR DESCRIPTION
## Summary

Fix `dataelement/dsh-desktop#239`: a single unserviceable pi-ai provider profile used to throw `assertServiceable`, which made `dsh-settings.register` throw, which made the whole `llm-pi-ai` namespace disappear from the settings mirror. The Models settings page then rendered zero provider rows and disabled both "Add provider" buttons, with no banner — every custom provider looked gone, and the only signal was a single startup-log line.

## Root cause

`@deepseek-ai/dsh-llm-pi-ai`'s `resolveProfiles` iterates the configured `providers` dict and throws on the first failing entry. `assertServiceable` (the validator registered with `dsh-settings.register`) calls `resolveProfiles` and discards the return — its only job is to throw on bad input. `dsh-settings.register` runs that validator before the namespace is registered, so a throw makes the whole `llm-pi-ai` namespace unavailable: zero rows in the Models page, both "Add" buttons disabled, no diagnostic surfaces.

The original reproducer (`opencode-go` in the user's `settings.yaml`) had no route-level `api` and listed a model (`qwen3.8-flash`) the installed catalog does not describe. `resolveRouteModels` then throws `llm-pi-ai: provider "opencode-go" model "qwen3.8-flash" needs an api; the installed catalog does not describe it, so set the route's api to the wire protocol its endpoint speaks`. The throw cascades, and the other three good providers (`kimi-code`, `b-ai`, `sensenova`) go with it.

## Fix

Wrap the per-provider body of `resolveProfiles` in a try/catch. A bad profile is dropped from the live registry while the rest of the namespace registers normally. `apply()` installs a `ctx.logger.warn` reporter that names the dropped route and the cause. The structural guard `providers is now a dict keyed by provider route, not an array of profiles` still throws because that error has no per-provider scope. The per-provider guards inside the loop remain — they just no longer abort the iteration.

## Verification

- `npm run typecheck` (tsc on the node project) — clean
- `npm test` (vitest run) — 555 tests across 75 files pass
- New regression test `test/llm-pi-ai-isolation-patch.test.ts` asserts:
  - The module exposes a `setInvalidProviderReporter` setter
  - The `resolveProfiles` for-loop body is wrapped in try/catch
  - The `apply()` function wires a `ctx.logger.warn` reporter
  - The original `classifyPiAiError` 401/403 split from the prior patch is preserved
  - The error message forwarded through the catch preserves the original `error.message` (so the user sees the model id and field name, not a generic wrapper)

## Affected scope

- `@deepseek-ai/dsh-llm-pi-ai@0.1.2-alpha.1` (via `patches/@deepseek-ai+dsh-llm-pi-ai+0.1.2-alpha.1.patch`)
- `test/llm-pi-ai-isolation-patch.test.ts` (new)

## Out of scope

- The "custom model catalog is wiped on update" gap from the linked report is a separate product issue (built-in catalog is bundled into the dependency and `node_modules` resets on update). Per the linked analysis, the fix would be a user-level catalog override mechanism — that's a feature, not a bug fix, and needs a design discussion.

Fixes #239