### PR TITLE
fix: remove generation plugins through the registry so uninstalls per…

### DIFF
--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -11,6 +11,8 @@ import { PassThrough } from 'node:stream'
 import { installGeneration } from './generations/installer.mjs'
 import { projectGenerations } from './generations/projection.mjs'
 import {
+  disableGeneration,
+  isGenerationPlugin,
   listGenerations,
   readDesired,
   withRegistryLock,
@@ -477,11 +479,124 @@ export function createDesktopPnpmService(options) {
     return handle
   }
 
+  /**
+   * Remove one plugin from the active profile.
+   *
+   * A generation plugin is removed through the generations registry — it is
+   * dropped from `desired.json` and the profile is reprojected — never via
+   * `pnpm remove`. The profile's manifest rows and `node_modules` link for a
+   * generation are projected from `desired.json` on every launch, so a plain
+   * pnpm remove succeeds and is silently undone on the next start when
+   * `projectGenerations` re-derives the profile from the registry (the plugin
+   * simply reappears after a refresh). Anything that is not a generation (a
+   * shared-tree dependency such as dshmarket, a github-sourced dependency,
+   * a leftover) falls through to the unchanged pnpm path, under the same
+   * registry lock so the two kinds of removal never interleave.
+   *
+   * The returned handle keeps the shape `runPlugin` promises: `stdout` and
+   * `stderr` streams the caller (dsh-market's desktop runtime) attaches data
+   * listeners to, a `done` promise resolving to `{ exitCode, signal }`, and a
+   * `cancel()` that kills a running pnpm child.
+   */
+  const runPluginRemoval = (args, invokingDir, signal) => {
+    const pluginName = args.slice(1).find((argument) => !argument.startsWith('-'))
+    if (typeof pluginName !== 'string' || pluginName === '') {
+      throw new Error('The remove operation needs a plugin name.')
+    }
+
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    let cancelled = false
+    let child
+
+    const cancel = () => {
+      cancelled = true
+      if (child) killProcessTree(child)
+    }
+
+    const done = (async () => {
+      // The registry check and the removal are one locked critical section,
+      // mirroring runExternalMarketPluginInstall: the lock is the
+      // cross-process serialization for .generations mutations. It is
+      // released again before the pnpm fallback below, which never touches
+      // the registry.
+      let outcome
+      try {
+        outcome = await withRegistryLock(home, async () => {
+          if (!(await isGenerationPlugin(home, pluginName))) {
+            return { kind: 'pnpm' }
+          }
+          const removed = await disableGeneration(home, pluginName)
+          const projection = await projectGenerations(home)
+          stdout.write(
+            removed
+              ? `removed ${pluginName} from the enabled plugin generations\n`
+              : `${pluginName} was already disabled\n`
+          )
+          stdout.write(`enabled: ${projection.linked.join(', ')}\n`)
+          return { kind: 'generation' }
+        })
+      } catch (error) {
+        stderr.write(error instanceof Error ? error.message : String(error))
+        return { exitCode: 1, signal: null }
+      }
+      if (outcome.kind === 'generation') {
+        return { exitCode: 0, signal: null }
+      }
+
+      // Not a generation plugin: the ordinary pnpm removal, unchanged.
+      if (closed) {
+        stderr.write('The DSH Desktop pnpm service has been disposed.')
+        return { exitCode: 127, signal: null }
+      }
+      void cleanStaleTemporaryDirectories(home).catch(() => undefined)
+      child = spawnProcess(
+        executablePath,
+        [dshEntryPath, 'plugin', '--profile', MARKET_PROFILE, ...args],
+        {
+          cwd: invokingDir,
+          env: buildPnpmEnvironment(binDirectory, environment, executablePath),
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+          detached: process.platform !== 'win32'
+        }
+      )
+      const abort = () => cancel()
+      signal?.addEventListener('abort', abort, { once: true })
+      if (signal?.aborted) abort()
+      child.stdout.pipe(stdout)
+      child.stderr.pipe(stderr)
+      try {
+        return await new Promise((resolveDone, rejectDone) => {
+          child.once('error', rejectDone)
+          child.once('close', (exitCode, exitSignal) => {
+            resolveDone({ exitCode, signal: exitSignal })
+          })
+        })
+      } finally {
+        signal?.removeEventListener('abort', abort)
+      }
+    })().finally(() => {
+      stdout.end()
+      stderr.end()
+    })
+
+    const handle = { stdout, stderr, done, cancel }
+    active = handle
+    const release = () => {
+      if (active === handle) active = undefined
+    }
+    void done.then(release, release)
+    return handle
+  }
+
   const runPlugin = (args, invokingDir, signal) => {
     validatePluginOperation(args, invokingDir)
     if (closed) throw new Error('The DSH Desktop pnpm service has been disposed.')
     if (signal?.aborted) throw signal.reason ?? new Error('The package operation was aborted.')
     if (active) throw new Error('Another desktop pnpm operation is already running.')
+
+    if (args[0] === 'remove') return runPluginRemoval(args, invokingDir, signal)
 
     void cleanStaleTemporaryDirectories(home).catch(() => undefined)
 

--- a/test/market-installer.test.js
+++ b/test/market-installer.test.js
@@ -1,8 +1,12 @@
-import { mkdtemp, mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdtemp, mkdir, readFile, realpath, symlink, writeFile } from 'node:fs/promises'
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { ensureStoreDirPinned, inspectStoreConsistency } from '../src/main/state/profile-store'
+import { ensureRegistryDirectories, readDesired, writeDesired, writeGenerationMeta } from '../packages/dsh-desktop-market-installer/generations/registry'
 import {
   INSTALL_PATH,
   MARKET_PACKAGE,
@@ -247,7 +251,8 @@ describe('desktop plugin market installer', () => {
       binDirectory,
       dshEntryPath: fakeDshEntry,
       executablePath: process.execPath,
-      environment
+      environment,
+      home: root
     })
     const handle = service.runPlugin(['remove', 'example-plugin'], root)
     expect(() => service.runPlugin(['install'], root)).toThrow(
@@ -381,5 +386,133 @@ describe('desktop plugin market installer', () => {
     expect(main).toContain("ipcMain.handle('market:uninstall'")
     expect(main).toContain("await runtime.stop()")
     expect(main).toMatch(/'dshmarket',\s+true/u)
+  })
+
+  /**
+   * A scratch profile with one enabled generation, mirroring what
+   * projectGenerations produces for a real plugin-market install.
+   */
+  async function generationProfile(pluginName = '@example/voice-mode') {
+    const root = await realpath(await mkdtemp(join(tmpdir(), 'dsh-market-generation-remove-')))
+    const generationId = `example+voice-mode+1.0.0+test`
+    const generationDir = join(root, 'profiles', '.generations', 'live', generationId)
+    await ensureRegistryDirectories(root)
+    await mkdir(generationDir, { recursive: true })
+    await writeGenerationMeta(generationDir, { pluginName, version: '1.0.0' })
+    const packageDir = join(generationDir, 'node_modules', pluginName)
+    await mkdir(packageDir, { recursive: true })
+    await writeFile(
+      join(packageDir, 'package.json'),
+      JSON.stringify({ name: pluginName, version: '1.0.0', dsh: { bundle: { patch: 'cordis.patch.yml' } } })
+    )
+    await writeFile(join(packageDir, 'cordis.patch.yml'), '[]\n')
+    await writeDesired(root, [generationId])
+
+    const profileDirectory = join(root, 'profiles', 'web')
+    await mkdir(join(profileDirectory, 'node_modules'), { recursive: true })
+    await writeFile(
+      join(profileDirectory, 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          [pluginName]: `link:../.generations/live/${generationId}/node_modules/${pluginName}`,
+          dshmarket: '^1.0.0'
+        },
+        dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket', pluginName] } }
+      })
+    )
+    await mkdir(join(profileDirectory, 'node_modules', ...pluginName.split('/').slice(0, -1)), {
+      recursive: true
+    })
+    await symlink(
+      packageDir,
+      join(profileDirectory, 'node_modules', pluginName),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    return { root, profileDirectory, pluginName, generationId }
+  }
+
+  it('removes a generation plugin through the registry, not pnpm, so it stays gone', async () => {
+    const { root, profileDirectory, pluginName, generationId } = await generationProfile()
+    let spawned = 0
+    const service = createDesktopPnpmService({
+      home: root,
+      binDirectory: join(root, '.desktop-bin'),
+      dshEntryPath: join(root, 'unused-dsh-entry.mjs'),
+      executablePath: process.execPath,
+      spawnProcess: () => {
+        spawned += 1
+        throw new Error('a generation plugin must never reach pnpm')
+      }
+    })
+
+    const handle = service.runPlugin(
+      ['remove', '-w', pluginName, '--reporter=ndjson'],
+      profileDirectory
+    )
+    let stdout = ''
+    handle.stdout.on('data', (chunk) => {
+      stdout += chunk.toString('utf8')
+    })
+    await expect(handle.done).resolves.toEqual({ exitCode: 0, signal: null })
+    expect(spawned).toBe(0)
+    expect(stdout).toContain('removed')
+
+    const manifest = JSON.parse(await readFile(join(profileDirectory, 'package.json'), 'utf8'))
+    expect(manifest.dependencies[pluginName]).toBeUndefined()
+    expect(manifest.dsh.profile.bundles).not.toContain(pluginName)
+    expect(existsSync(join(profileDirectory, 'node_modules', pluginName))).toBe(false)
+    // The authoritative registry no longer wants the plugin, so the next
+    // launch's projection cannot bring it back — the uninstall persists.
+    expect(await readDesired(root)).toEqual([])
+    expect(existsSync(join(root, 'profiles', '.generations', 'live', generationId))).toBe(true)
+    await service.dispose()
+  })
+
+  it('falls through to pnpm for a remove that is not a generation plugin', async () => {
+    const { root, profileDirectory } = await generationProfile()
+    const spawned = []
+    const service = createDesktopPnpmService({
+      home: root,
+      binDirectory: join(root, '.desktop-bin'),
+      dshEntryPath: '/app/dsh/bin.js',
+      executablePath: '/app/electron',
+      environment: process.env,
+      spawnProcess: (executable, argv, options) => {
+        spawned.push({ executable, argv, options })
+        const child = new EventEmitter()
+        child.stdout = new PassThrough()
+        child.stderr = new PassThrough()
+        child.pid = 4242
+        setTimeout(() => {
+          child.stdout.end()
+          child.stderr.end()
+          child.emit('close', 0, null)
+        }, 10)
+        return child
+      }
+    })
+
+    // dshmarket lives in the shared tree, not in the generations registry.
+    const handle = service.runPlugin(
+      ['remove', '-w', 'dshmarket', '--reporter=ndjson'],
+      profileDirectory
+    )
+    handle.stdout.resume()
+    handle.stderr.resume()
+    await expect(handle.done).resolves.toEqual({ exitCode: 0, signal: null })
+    expect(spawned).toHaveLength(1)
+    expect(spawned[0].executable).toBe('/app/electron')
+    expect(spawned[0].argv).toEqual([
+      '/app/dsh/bin.js',
+      'plugin',
+      '--profile',
+      'web',
+      'remove',
+      '-w',
+      'dshmarket',
+      '--reporter=ndjson'
+    ])
+    expect(spawned[0].options.cwd).toBe(profileDirectory)
+    await service.dispose()
   })
 })


### PR DESCRIPTION
…sist

Uninstalling a plugin from the marketplace runs pnpm remove against the web profile, but generation plugins are projected back from the generations registry (desired.json) on every launch. pnpm remove never touches the registry, so the plugin reappears after a Harness restart.

Route 'remove' through the registry when the target is a generation plugin: drop it from desired.json and reproject the profile, all inside the cross-process registry lock, exactly like runExternalMarketPluginInstall serializes installs. Non-generation plugins (dshmarket, github-sourced dependencies, leftovers) keep the unchanged pnpm path.

Adds regression tests covering both branches and makes the existing pnpm boundary test hermetic by passing an explicit home.