### PR TITLE
feat: add OrcaRouter as a first-class model provider

### DIFF
--- a/patches/@deepseek-ai+dsh-client-ui-settings-models+0.1.2-alpha.1.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-settings-models+0.1.2-alpha.1.patch
@@ -581,7 +581,7 @@ index a7689db..ee4304f 100644
  					})
  				]
  			});
-@@ -1821,6 +2113,26 @@ window.__ModuleLoader__.load({
+@@ -1821,6 +2113,27 @@ window.__ModuleLoader__.load({
  		function providerCopy(template, target) {
  			return template.replace("{provider}", () => providerTargetLabel(target));
  		}
@@ -593,6 +593,7 @@ index a7689db..ee4304f 100644
 +			"anthropic",
 +			"google",
 +			"openrouter",
++			"orcarouter",
 +			"xai",
 +			"moonshotai-cn",
 +			"moonshotai",
@@ -731,7 +732,7 @@ index a7689db..ee4304f 100644
  		const tagId$1 = "@deepseek-ai/dsh-client-ui-settings-models/DeepSeekOnboardingDialog.module.css";
  		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId$1) + "]") === null) {
  			const tag = document.createElement("style");
-@@ -2258,35 +2622,50 @@ window.__ModuleLoader__.load({
+@@ -2258,35 +2622,51 @@ window.__ModuleLoader__.load({
  		function assertNever$1(_value) {
  			throw new Error("unexpected DeepSeek onboarding state");
  		}
@@ -742,6 +743,7 @@ index a7689db..ee4304f 100644
 +			{ provider: "anthropic", displayName: "Anthropic", kind: "onboardingManufacturer" },
 +			{ provider: "google", displayName: "Google Gemini", kind: "onboardingManufacturer" },
 +			{ provider: "openrouter", displayName: "OpenRouter", kind: "onboardingAggregator" },
++			{ provider: "orcarouter", displayName: "OrcaRouter", kind: "onboardingAggregator" },
 +			{ provider: "xai", displayName: "xAI", kind: "onboardingManufacturer" },
 +			{ provider: "moonshotai-cn", displayName: "Moonshot / Kimi", kind: "onboardingManufacturer" },
 +			{ provider: "minimax-cn", displayName: "MiniMax", kind: "onboardingManufacturer" },

--- a/patches/@earendil-works+pi-ai+0.84.3.patch
+++ b/patches/@earendil-works+pi-ai+0.84.3.patch
@@ -1,0 +1,3852 @@
+diff --git a/node_modules/@earendil-works/pi-ai/dist/models.generated.d.ts b/node_modules/@earendil-works/pi-ai/dist/models.generated.d.ts
+index 60a5253..d88873a 100644
+--- a/node_modules/@earendil-works/pi-ai/dist/models.generated.d.ts
++++ b/node_modules/@earendil-works/pi-ai/dist/models.generated.d.ts
+@@ -25,6 +25,7 @@ import { OPENAI_CODEX_MODELS } from "./providers/openai-codex.models.ts";
+ import { OPENCODE_MODELS } from "./providers/opencode.models.ts";
+ import { OPENCODE_GO_MODELS } from "./providers/opencode-go.models.ts";
+ import { OPENROUTER_MODELS } from "./providers/openrouter.models.ts";
++import { ORCAROUTER_MODELS } from "./providers/orcarouter.models.ts";
+ import { QWEN_TOKEN_PLAN_MODELS } from "./providers/qwen-token-plan.models.ts";
+ import { QWEN_TOKEN_PLAN_CN_MODELS } from "./providers/qwen-token-plan-cn.models.ts";
+ import { QWEN_TOKEN_PLAN_INDIVIDUAL_MODELS } from "./providers/qwen-token-plan-individual.models.ts";
+@@ -65,6 +66,7 @@ export declare const MODELS: {
+     readonly "opencode": typeof OPENCODE_MODELS;
+     readonly "opencode-go": typeof OPENCODE_GO_MODELS;
+     readonly "openrouter": typeof OPENROUTER_MODELS;
++    readonly "orcarouter": typeof ORCAROUTER_MODELS;
+     readonly "qwen-token-plan": typeof QWEN_TOKEN_PLAN_MODELS;
+     readonly "qwen-token-plan-cn": typeof QWEN_TOKEN_PLAN_CN_MODELS;
+     readonly "qwen-token-plan-individual": typeof QWEN_TOKEN_PLAN_INDIVIDUAL_MODELS;
+diff --git a/node_modules/@earendil-works/pi-ai/dist/models.generated.js b/node_modules/@earendil-works/pi-ai/dist/models.generated.js
+index c494a8d..7226634 100644
+--- a/node_modules/@earendil-works/pi-ai/dist/models.generated.js
++++ b/node_modules/@earendil-works/pi-ai/dist/models.generated.js
+@@ -27,6 +27,7 @@ import { OPENAI_CODEX_MODELS } from "./providers/openai-codex.models.js";
+ import { OPENCODE_MODELS } from "./providers/opencode.models.js";
+ import { OPENCODE_GO_MODELS } from "./providers/opencode-go.models.js";
+ import { OPENROUTER_MODELS } from "./providers/openrouter.models.js";
++import { ORCAROUTER_MODELS } from "./providers/orcarouter.models.js";
+ import { QWEN_TOKEN_PLAN_MODELS } from "./providers/qwen-token-plan.models.js";
+ import { QWEN_TOKEN_PLAN_CN_MODELS } from "./providers/qwen-token-plan-cn.models.js";
+ import { QWEN_TOKEN_PLAN_INDIVIDUAL_MODELS } from "./providers/qwen-token-plan-individual.models.js";
+@@ -67,6 +68,7 @@ export const MODELS = {
+     "opencode": OPENCODE_MODELS,
+     "opencode-go": OPENCODE_GO_MODELS,
+     "openrouter": OPENROUTER_MODELS,
++    "orcarouter": ORCAROUTER_MODELS,
+     "qwen-token-plan": QWEN_TOKEN_PLAN_MODELS,
+     "qwen-token-plan-cn": QWEN_TOKEN_PLAN_CN_MODELS,
+     "qwen-token-plan-individual": QWEN_TOKEN_PLAN_INDIVIDUAL_MODELS,
+diff --git a/node_modules/@earendil-works/pi-ai/dist/providers/all.js b/node_modules/@earendil-works/pi-ai/dist/providers/all.js
+index a61cde8..a63af23 100644
+--- a/node_modules/@earendil-works/pi-ai/dist/providers/all.js
++++ b/node_modules/@earendil-works/pi-ai/dist/providers/all.js
+@@ -30,6 +30,7 @@ import { opencodeProvider } from "./opencode.js";
+ import { opencodeGoProvider } from "./opencode-go.js";
+ import { openrouterProvider } from "./openrouter.js";
+ import { openrouterImagesProvider } from "./openrouter-images.js";
++import { orcarouterProvider } from "./orcarouter.js";
+ import { qwenTokenPlanProvider } from "./qwen-token-plan.js";
+ import { qwenTokenPlanCnProvider } from "./qwen-token-plan-cn.js";
+ import { qwenTokenPlanIndividualProvider } from "./qwen-token-plan-individual.js";
+@@ -93,6 +94,7 @@ export function builtinProviders() {
+         opencodeProvider(),
+         opencodeGoProvider(),
+         openrouterProvider(),
++        orcarouterProvider(),
+         qwenTokenPlanProvider(),
+         qwenTokenPlanCnProvider(),
+         qwenTokenPlanIndividualProvider(),
+diff --git a/node_modules/@earendil-works/pi-ai/dist/providers/data/orcarouter.json b/node_modules/@earendil-works/pi-ai/dist/providers/data/orcarouter.json
+new file mode 100644
+index 0000000..3c0491b
+--- /dev/null
++++ b/node_modules/@earendil-works/pi-ai/dist/providers/data/orcarouter.json
+@@ -0,0 +1,3726 @@
++{
++ "openai-completions": {
++  "orcarouter/free": {
++   "id": "orcarouter/free",
++   "name": "orcarouter/free",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "orcarouter/fusion": {
++   "id": "orcarouter/fusion",
++   "name": "orcarouter/fusion",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "orcarouter/fusion-flash": {
++   "id": "orcarouter/fusion-flash",
++   "name": "orcarouter/fusion-flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 200000,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "orcarouter/fusion-mini": {
++   "id": "orcarouter/fusion-mini",
++   "name": "orcarouter/fusion-mini",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "orcarouter/orcacode-review": {
++   "id": "orcarouter/orcacode-review",
++   "name": "orcarouter/orcacode-review",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "orcarouter/open-code": {
++   "id": "orcarouter/open-code",
++   "name": "orcarouter/open-code",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "orcarouter/auto": {
++   "id": "orcarouter/auto",
++   "name": "orcarouter/auto",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-fable-5": {
++   "id": "anthropic/claude-fable-5",
++   "name": "Anthropic: Claude Fable 5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 10.0,
++    "output": 50.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-haiku-4.5": {
++   "id": "anthropic/claude-haiku-4.5",
++   "name": "Anthropic: Claude Haiku 4.5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.0,
++    "output": 5.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 200000,
++   "maxTokens": 64000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-opus-4.5": {
++   "id": "anthropic/claude-opus-4.5",
++   "name": "Anthropic: Claude Opus 4.5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 5.0,
++    "output": 25.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 200000,
++   "maxTokens": 64000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-opus-4.6": {
++   "id": "anthropic/claude-opus-4.6",
++   "name": "Anthropic: Claude Opus 4.6",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 5.0,
++    "output": 25.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-opus-4.7": {
++   "id": "anthropic/claude-opus-4.7",
++   "name": "Anthropic: Claude Opus 4.7",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 5.0,
++    "output": 25.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-opus-4.8": {
++   "id": "anthropic/claude-opus-4.8",
++   "name": "Anthropic: Claude Opus 4.8",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 5.0,
++    "output": 25.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-opus-5": {
++   "id": "anthropic/claude-opus-5",
++   "name": "Anthropic: Claude Opus 5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 5.0,
++    "output": 25.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-sonnet-4.5": {
++   "id": "anthropic/claude-sonnet-4.5",
++   "name": "Anthropic: Claude Sonnet 4.5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 3.0,
++    "output": 15.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 64000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-sonnet-4.6": {
++   "id": "anthropic/claude-sonnet-4.6",
++   "name": "Anthropic: Claude Sonnet 4.6",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 3.0,
++    "output": 15.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 64000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "anthropic/claude-sonnet-5": {
++   "id": "anthropic/claude-sonnet-5",
++   "name": "Anthropic: Claude Sonnet 5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.0,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "deepseek/deepseek-chat": {
++   "id": "deepseek/deepseek-chat",
++   "name": "DeepSeek: DeepSeek V3",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.147,
++    "output": 0.295,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 384000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "deepseek/deepseek-reasoner": {
++   "id": "deepseek/deepseek-reasoner",
++   "name": "deepseek/deepseek-reasoner",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.147,
++    "output": 0.295,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 384000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "deepseek/deepseek-v4-flash": {
++   "id": "deepseek/deepseek-v4-flash",
++   "name": "DeepSeek: DeepSeek V4 Flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.147,
++    "output": 0.295,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 384000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "deepseek/deepseek-v4-flash-0731": {
++   "id": "deepseek/deepseek-v4-flash-0731",
++   "name": "DeepSeek: DeepSeek V4 Flash 0731",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.147,
++    "output": 0.295,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 384000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "deepseek/deepseek-v4-flash-vision-exp": {
++   "id": "deepseek/deepseek-v4-flash-vision-exp",
++   "name": "DeepSeek: DeepSeek V4 Flash Vision (Exp)",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.147,
++    "output": 0.295,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 384000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "deepseek/deepseek-v4-pro": {
++   "id": "deepseek/deepseek-v4-pro",
++   "name": "DeepSeek: DeepSeek V4 Pro",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.442,
++    "output": 0.884,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 384000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "deepseek/deepseek-v4-pro-0813": {
++   "id": "deepseek/deepseek-v4-pro-0813",
++   "name": "DeepSeek: DeepSeek V4 Pro 0813",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.442,
++    "output": 0.884,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 384000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-2.5-flash": {
++   "id": "google/gemini-2.5-flash",
++   "name": "Google: Gemini 2.5 Flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.3,
++    "output": 2.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-2.5-flash-lite": {
++   "id": "google/gemini-2.5-flash-lite",
++   "name": "Google: Gemini 2.5 Flash Lite",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.1,
++    "output": 0.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-2.5-flash-preview-tts": {
++   "id": "google/gemini-2.5-flash-preview-tts",
++   "name": "google/gemini-2.5-flash-preview-tts",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.5,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-2.5-pro": {
++   "id": "google/gemini-2.5-pro",
++   "name": "Google: Gemini 2.5 Pro",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.5,
++    "output": 15.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-2.5-pro-preview-tts": {
++   "id": "google/gemini-2.5-pro-preview-tts",
++   "name": "google/gemini-2.5-pro-preview-tts",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 1.0,
++    "output": 20.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-3-flash-preview": {
++   "id": "google/gemini-3-flash-preview",
++   "name": "Google: Gemini 3 Flash Preview",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.5,
++    "output": 3.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-3.1-flash-lite-preview": {
++   "id": "google/gemini-3.1-flash-lite-preview",
++   "name": "Google: Gemini 3.1 Flash Lite Preview",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.25,
++    "output": 1.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-3.1-flash-tts-preview": {
++   "id": "google/gemini-3.1-flash-tts-preview",
++   "name": "google/gemini-3.1-flash-tts-preview",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 1.0,
++    "output": 20.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-3.1-pro-preview": {
++   "id": "google/gemini-3.1-pro-preview",
++   "name": "Google: Gemini 3.1 Pro Preview",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.0,
++    "output": 12.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-3.1-pro-preview-customtools": {
++   "id": "google/gemini-3.1-pro-preview-customtools",
++   "name": "Google: Gemini 3.1 Pro Preview Custom Tools",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 4.0,
++    "output": 18.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-3.5-flash": {
++   "id": "google/gemini-3.5-flash",
++   "name": "Gemini 3.5 Flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.5,
++    "output": 9.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-3.5-flash-lite": {
++   "id": "google/gemini-3.5-flash-lite",
++   "name": "Google: Gemini 3.5 Flash-Lite",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.3,
++    "output": 2.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-3.6-flash": {
++   "id": "google/gemini-3.6-flash",
++   "name": "Google: Gemini 3.6 Flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.5,
++    "output": 7.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-flash-latest": {
++   "id": "google/gemini-flash-latest",
++   "name": "google/gemini-flash-latest",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.5,
++    "output": 3.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-flash-lite-latest": {
++   "id": "google/gemini-flash-lite-latest",
++   "name": "google/gemini-flash-lite-latest",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.25,
++    "output": 1.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-pro-latest": {
++   "id": "google/gemini-pro-latest",
++   "name": "google/gemini-pro-latest",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 4.0,
++    "output": 18.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemini-robotics-er-1.6-preview": {
++   "id": "google/gemini-robotics-er-1.6-preview",
++   "name": "google/gemini-robotics-er-1.6-preview",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.0,
++    "output": 5.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "google/gemma-4-26b-a4b-it": {
++   "id": "google/gemma-4-26b-a4b-it",
++   "name": "Google: Gemma 4 26B A4B ",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.06,
++    "output": 0.33,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "gpt-5.6-luna": {
++   "id": "gpt-5.6-luna",
++   "name": "gpt-5.6-luna",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.2,
++    "output": 1.6,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1050000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "grok/grok-4.3": {
++   "id": "grok/grok-4.3",
++   "name": "grok/grok-4.3",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 2.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "grok/grok-4.5": {
++   "id": "grok/grok-4.5",
++   "name": "xAI: Grok 4.5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.0,
++    "output": 6.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 500000,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "grok/grok-4.6": {
++   "id": "grok/grok-4.6",
++   "name": "SpaceXAI: Grok 4.6",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.0,
++    "output": 6.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 500000,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "kimi/kimi-k2.5": {
++   "id": "kimi/kimi-k2.5",
++   "name": "kimi/kimi-k2.5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.6,
++    "output": 3.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "kimi/kimi-k2.6": {
++   "id": "kimi/kimi-k2.6",
++   "name": "kimi/kimi-k2.6",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.95,
++    "output": 4.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "kimi/kimi-k2.7-code": {
++   "id": "kimi/kimi-k2.7-code",
++   "name": "MoonshotAI: Kimi K2.7 Code",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.95,
++    "output": 4.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 262144,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "kimi/kimi-k3": {
++   "id": "kimi/kimi-k3",
++   "name": "MoonshotAI: Kimi K3",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 3.0,
++    "output": 15.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "meta/muse-spark-1.1": {
++   "id": "meta/muse-spark-1.1",
++   "name": "Meta: Muse Spark 1.1",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 4.25,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "meta/muse-spark-1.2": {
++   "id": "meta/muse-spark-1.2",
++   "name": "Meta: Muse Spark 1.2",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 4.25,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "minimax/minimax-m2.5": {
++   "id": "minimax/minimax-m2.5",
++   "name": "MiniMax: MiniMax M2.5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.3,
++    "output": 1.2,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 204800,
++   "maxTokens": 2048,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "minimax/minimax-m2.5-highspeed": {
++   "id": "minimax/minimax-m2.5-highspeed",
++   "name": "MiniMax M2.5 highspeed",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.6,
++    "output": 2.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 204800,
++   "maxTokens": 2048,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "minimax/minimax-m2.7": {
++   "id": "minimax/minimax-m2.7",
++   "name": "MiniMax: MiniMax M2.7",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.3,
++    "output": 1.2,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 204800,
++   "maxTokens": 2048,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "minimax/minimax-m2.7-highspeed": {
++   "id": "minimax/minimax-m2.7-highspeed",
++   "name": "MiniMax M2.7 highspeed",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.6,
++    "output": 2.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 204800,
++   "maxTokens": 2048,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "minimax/minimax-m3": {
++   "id": "minimax/minimax-m3",
++   "name": "MiniMax: MiniMax M3",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.3,
++    "output": 1.2,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 512000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "obsidian/gemma-4-26B-A4B": {
++   "id": "obsidian/gemma-4-26B-A4B",
++   "name": "Gemma4 26B A4B Uncensored (Balanced)",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.25,
++    "output": 2.9,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "obsidian/Qwen3.6-35B-A3B": {
++   "id": "obsidian/Qwen3.6-35B-A3B",
++   "name": "Qwen3.6 35B A3B Uncensored (Aggressive)",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.31,
++    "output": 4.21,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "obsidian/Qwen3.8-27B": {
++   "id": "obsidian/Qwen3.8-27B",
++   "name": "Qwen3.8 27B",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.4,
++    "output": 4.21,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-3.5-turbo": {
++   "id": "openai/gpt-3.5-turbo",
++   "name": "OpenAI: GPT-3.5 Turbo",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.5,
++    "output": 1.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 16385,
++   "maxTokens": 4096,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-3.5-turbo-0125": {
++   "id": "openai/gpt-3.5-turbo-0125",
++   "name": "openai/gpt-3.5-turbo-0125",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.5,
++    "output": 1.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 4096,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-3.5-turbo-1106": {
++   "id": "openai/gpt-3.5-turbo-1106",
++   "name": "openai/gpt-3.5-turbo-1106",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 1.0,
++    "output": 2.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 4096,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-3.5-turbo-16k": {
++   "id": "openai/gpt-3.5-turbo-16k",
++   "name": "OpenAI: GPT-3.5 Turbo 16k",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 3.0,
++    "output": 4.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 16385,
++   "maxTokens": 4096,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4": {
++   "id": "openai/gpt-4",
++   "name": "OpenAI: GPT-4",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 30.0,
++    "output": 60.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 8191,
++   "maxTokens": 8192,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4-0613": {
++   "id": "openai/gpt-4-0613",
++   "name": "openai/gpt-4-0613",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 30.0,
++    "output": 60.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 8192,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4-turbo": {
++   "id": "openai/gpt-4-turbo",
++   "name": "OpenAI: GPT-4 Turbo",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 10.0,
++    "output": 30.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 4096,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4-turbo-2024-04-09": {
++   "id": "openai/gpt-4-turbo-2024-04-09",
++   "name": "openai/gpt-4-turbo-2024-04-09",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 10.0,
++    "output": 30.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 4096,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4.1": {
++   "id": "openai/gpt-4.1",
++   "name": "OpenAI: GPT-4.1",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.0,
++    "output": 8.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1047576,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4.1-2025-04-14": {
++   "id": "openai/gpt-4.1-2025-04-14",
++   "name": "openai/gpt-4.1-2025-04-14",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.0,
++    "output": 8.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1047576,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4.1-mini": {
++   "id": "openai/gpt-4.1-mini",
++   "name": "OpenAI: GPT-4.1 Mini",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.4,
++    "output": 1.6,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1047576,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4.1-mini-2025-04-14": {
++   "id": "openai/gpt-4.1-mini-2025-04-14",
++   "name": "openai/gpt-4.1-mini-2025-04-14",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.4,
++    "output": 1.6,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1047576,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4.1-nano": {
++   "id": "openai/gpt-4.1-nano",
++   "name": "OpenAI: GPT-4.1 Nano",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.1,
++    "output": 0.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1047576,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4.1-nano-2025-04-14": {
++   "id": "openai/gpt-4.1-nano-2025-04-14",
++   "name": "openai/gpt-4.1-nano-2025-04-14",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.1,
++    "output": 0.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1047576,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4o": {
++   "id": "openai/gpt-4o",
++   "name": "OpenAI: GPT-4o",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.5,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 16384,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4o-2024-05-13": {
++   "id": "openai/gpt-4o-2024-05-13",
++   "name": "OpenAI: GPT-4o (2024-05-13)",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 5.0,
++    "output": 15.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 16384,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4o-2024-08-06": {
++   "id": "openai/gpt-4o-2024-08-06",
++   "name": "OpenAI: GPT-4o (2024-08-06)",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.5,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 16384,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4o-2024-11-20": {
++   "id": "openai/gpt-4o-2024-11-20",
++   "name": "OpenAI: GPT-4o (2024-11-20)",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.5,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 16384,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4o-mini": {
++   "id": "openai/gpt-4o-mini",
++   "name": "OpenAI: GPT-4o-mini",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.15,
++    "output": 0.6,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 16384,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4o-mini-2024-07-18": {
++   "id": "openai/gpt-4o-mini-2024-07-18",
++   "name": "OpenAI: GPT-4o-mini (2024-07-18)",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.15,
++    "output": 0.6,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 16384,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4o-mini-tts": {
++   "id": "openai/gpt-4o-mini-tts",
++   "name": "openai/gpt-4o-mini-tts",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.6,
++    "output": 12.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4o-mini-tts-2025-03-20": {
++   "id": "openai/gpt-4o-mini-tts-2025-03-20",
++   "name": "openai/gpt-4o-mini-tts-2025-03-20",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.6,
++    "output": 12.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-4o-mini-tts-2025-12-15": {
++   "id": "openai/gpt-4o-mini-tts-2025-12-15",
++   "name": "openai/gpt-4o-mini-tts-2025-12-15",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.6,
++    "output": 12.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5": {
++   "id": "openai/gpt-5",
++   "name": "OpenAI: GPT-5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-2025-08-07": {
++   "id": "openai/gpt-5-2025-08-07",
++   "name": "openai/gpt-5-2025-08-07",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-chat-latest": {
++   "id": "openai/gpt-5-chat-latest",
++   "name": "openai/gpt-5-chat-latest",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 100000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-mini": {
++   "id": "openai/gpt-5-mini",
++   "name": "OpenAI: GPT-5 Mini",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.25,
++    "output": 2.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-mini-2025-08-07": {
++   "id": "openai/gpt-5-mini-2025-08-07",
++   "name": "openai/gpt-5-mini-2025-08-07",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.25,
++    "output": 2.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-nano": {
++   "id": "openai/gpt-5-nano",
++   "name": "OpenAI: GPT-5 Nano",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.05,
++    "output": 0.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-nano-2025-08-07": {
++   "id": "openai/gpt-5-nano-2025-08-07",
++   "name": "openai/gpt-5-nano-2025-08-07",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.05,
++    "output": 0.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-pro": {
++   "id": "openai/gpt-5-pro",
++   "name": "OpenAI: GPT-5 Pro",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 15.0,
++    "output": 120.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 272000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-pro-2025-10-06": {
++   "id": "openai/gpt-5-pro-2025-10-06",
++   "name": "openai/gpt-5-pro-2025-10-06",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 15.0,
++    "output": 120.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 272000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-search-api": {
++   "id": "openai/gpt-5-search-api",
++   "name": "openai/gpt-5-search-api",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5-search-api-2025-10-14": {
++   "id": "openai/gpt-5-search-api-2025-10-14",
++   "name": "openai/gpt-5-search-api-2025-10-14",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.1": {
++   "id": "openai/gpt-5.1",
++   "name": "OpenAI: GPT-5.1",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.1-2025-11-13": {
++   "id": "openai/gpt-5.1-2025-11-13",
++   "name": "openai/gpt-5.1-2025-11-13",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.1-chat-latest": {
++   "id": "openai/gpt-5.1-chat-latest",
++   "name": "openai/gpt-5.1-chat-latest",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 16384,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.1-codex": {
++   "id": "openai/gpt-5.1-codex",
++   "name": "OpenAI: GPT-5.1-Codex",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 10.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.1-codex-mini": {
++   "id": "openai/gpt-5.1-codex-mini",
++   "name": "OpenAI: GPT-5.1-Codex-Mini",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.25,
++    "output": 2.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.2": {
++   "id": "openai/gpt-5.2",
++   "name": "OpenAI: GPT-5.2",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.75,
++    "output": 14.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.2-2025-12-11": {
++   "id": "openai/gpt-5.2-2025-12-11",
++   "name": "openai/gpt-5.2-2025-12-11",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.75,
++    "output": 14.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.2-chat-latest": {
++   "id": "openai/gpt-5.2-chat-latest",
++   "name": "openai/gpt-5.2-chat-latest",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.75,
++    "output": 14.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 16384,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.2-codex": {
++   "id": "openai/gpt-5.2-codex",
++   "name": "OpenAI: GPT-5.2-Codex",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.75,
++    "output": 14.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.2-pro": {
++   "id": "openai/gpt-5.2-pro",
++   "name": "OpenAI: GPT-5.2 Pro",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 21.0,
++    "output": 168.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.2-pro-2025-12-11": {
++   "id": "openai/gpt-5.2-pro-2025-12-11",
++   "name": "openai/gpt-5.2-pro-2025-12-11",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 21.0,
++    "output": 168.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.3-codex": {
++   "id": "openai/gpt-5.3-codex",
++   "name": "OpenAI: GPT-5.3-Codex",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 1.75,
++    "output": 14.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.4": {
++   "id": "openai/gpt-5.4",
++   "name": "OpenAI: GPT-5.4",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 5.0,
++    "output": 22.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1050000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.4-2026-03-05": {
++   "id": "openai/gpt-5.4-2026-03-05",
++   "name": "openai/gpt-5.4-2026-03-05",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 5.0,
++    "output": 22.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1050000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.4-mini": {
++   "id": "openai/gpt-5.4-mini",
++   "name": "OpenAI: GPT-5.4 Mini",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.75,
++    "output": 4.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.4-mini-2026-03-17": {
++   "id": "openai/gpt-5.4-mini-2026-03-17",
++   "name": "openai/gpt-5.4-mini-2026-03-17",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.75,
++    "output": 4.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.4-nano": {
++   "id": "openai/gpt-5.4-nano",
++   "name": "OpenAI: GPT-5.4 Nano",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.2,
++    "output": 1.25,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 400000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.4-nano-2026-03-17": {
++   "id": "openai/gpt-5.4-nano-2026-03-17",
++   "name": "openai/gpt-5.4-nano-2026-03-17",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.2,
++    "output": 1.25,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.4-pro": {
++   "id": "openai/gpt-5.4-pro",
++   "name": "OpenAI: GPT-5.4 Pro",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 60.0,
++    "output": 270.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1050000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.4-pro-2026-03-05": {
++   "id": "openai/gpt-5.4-pro-2026-03-05",
++   "name": "openai/gpt-5.4-pro-2026-03-05",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 60.0,
++    "output": 270.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1050000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.5": {
++   "id": "openai/gpt-5.5",
++   "name": "OpenAI: GPT-5.5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 5.0,
++    "output": 30.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.5-2026-04-23": {
++   "id": "openai/gpt-5.5-2026-04-23",
++   "name": "openai/gpt-5.5-2026-04-23",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 10.0,
++    "output": 45.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.5-pro": {
++   "id": "openai/gpt-5.5-pro",
++   "name": "OpenAI: GPT-5.5 Pro",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 30.0,
++    "output": 180.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 100000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.5-pro-2026-04-23": {
++   "id": "openai/gpt-5.5-pro-2026-04-23",
++   "name": "openai/gpt-5.5-pro-2026-04-23",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 60.0,
++    "output": 270.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 100000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.6-luna": {
++   "id": "openai/gpt-5.6-luna",
++   "name": "OpenAI: GPT-5.6 Luna",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.2,
++    "output": 1.2,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1050000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.6-sol": {
++   "id": "openai/gpt-5.6-sol",
++   "name": "OpenAI: GPT-5.6 Sol",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 4.0,
++    "output": 20.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1050000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "openai/gpt-5.6-terra": {
++   "id": "openai/gpt-5.6-terra",
++   "name": "OpenAI: GPT-5.6 Terra",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.0,
++    "output": 12.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1050000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3-max": {
++   "id": "qwen/qwen3-max",
++   "name": "Qwen: Qwen3 Max",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.359,
++    "output": 1.434,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3-max-preview": {
++   "id": "qwen/qwen3-max-preview",
++   "name": "qwen/qwen3-max-preview",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.861,
++    "output": 3.441,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3-vl-235b-a22b-thinking": {
++   "id": "qwen/qwen3-vl-235b-a22b-thinking",
++   "name": "Qwen: Qwen3 VL 235B A22B Thinking",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.4,
++    "output": 4.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 131072,
++   "maxTokens": 40960,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3-vl-8b-instruct": {
++   "id": "qwen/qwen3-vl-8b-instruct",
++   "name": "Qwen: Qwen3 VL 8B Instruct",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.18,
++    "output": 0.7,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 131072,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3-vl-8b-thinking": {
++   "id": "qwen/qwen3-vl-8b-thinking",
++   "name": "Qwen: Qwen3 VL 8B Thinking",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.18,
++    "output": 2.1,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 131072,
++   "maxTokens": 40960,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.5-122b-a10b": {
++   "id": "qwen/qwen3.5-122b-a10b",
++   "name": "Qwen: Qwen3.5-122B-A10B",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.115,
++    "output": 0.917,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 32768,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.5-27b": {
++   "id": "qwen/qwen3.5-27b",
++   "name": "Qwen: Qwen3.5-27B",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.086,
++    "output": 0.688,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 32768,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.5-35b-a3b": {
++   "id": "qwen/qwen3.5-35b-a3b",
++   "name": "Qwen: Qwen3.5-35B-A3B",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.057,
++    "output": 0.459,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 32768,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.5-397b-a17b": {
++   "id": "qwen/qwen3.5-397b-a17b",
++   "name": "Qwen: Qwen3.5 397B A17B",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.172,
++    "output": 1.032,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 32768,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.5-flash": {
++   "id": "qwen/qwen3.5-flash",
++   "name": "qwen/qwen3.5-flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.1,
++    "output": 0.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.5-flash-2026-02-23": {
++   "id": "qwen/qwen3.5-flash-2026-02-23",
++   "name": "qwen/qwen3.5-flash-2026-02-23",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.1,
++    "output": 0.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.5-plus": {
++   "id": "qwen/qwen3.5-plus",
++   "name": "qwen/qwen3.5-plus",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.115,
++    "output": 0.688,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.5-plus-2026-02-15": {
++   "id": "qwen/qwen3.5-plus-2026-02-15",
++   "name": "qwen/qwen3.5-plus-2026-02-15",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.115,
++    "output": 0.688,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.6-35b-a3b": {
++   "id": "qwen/qwen3.6-35b-a3b",
++   "name": "Qwen: Qwen3.6 35B A3B",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.248,
++    "output": 1.485,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.6-flash": {
++   "id": "qwen/qwen3.6-flash",
++   "name": "Qwen: Qwen3.6 Flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.25,
++    "output": 1.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.6-flash-2026-04-16": {
++   "id": "qwen/qwen3.6-flash-2026-04-16",
++   "name": "qwen/qwen3.6-flash-2026-04-16",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.25,
++    "output": 1.5,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.6-plus": {
++   "id": "qwen/qwen3.6-plus",
++   "name": "Qwen: Qwen3.6 Plus",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.5,
++    "output": 3.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.6-plus-2026-04-02": {
++   "id": "qwen/qwen3.6-plus-2026-04-02",
++   "name": "qwen/qwen3.6-plus-2026-04-02",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.276,
++    "output": 1.651,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1048576,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.7-flash": {
++   "id": "qwen/qwen3.7-flash",
++   "name": "Qwen: Qwen3.7 Flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.03,
++    "output": 0.13,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.7-max": {
++   "id": "qwen/qwen3.7-max",
++   "name": "Qwen3.7 Max",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 3.75,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 64000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.7-max-2026-05-20": {
++   "id": "qwen/qwen3.7-max-2026-05-20",
++   "name": "Qwen3.7 Max (2026-05-20)",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 1.25,
++    "output": 3.75,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 64000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.7-plus": {
++   "id": "qwen/qwen3.7-plus",
++   "name": "Qwen: Qwen3.7 Plus",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.35,
++    "output": 1.42,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 65536,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.8-27b": {
++   "id": "qwen/qwen3.8-27b",
++   "name": "Qwen: Qwen3.8 27B",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.33,
++    "output": 2.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.8-27b-free": {
++   "id": "qwen/qwen3.8-27b-free",
++   "name": "Qwen: Qwen3.8 27B (free)",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 65536,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.8-flash": {
++   "id": "qwen/qwen3.8-flash",
++   "name": "Qwen: Qwen3.8 Flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.15,
++    "output": 0.47,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 131072,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "qwen/qwen3.8-max": {
++   "id": "qwen/qwen3.8-max",
++   "name": "Qwen: Qwen3.8 Max",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": true,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 2.0,
++    "output": 6.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "tencent/hy3": {
++   "id": "tencent/hy3",
++   "name": "Tencent: Hy3",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.18,
++    "output": 0.59,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "z-ai/glm-4.5": {
++   "id": "z-ai/glm-4.5",
++   "name": "Z.ai: GLM 4.5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.6,
++    "output": 2.2,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 96000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "z-ai/glm-4.5-air": {
++   "id": "z-ai/glm-4.5-air",
++   "name": "Z.ai: GLM 4.5 Air",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.2,
++    "output": 1.1,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 128000,
++   "maxTokens": 96000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "z-ai/glm-4.6": {
++   "id": "z-ai/glm-4.6",
++   "name": "Z.ai: GLM 4.6",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.6,
++    "output": 2.2,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 200000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "z-ai/glm-4.7": {
++   "id": "z-ai/glm-4.7",
++   "name": "Z.ai: GLM 4.7",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.6,
++    "output": 2.2,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 200000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "z-ai/glm-5": {
++   "id": "z-ai/glm-5",
++   "name": "Z.ai: GLM 5",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 1.0,
++    "output": 3.2,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 200000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "z-ai/glm-5.1": {
++   "id": "z-ai/glm-5.1",
++   "name": "Z.ai: GLM 5.1",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 1.4,
++    "output": 4.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 200000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "z-ai/glm-5.2": {
++   "id": "z-ai/glm-5.2",
++   "name": "Z.ai: GLM 5.2",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 1.4,
++    "output": 4.4,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "z-ai/glm-5.3": {
++   "id": "z-ai/glm-5.3",
++   "name": "Z.ai: GLM 5.3",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 1.26,
++    "output": 3.96,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "z-ai/glm-5.3-flash": {
++   "id": "z-ai/glm-5.3-flash",
++   "name": "Z.ai: GLM 5.3 Flash",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text",
++    "image"
++   ],
++   "cost": {
++    "input": 0.075,
++    "output": 0.25,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 1000000,
++   "maxTokens": 128000,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "claude-haiku-4-5-20251001": {
++   "id": "claude-haiku-4-5-20251001",
++   "name": "claude-haiku-4-5-20251001",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "claude-opus-4-5-20251101": {
++   "id": "claude-opus-4-5-20251101",
++   "name": "claude-opus-4-5-20251101",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "claude-opus-4-6": {
++   "id": "claude-opus-4-6",
++   "name": "claude-opus-4-6",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "claude-opus-4-7": {
++   "id": "claude-opus-4-7",
++   "name": "claude-opus-4-7",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "claude-opus-4-8": {
++   "id": "claude-opus-4-8",
++   "name": "claude-opus-4-8",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "claude-sonnet-4-5-20250929": {
++   "id": "claude-sonnet-4-5-20250929",
++   "name": "claude-sonnet-4-5-20250929",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  },
++  "claude-sonnet-4-6": {
++   "id": "claude-sonnet-4-6",
++   "name": "claude-sonnet-4-6",
++   "api": "openai-completions",
++   "baseUrl": "https://api.orcarouter.ai/v1",
++   "provider": "orcarouter",
++   "reasoning": false,
++   "input": [
++    "text"
++   ],
++   "cost": {
++    "input": 0.0,
++    "output": 0.0,
++    "cacheRead": 0,
++    "cacheWrite": 0
++   },
++   "contextWindow": 262144,
++   "maxTokens": 32768,
++   "compat": {
++    "supportsDeveloperRole": false
++   }
++  }
++ }
++}
+\ No newline at end of file
+diff --git a/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.d.ts b/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.d.ts
+new file mode 100644
+index 0000000..c3f9dae
+--- /dev/null
++++ b/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.d.ts
+@@ -0,0 +1,2 @@
++import { type Provider } from "../models.ts";
++export declare function orcarouterProvider(): Provider<"openai-completions">;
+diff --git a/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.js b/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.js
+new file mode 100644
+index 0000000..199e713
+--- /dev/null
++++ b/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.js
+@@ -0,0 +1,14 @@
++import { openAICompletionsApi } from "../api/openai-completions.lazy.js";
++import { envApiKeyAuth } from "../auth/helpers.js";
++import { createProvider } from "../models.js";
++import { ORCAROUTER_MODELS } from "./orcarouter.models.js";
++export function orcarouterProvider() {
++    return createProvider({
++        id: "orcarouter",
++        name: "OrcaRouter",
++        baseUrl: "https://api.orcarouter.ai/v1",
++        auth: { apiKey: envApiKeyAuth("OrcaRouter API key", ["ORCAROUTER_API_KEY"]) },
++        models: Object.values(ORCAROUTER_MODELS),
++        api: openAICompletionsApi(),
++    });
++}
+diff --git a/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.models.d.ts b/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.models.d.ts
+new file mode 100644
+index 0000000..87bcc82
+--- /dev/null
++++ b/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.models.d.ts
+@@ -0,0 +1,3 @@
++import values from "./data/orcarouter.json";
++import { type ModelCatalog } from "../model-catalog.ts";
++export declare const ORCAROUTER_MODELS: ModelCatalog<typeof values, "orcarouter">;
+diff --git a/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.models.js b/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.models.js
+new file mode 100644
+index 0000000..24481e4
+--- /dev/null
++++ b/node_modules/@earendil-works/pi-ai/dist/providers/orcarouter.models.js
+@@ -0,0 +1,3 @@
++import values from "./data/orcarouter.json" with { type: "json" };
++import { flattenModelCatalog } from "../model-catalog.js";
++export const ORCAROUTER_MODELS = flattenModelCatalog("orcarouter", values);
+diff --git a/node_modules/@earendil-works/pi-ai/dist/types.d.ts b/node_modules/@earendil-works/pi-ai/dist/types.d.ts
+index 5bba63f..1c99aad 100644
+--- a/node_modules/@earendil-works/pi-ai/dist/types.d.ts
++++ b/node_modules/@earendil-works/pi-ai/dist/types.d.ts
+@@ -16,7 +16,7 @@ export type KnownApi = "openai-completions" | "mistral-conversations" | "openai-
+ export type Api = KnownApi | (string & {});
+ export type KnownImagesApi = "openrouter-images";
+ export type ImagesApi = KnownImagesApi | (string & {});
+-export type KnownProvider = "amazon-bedrock" | "ant-ling" | "anthropic" | "google" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "radius" | "nvidia" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "vercel-ai-gateway" | "zai" | "zai-coding-cn" | "mistral" | "minimax" | "minimax-cn" | "moonshotai" | "moonshotai-cn" | "huggingface" | "fireworks" | "together" | "baseten" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai" | "cloudflare-ai-gateway" | "qwen-token-plan" | "qwen-token-plan-cn" | "qwen-token-plan-individual" | "xiaomi" | "xiaomi-token-plan-cn" | "xiaomi-token-plan-ams" | "xiaomi-token-plan-sgp";
++export type KnownProvider = "amazon-bedrock" | "ant-ling" | "anthropic" | "google" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "radius" | "nvidia" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "orcarouter" | "vercel-ai-gateway" | "zai" | "zai-coding-cn" | "mistral" | "minimax" | "minimax-cn" | "moonshotai" | "moonshotai-cn" | "huggingface" | "fireworks" | "together" | "baseten" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai" | "cloudflare-ai-gateway" | "qwen-token-plan" | "qwen-token-plan-cn" | "qwen-token-plan-individual" | "xiaomi" | "xiaomi-token-plan-cn" | "xiaomi-token-plan-ams" | "xiaomi-token-plan-sgp";
+ export type ProviderId = KnownProvider | string;
+ export type KnownImagesProvider = "openrouter";
+ export type ImagesProviderId = KnownImagesProvider | string;

--- a/test/onboarding-patch.test.ts
+++ b/test/onboarding-patch.test.ts
@@ -8,6 +8,7 @@ const PI_AI_ONBOARDING_PROVIDERS = [
   'anthropic',
   'google',
   'openrouter',
+  'orcarouter',
   'xai',
   'moonshotai-cn',
   'minimax-cn',


### PR DESCRIPTION
Add [OrcaRouter](https://www.orcarouter.ai) as a first-class model provider in DSH Desktop's bundled pi-ai catalog, alongside the existing OpenRouter integration.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named provider means DSH Desktop users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This mirrors how the existing `openrouter` route is wired: a pi-ai catalog provider (`@earendil-works/pi-ai` patch) with a curated OpenAI-completions catalog of 164 models, plus an entry in the first-run onboarding provider grid and the Models settings provider ordering.

**Verification**
- `npm test` — 554 passed, 2 skipped
- `npm run typecheck` — clean
- `npm run build` — clean
- Live test: streamed a completion from `https://api.orcarouter.ai/v1` through the `orcarouter` provider with `ORCAROUTER_API_KEY`

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
