### PR TITLE
fix(plugins): remove destructive generation rollback

### DIFF
--- a/packages/dsh-desktop-market-installer/generations/registry.d.ts
+++ b/packages/dsh-desktop-market-installer/generations/registry.d.ts
@@ -12,7 +12,6 @@ export interface RegistryLayout {
   staging: string
   trash: string
   desiredPointer: string
-  lastKnownGoodPointer: string
   lockFile: string
 }
 
@@ -30,10 +29,7 @@ export function writeGenerationMeta(
 ): Promise<void>
 export function listGenerations(dshHome: string): Promise<Generation[]>
 export function readDesired(dshHome: string): Promise<string[]>
-export function readLastKnownGood(dshHome: string): Promise<string[]>
 export function writeDesired(dshHome: string, generationIds: string[]): Promise<void>
-export function commitLastKnownGood(dshHome: string): Promise<void>
-export function revertToLastKnownGood(dshHome: string): Promise<string[]>
 export function disableGeneration(dshHome: string, pluginName: string): Promise<boolean>
 export function isGenerationPlugin(dshHome: string, pluginName: string): Promise<boolean>
 export function resolveEnabledGenerations(dshHome: string): Promise<Map<string, Generation>>

--- a/packages/dsh-desktop-market-installer/generations/registry.mjs
+++ b/packages/dsh-desktop-market-installer/generations/registry.mjs
@@ -14,16 +14,9 @@ import { join } from 'node:path'
  * Windows operation that wedges pnpm: renaming over a directory that already
  * exists.
  *
