### PR TITLE
test(release): 修复飞书 previous-tag 测试对仓库拓扑的依赖

### DIFF
--- a/test/feishu-release-notes.test.ts
+++ b/test/feishu-release-notes.test.ts
@@ -1,7 +1,8 @@
 import { execFileSync } from 'node:child_process'
-import { readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 describe('Feishu release notes pipeline', () => {
   const pythonTestTimeoutMs = 15_000
@@ -9,6 +10,47 @@ describe('Feishu release notes pipeline', () => {
   const workflowPath = join(process.cwd(), '.github', 'workflows', 'release.yml')
 
   const pythonEnv = { ...process.env, PYTHONIOENCODING: 'utf-8' }
+
+  const fixtureRepos: string[] = []
+
+  afterEach(() => {
+    for (const dir of fixtureRepos.splice(0)) rmSync(dir, { recursive: true, force: true })
+  })
+
+  interface FixtureCommit {
+    message: string
+    date: string
+    tag?: string
+  }
+
+  /** A throwaway git repo with a known commit + tag graph, HEAD left untagged. */
+  function buildTagFixtureRepo(commits: FixtureCommit[]): string {
+    const dir = mkdtempSync(join(tmpdir(), 'feishu-tags-'))
+    fixtureRepos.push(dir)
+    const git = (args: string[], extraEnv: Record<string, string> = {}): void => {
+      execFileSync('git', args, {
+        cwd: dir,
+        env: {
+          ...process.env,
+          GIT_CONFIG_GLOBAL: '/dev/null',
+          GIT_CONFIG_SYSTEM: '/dev/null',
+          GIT_AUTHOR_NAME: 'Test',
+          GIT_AUTHOR_EMAIL: 'test@example.com',
+          GIT_COMMITTER_NAME: 'Test',
+          GIT_COMMITTER_EMAIL: 'test@example.com',
+          ...extraEnv
+        }
+      })
+    }
+    git(['init', '-q', '-b', 'main'])
+    for (const { message, date, tag } of commits) {
+      writeFileSync(join(dir, 'file.txt'), `${message}\n`)
+      git(['add', '.'])
+      git(['commit', '-q', '-m', message], { GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date })
+      if (tag) git(['tag', tag])
+    }
+    return dir
+  }
 
   it(
     'builds a prompt with valid metadata and evidence blocks',
@@ -152,49 +194,33 @@ Description here.
   )
 
   it('differentiates previous tag resolution between prerelease and official release', () => {
-    // For official release v0.7.1, previous stable tag is v0.7.0
-    const officialPrompt = execFileSync(
-      'python3',
-      [scriptPath, 'build-prompt', '--tag', 'v0.7.1'],
-      {
+    // A self-contained tag graph so this does not depend on which branch or
+    // which fetched tags the checkout happens to carry:
+    //   c0 (v0.7.0) -> c1 (v0.7.1) -> c2 (0.7.2, prerelease-style) -> c3 (HEAD, untagged)
+    const repo = buildTagFixtureRepo([
+      { message: 'base', date: '2026-01-01T00:00:00', tag: 'v0.7.0' },
+      { message: 'stable work', date: '2026-02-01T00:00:00', tag: 'v0.7.1' },
+      { message: 'prerelease cut', date: '2026-03-01T00:00:00', tag: '0.7.2' },
+      { message: 'unreleased work', date: '2026-04-01T00:00:00' }
+    ])
+    const buildPrompt = (args: string[]): string =>
+      execFileSync('python3', [scriptPath, 'build-prompt', ...args], {
         encoding: 'utf8',
-        env: pythonEnv
-      }
-    )
-    expect(officialPrompt).toContain('Previous stable tag: v0.7.0')
+        env: pythonEnv,
+        cwd: repo
+      })
 
-    // For prerelease 0.7.2, previous tag is v0.7.1
-    const prereleasePrompt = execFileSync(
-      'python3',
-      [scriptPath, 'build-prompt', '--tag', '0.7.2', '--prerelease'],
-      {
-        encoding: 'utf8',
-        env: pythonEnv
-      }
-    )
-    expect(prereleasePrompt).toContain('Previous tag: v0.7.1')
+    // Official v0.7.1: previous stable tag is v0.7.0.
+    expect(buildPrompt(['--tag', 'v0.7.1'])).toContain('Previous stable tag: v0.7.0')
 
-    // For a future simulated prerelease like 0.8.0-rc.1 on current HEAD, previous tag is 0.7.2
-    const futurePrereleasePrompt = execFileSync(
-      'python3',
-      [scriptPath, 'build-prompt', '--tag', '0.8.0-rc.1', '--prerelease'],
-      {
-        encoding: 'utf8',
-        env: pythonEnv
-      }
-    )
-    expect(futurePrereleasePrompt).toContain('Previous tag: 0.7.2')
+    // Prerelease 0.7.2: nearest tag of any kind before it is v0.7.1.
+    expect(buildPrompt(['--tag', '0.7.2', '--prerelease'])).toContain('Previous tag: v0.7.1')
 
-    // For a future official release v0.8.0 on current HEAD, previous stable tag must skip 0.7.2 and find v0.7.1
-    const futureOfficialPrompt = execFileSync(
-      'python3',
-      [scriptPath, 'build-prompt', '--tag', 'v0.8.0'],
-      {
-        encoding: 'utf8',
-        env: pythonEnv
-      }
-    )
-    expect(futureOfficialPrompt).toContain('Previous stable tag: v0.7.1')
+    // Future prerelease 0.8.0-rc.1 on HEAD: nearest tag is the 0.7.2 prerelease.
+    expect(buildPrompt(['--tag', '0.8.0-rc.1', '--prerelease'])).toContain('Previous tag: 0.7.2')
+
+    // Future official v0.8.0 on HEAD: must skip the 0.7.2 prerelease and pick v0.7.1.
+    expect(buildPrompt(['--tag', 'v0.8.0'])).toContain('Previous stable tag: v0.7.1')
   })
 
   it('integrates Feishu release notification into GitHub Actions workflow', () => {


### PR DESCRIPTION
## 问题

`Release desktop installers` 工作流的 `npm test` 步骤在所有 build job 上失败，导致整个 release/prerelease 流水线卡死（sign / publish 全部 skip）。

失败用例：`test/feishu-release-notes.test.ts` → `differentiates previous tag resolution between prerelease and official release`

```
AssertionError: expected '<prompt>' to contain 'Previous tag: 0.7.2'
```

## 根因

该用例硬编码断言 `build-prompt --tag 0.8.0-rc.1 --prerelease` 的输出包含 `Previous tag: 0.7.2`。

`feishu_release_notes.py` 的 `find_previous_tag`：当目标 tag 尚不存在时，回退到 `git tag --merged HEAD` 找最近的祖先 tag。标签 `0.7.2` 是从 `release/0.7.2`（commit `11481ac`）切的，**从未合并进 `main`**，因此对任何基于 main 的分支都不可达 → 脚本解析出 `v0.7.1` 而非 `0.7.2` → 断言失败。

即：这个测试在 `main` 上本身就是红的，之前 PR 能绿只是因为在一个能看到 `0.7.2` 的分支上跑的。

## 修复

把该用例重建成在一个**临时 git 仓库**里跑，仓库有确定的 tag 图：

```
c0 (v0.7.0) → c1 (v0.7.1) → c2 (0.7.2, 预发布式) → c3 (HEAD, 无 tag)
```

四个断言（official→上一个 stable、prerelease→任意类型上一个、未来 prerelease 在 HEAD→跳到 0.7.2、未来 official 在 HEAD→跳过 0.7.2 取 v0.7.1）现在都与真实仓库拓扑无关，确定性通过。

## 验证

- `test/feishu-release-notes.test.ts` 7/7 通过。
- `test/release.test.ts`、`test/github-release-notes.test.ts` 通过。
- `tsc --noEmit -p tsconfig.node.json` 通过。