### PR TITLE
feat: configure mobile bridge port

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,7 @@ import {
 } from './state/profile-compatibility'
 import { ensureStoreDirPinned, inspectStoreConsistency } from './state/profile-store'
 import { LanMobileBridge } from './mobile/lan-mobile-bridge'
+import { resolveMobileBridgePort } from './mobile/mobile-bridge-port'
 import {
   detectPluginRecovery,
   PLUGIN_RECOVERY_EVIDENCE_TIMEOUT_MS
@@ -2031,7 +2032,7 @@ async function bootstrap(): Promise<void> {
     cloudflaredCacheDir: join(app.getPath('userData'), 'bin'),
     forceCloudflareFailure: process.env.DSH_TUNNEL_FORCE_PINGGY === '1',
     tunnelLog: (message) => console.warn(message),
-    port: developmentBuild ? 43128 : 43127,
+    port: resolveMobileBridgePort(developmentBuild),
     onReconnectRequested: () => {
       void showMobilePairing().catch(showUnexpectedError)
     },

--- a/src/main/mobile/mobile-bridge-port.ts
+++ b/src/main/mobile/mobile-bridge-port.ts
@@ -1,0 +1,24 @@
+const DEFAULT_PRODUCTION_MOBILE_BRIDGE_PORT = 43127
+const DEFAULT_DEVELOPMENT_MOBILE_BRIDGE_PORT = 43128
+
+export const MOBILE_BRIDGE_PORT_ENVIRONMENT_VARIABLE = 'DSH_DESKTOP_MOBILE_BRIDGE_PORT'
+
+export function resolveMobileBridgePort(
+  developmentBuild: boolean,
+  environment: Readonly<Record<string, string | undefined>> = process.env
+): number {
+  const configured = environment[MOBILE_BRIDGE_PORT_ENVIRONMENT_VARIABLE]
+  if (configured === undefined) {
+    return developmentBuild
+      ? DEFAULT_DEVELOPMENT_MOBILE_BRIDGE_PORT
+      : DEFAULT_PRODUCTION_MOBILE_BRIDGE_PORT
+  }
+  if (!/^[1-9]\d*$/u.test(configured)) {
+    throw new Error(`${MOBILE_BRIDGE_PORT_ENVIRONMENT_VARIABLE} must be an integer from 1 to 65535`)
+  }
+  const port = Number(configured)
+  if (!Number.isSafeInteger(port) || port > 65535) {
+    throw new Error(`${MOBILE_BRIDGE_PORT_ENVIRONMENT_VARIABLE} must be an integer from 1 to 65535`)
+  }
+  return port
+}

--- a/test/mobile-bridge-port.test.ts
+++ b/test/mobile-bridge-port.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveMobileBridgePort } from '../src/main/mobile/mobile-bridge-port'
+
+describe('mobile bridge port configuration', () => {
+  it('keeps the production and development defaults when the environment variable is absent', () => {
+    expect(resolveMobileBridgePort(false, {})).toBe(43127)
+    expect(resolveMobileBridgePort(true, {})).toBe(43128)
+  })
+
+  it('uses DSH_DESKTOP_MOBILE_BRIDGE_PORT for the current Desktop process', () => {
+    expect(resolveMobileBridgePort(false, { DSH_DESKTOP_MOBILE_BRIDGE_PORT: '45127' })).toBe(45127)
+    expect(resolveMobileBridgePort(true, { DSH_DESKTOP_MOBILE_BRIDGE_PORT: '45128' })).toBe(45128)
+  })
+
+  it.each(['', '0', '-1', '1.5', '65536', 'port'])('rejects invalid configured port %j', (value) => {
+    expect(() => resolveMobileBridgePort(false, { DSH_DESKTOP_MOBILE_BRIDGE_PORT: value })).toThrow(
+      'DSH_DESKTOP_MOBILE_BRIDGE_PORT must be an integer from 1 to 65535'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- read the mobile bridge port from `DSH_DESKTOP_MOBILE_BRIDGE_PORT`
- keep production/development defaults when the variable is absent
- validate the configured port and cover both defaults and overrides with unit tests

## Test

- `vitest run test/mobile-bridge-port.test.ts`