- * Two pointer files, not one:
- *
- *   desired.json         the generations the user has asked to run
- *   last-known-good.json  the generations that actually booted — committed only
- *                         after Harness reports ready AND the window renders
- *
- * `.install-complete` recorded that a pnpm command exited zero, then got read
- * as "this profile boots". Those are different claims. `desired` carries the
- * first, `last-known-good` the second, and a failed launch falls back to the
- * second rather than to a hash that only ever meant the first.
+ * `desired.json` is the sole authority for the generations the user has asked
+ * to run. A failed launch never rewrites it; recovery requires an explicit,
+ * exact plugin selection so one incompatible plugin cannot remove siblings.
  */
 
 /**
@@ -45,7 +38,6 @@ export function registryLayout(dshHome) {
     staging: join(root, 'staging'),
     trash: join(root, 'trash'),
     desiredPointer: join(root, 'desired.json'),
-    lastKnownGoodPointer: join(root, 'last-known-good.json'),
     lockFile: join(root, '.lock')
   }
 }
@@ -185,29 +177,8 @@ export async function readDesired(dshHome) {
   return readPointer(registryLayout(dshHome).desiredPointer)
 }
 
-export async function readLastKnownGood(dshHome) {
-  return readPointer(registryLayout(dshHome).lastKnownGoodPointer)
-}
-
 export async function writeDesired(dshHome, generationIds) {
   await writePointerAtomically(registryLayout(dshHome).desiredPointer, generationIds)
-}
-
-/**
- * Commit the currently-desired set as known good. Call this only once Harness
- * has reported ready and the main window has rendered — never on a pnpm exit
- * code.
- */
-export async function commitLastKnownGood(dshHome) {
-  const desired = await readDesired(dshHome)
-  await writePointerAtomically(registryLayout(dshHome).lastKnownGoodPointer, desired)
-}
-
-/** Roll `desired` back to the last set that actually booted. */
-export async function revertToLastKnownGood(dshHome) {
-  const lkg = await readLastKnownGood(dshHome)
-  await writeDesired(dshHome, lkg)
-  return lkg
 }
 
 /**
@@ -252,18 +223,13 @@ export async function resolveEnabledGenerations(dshHome) {
   return enabled
 }
 
-/**
- * The generation ids that are safe to physically delete now: nothing in either
- * pointer references them, so no running process could be importing from them
- * once Harness is stopped.
- */
+/** The generation ids not referenced by the authoritative desired pointer. */
 export async function collectUnreferencedGenerations(dshHome) {
-  const [desired, lkg, all] = await Promise.all([
+  const [desired, all] = await Promise.all([
     readDesired(dshHome),
-    readLastKnownGood(dshHome),
     listGenerations(dshHome)
   ])
-  const referenced = new Set([...desired, ...lkg])
+  const referenced = new Set(desired)
   return all.filter((generation) => !referenced.has(generation.id)).map((generation) => generation.id)
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,10 @@ import {
 } from 'electron'
 import { extractFailureCause, HarnessRuntime } from './runtime/harness-runtime'
 import { launchDisclaimedUtilityProcess } from './runtime/disclaimed-utility-process'
-import { installProfileDependenciesWithDsh } from './runtime/profile-plugin-command'
+import {
+  installProfileDependenciesWithDsh,
+  removeProfilePluginWithDsh
+} from './runtime/profile-plugin-command'
 import { clearDamagedPackageDirectories, hasProfile } from './state/profile-repair'
 import {
   clearProfileInstallMarker,
@@ -60,10 +63,7 @@ import {
 } from './state/plugin-recovery'
 import { ensureSafeModeProfile, SAFE_MODE_PROFILE } from './state/safe-mode-profile'
 import {
-  desiredIsUntried,
-  markGenerationsBooted,
   prepareGenerationsForLaunch,
-  rollBackToLastKnownGood,
   uninstallGenerationPlugin
 } from './state/generation-launch'
 import {
@@ -629,11 +629,7 @@ const GPU_STABLE_LAUNCH_DELAY_MS = 60_000
 function markHarnessRendered(): void {
   if (harnessRendered) return
   harnessRendered = true
-  // The window rendered, so whatever plugin generations are enabled boot. This
-  // is the proof `.install-complete` never was — a pnpm exit code said nothing
-  // about whether the profile could start.
   const dshHome = join(app.getPath('userData'), 'harness')
-  void markGenerationsBooted(dshHome, (line) => runtime?.note(line))
   // A migrated profile that rendered a window is confirmed; the pre-upgrade
   // snapshot is no longer needed.
   if (isProfileMigrated(dshHome)) {
@@ -1094,19 +1090,16 @@ function launchHarness(): Promise<void> {
     await auditInstalledLaunchAgents(dshHome)
     await runtime.start(launchDirectory)
 
-    // A new plugin set that did not reach 'ready' is rolled back to the last
-    // set that rendered a window, then Harness is started once more. Reaching
-    // 'ready' is necessary but not sufficient for "known good" — the
-    // window-rendered commit in markHarnessRendered is what confirms it.
+    // A failed launch must not rewrite the user's enabled plugin set. Recovery
+    // and Safe Mode operate on explicit, exact plugin selections; automatically
+    // restoring a stale snapshot can resurrect an incompatible old version or
+    // collapse the whole profile when that snapshot is empty.
     if (runtime.snapshot().phase !== 'ready') {
       // A migration that did not boot rolls the whole profile back to the
       // pre-upgrade snapshot — nothing was lost, and the old shared-tree path
       // runs next launch.
       if (migrated && (await rollBackMigration(dshHome, (line) => runtime.note(line)))) {
         await repairProfilePackages(dshHome)
-        await runtime.start(launchDirectory)
-      } else if (await desiredIsUntried(dshHome).catch(() => false)) {
-        await rollBackToLastKnownGood(dshHome, (line) => runtime.note(line))
         await runtime.start(launchDirectory)
       }
     }

--- a/src/main/state/generation-launch.ts
+++ b/src/main/state/generation-launch.ts
@@ -6,13 +6,9 @@ import {
   resolveProfileDir
 } from '@deepseek-ai/dsh-app-boot'
 import {
-  commitLastKnownGood,
   disableGeneration,
   isGenerationPlugin,
-  readDesired,
-  readLastKnownGood,
   resolveEnabledGenerations,
-  revertToLastKnownGood,
   sweepRegistry
 } from 'dsh-desktop-market-installer/generations/registry'
 import { projectGenerations } from 'dsh-desktop-market-installer/generations/projection'
@@ -71,32 +67,6 @@ export async function prepareGenerationsForLaunch(dshHome: string, note: Note): 
 }
 
 /**
- * Whether `desired` has moved ahead of the set that last booted. A failed
- * launch after this is true is a new generation set that did not work, and the
- * fix is to fall back — not to a hash that only meant "pnpm exited zero".
- */
-export async function desiredIsUntried(dshHome: string): Promise<boolean> {
-  const [desired, lkg] = await Promise.all([readDesired(dshHome), readLastKnownGood(dshHome)])
-  if (desired.length !== lkg.length) return true
-  const known = new Set(lkg)
-  return desired.some((id) => !known.has(id))
-}
-
-/**
- * Roll `desired` back to the last set that rendered a window, reproject, and
- * report it. The caller relaunches Harness once after this.
- */
-export async function rollBackToLastKnownGood(dshHome: string, note: Note): Promise<boolean> {
-  const reverted = await revertToLastKnownGood(dshHome)
-  await projectGenerations(dshHome).catch(() => undefined)
-  note(
-    `[desktop] a new plugin set failed to boot; rolled back to the last working set ` +
-      `(${reverted.length} generation(s))`
-  )
-  return true
-}
-
-/**
  * Uninstall a plugin that is a generation: drop it from `desired` and
  * reproject. Returns false when the plugin is not a generation, so the caller
  * can fall through to the shared-tree `dsh plugin remove`.
@@ -131,24 +101,5 @@ export async function uninstallGenerationPlugin(
         `${error instanceof Error ? error.message : error}`
     )
     return false
-  }
-}
-
-/**
- * Record the currently-desired generation set as known good. Call this only
- * once Harness has reported ready AND the window has rendered — the window is
- * the proof the set works, which `.install-complete` never was.
- */
-export async function markGenerationsBooted(dshHome: string, note: Note): Promise<void> {
-  try {
-    const before = await readLastKnownGood(dshHome)
-    await commitLastKnownGood(dshHome)
-    const after = await readLastKnownGood(dshHome)
-    if (before.length !== after.length || after.some((id) => !before.includes(id))) {
-      note('[desktop] committed the current plugin set as last-known-good')
-    }
-  } catch {
-    // A missing LKG file just means the next failed launch has nothing to roll
-    // back to — not a reason to fault a successful one.
   }
 }

--- a/test/generation-launch.test.ts
+++ b/test/generation-launch.test.ts
@@ -4,16 +4,11 @@ import { join } from 'node:path'
 import { PROFILE_TEMPLATES } from '@deepseek-ai/dsh-app-boot'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
-  desiredIsUntried,
-  markGenerationsBooted,
-  prepareGenerationsForLaunch,
-  rollBackToLastKnownGood
+  prepareGenerationsForLaunch
 } from '../src/main/state/generation-launch'
 import {
-  commitLastKnownGood,
   ensureRegistryDirectories,
   readDesired,
-  readLastKnownGood,
   registryLayout,
   writeDesired,
   writeGenerationMeta
@@ -75,9 +70,14 @@ describe('the launch-process half of the generation model', () => {
   it('is a no-op on a profile that has never used a generation', async () => {
     const home = await freshHome()
     await expect(prepareGenerationsForLaunch(home, silent)).resolves.toBeUndefined()
-    expect(await desiredIsUntried(home)).toBe(false)
-    await markGenerationsBooted(home, silent)
-    expect(await readLastKnownGood(home)).toEqual([])
+    expect(await readDesired(home)).toEqual([])
+  })
+
+  it('does not wire failed Harness startup to a generation-set rollback', async () => {
+    const main = await readFile('src/main/index.ts', 'utf8')
+    expect(main).not.toContain('rollBackToLastKnownGood')
+    expect(main).not.toContain('desiredIsUntried')
+    expect(main).toContain("A failed launch must not rewrite the user's enabled plugin set")
   })
 
   it('sweeps an unreferenced generation and projects the desired one on launch', async () => {
@@ -99,43 +99,23 @@ describe('the launch-process half of the generation model', () => {
     expect(manifest.dsh.profile.bundles).toContain('keeper')
   })
 
-  it('detects when desired has moved ahead of last-known-good', async () => {
+  it('does not retain or restore generations from a stale rollback pointer', async () => {
     const home = await freshHome()
     await ensureRegistryDirectories(home)
-    await writeDesired(home, ['a+1+x'])
-    await commitLastKnownGood(home)
-    expect(await desiredIsUntried(home)).toBe(false)
+    await fakeGeneration(home, 'keep+1+x', 'keeper')
+    await fakeGeneration(home, 'old+1+y', 'old-plugin')
+    await writeDesired(home, ['keep+1+x'])
+    await writeFile(
+      join(registryLayout(home).root, 'last-known-good.json'),
+      `${JSON.stringify(['old+1+y'])}\n`,
+      'utf8'
+    )
 
-    await writeDesired(home, ['a+1+x', 'b+2+y'])
-    expect(await desiredIsUntried(home)).toBe(true)
-  })
-
-  it('rolls desired back to last-known-good and reprojects', async () => {
-    const home = await freshHome()
-    await ensureRegistryDirectories(home)
-    await fakeGeneration(home, 'good+1+x', 'good')
-    await writeDesired(home, ['good+1+x'])
-    await commitLastKnownGood(home)
     await prepareGenerationsForLaunch(home, silent)
 
-    // a new plugin is desired but its generation is broken/missing
-    await writeDesired(home, ['good+1+x', 'broken+2+y'])
-    await rollBackToLastKnownGood(home, silent)
-
-    expect(await readDesired(home)).toEqual(['good+1+x'])
-    const manifest = JSON.parse(await readFile(join(home, 'profiles', 'web', 'package.json'), 'utf8'))
-    expect(manifest.dsh.profile.bundles).toEqual([
-      '@deepseek-ai/dsh-base',
-      '@deepseek-ai/dsh-web-app',
-      'good'
-    ])
-  })
-
-  it('commits last-known-good from the current desired set', async () => {
-    const home = await freshHome()
-    await ensureRegistryDirectories(home)
-    await writeDesired(home, ['x+1+a', 'y+2+b'])
-    await markGenerationsBooted(home, silent)
-    expect(await readLastKnownGood(home)).toEqual(['x+1+a', 'y+2+b'])
+    const { existsSync } = await import('node:fs')
+    expect(await readDesired(home)).toEqual(['keep+1+x'])
+    expect(existsSync(join(registryLayout(home).generations, 'old+1+y'))).toBe(false)
+    expect(existsSync(join(registryLayout(home).generations, 'keep+1+x'))).toBe(true)
   })
 })

--- a/test/generation-registry.test.ts
+++ b/test/generation-registry.test.ts
@@ -6,15 +6,12 @@ import {
   collectUnreferencedGenerations,
   disableGeneration,
   isGenerationPlugin,
-  commitLastKnownGood,
   ensureRegistryDirectories,
   generationId,
   listGenerations,
   readDesired,
-  readLastKnownGood,
   registryLayout,
   resolveEnabledGenerations,
-  revertToLastKnownGood,
   sweepRegistry,
   withRegistryLock,
   writeDesired,
@@ -61,11 +58,10 @@ describe('the plugin generation registry', () => {
     expect(generationId('name', '2.0.1', 'same')).toBe(generationId('name', '2.0.1', 'same'))
   })
 
-  it('starts with empty pointers and no generations', async () => {
+  it('starts with an empty desired pointer and no generations', async () => {
     const home = await freshHome()
     await ensureRegistryDirectories(home)
     expect(await readDesired(home)).toEqual([])
-    expect(await readLastKnownGood(home)).toEqual([])
     expect(await listGenerations(home)).toEqual([])
   })
 
@@ -84,37 +80,21 @@ describe('the plugin generation registry', () => {
     expect(enabled.has('@linxin666/dsh-pet')).toBe(false)
   })
 
-  it('commits last-known-good from desired, never the other way round', async () => {
-    const home = await freshHome()
-    await ensureRegistryDirectories(home)
-
-    await writeDesired(home, ['a+1+x'])
-    await commitLastKnownGood(home)
-    expect(await readLastKnownGood(home)).toEqual(['a+1+x'])
-
-    // A new install moves desired forward but not LKG.
-    await writeDesired(home, ['a+1+x', 'b+2+y'])
-    expect(await readLastKnownGood(home)).toEqual(['a+1+x'])
-
-    // A failed launch reverts desired to the set that booted.
-    const reverted = await revertToLastKnownGood(home)
-    expect(reverted).toEqual(['a+1+x'])
-    expect(await readDesired(home)).toEqual(['a+1+x'])
-  })
-
-  it('treats a generation as unreferenced only when neither pointer names it', async () => {
+  it('treats desired as the sole authority for generation retention', async () => {
     const home = await freshHome()
     await ensureRegistryDirectories(home)
     await fakeGeneration(home, 'a+1+x', 'a', '1')
     await fakeGeneration(home, 'b+2+y', 'b', '2')
     await fakeGeneration(home, 'c+3+z', 'c', '3')
 
-    await writeDesired(home, ['a+1+x'])
-    await commitLastKnownGood(home)
     await writeDesired(home, ['b+2+y'])
-    // a is still LKG, b is desired, c is neither.
+    await writeFile(
+      join(registryLayout(home).root, 'last-known-good.json'),
+      `${JSON.stringify(['a+1+x'])}\n`,
+      'utf8'
+    )
 
-    expect(await collectUnreferencedGenerations(home)).toEqual(['c+3+z'])
+    expect((await collectUnreferencedGenerations(home)).sort()).toEqual(['a+1+x', 'c+3+z'])
   })
 
   it('sweeps unreferenced generations and staging leftovers, keeps referenced ones', async () => {

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -380,6 +380,6 @@ describe('desktop plugin market installer', () => {
     expect(client).toContain("typeof bridge.uninstallMarket === 'function'")
     expect(main).toContain("ipcMain.handle('market:uninstall'")
     expect(main).toContain("await runtime.stop()")
-    expect(main).toContain("'dshmarket',\n    true")
+    expect(main).toMatch(/'dshmarket',\s+true/u)
   })
 })


### PR DESCRIPTION
## 问题
安全模式精确卸载一个插件后，后续 Harness 启动超时会把 generation 集合自动回滚到陈旧或空的 last-known-good，导致旧版插件复活，甚至清空全部第三方插件。

## 修复
- 移除启动失败时自动改写 generation desired 集合的回滚路径
- 以 desired.json 作为唯一启用集合
- 忽略历史 last-known-good 指针对插件保留与恢复的影响
- 修复 PR #236/#237 合并后遗漏的 removeProfilePluginWithDsh import
- 增加旧指针不得恢复旧插件的回归测试

## 验证
- npm test -- --run（75 files / 555 tests）
- npm run typecheck
- npm run build
- npx patch-package --error-on-fail