### PR TITLE
fix(release): 预发布产物的 update metadata 停留在 latest 通道

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -523,8 +523,13 @@ jobs:
           test -s "$installer.sig"
           rm -f "$installer.sig"
       - name: Rebuild Windows update metadata
+        env:
+          PRERELEASE_TAG: ${{ inputs.prerelease_tag }}
         run: |
-          version="${GITHUB_REF_NAME#v}"
+          # On a tag push the version is the tag; on a pre-release dispatch
+          # GITHUB_REF_NAME is the branch, so take it from the input instead.
+          version="${PRERELEASE_TAG:-${GITHUB_REF_NAME#v}}"
+          version="${version#v}"
           node scripts/finalize-windows-release.mjs \
             "$WINDOWS_SIGNING_WORK_DIR/release" \
             "$version"

--- a/package.json
+++ b/package.json
@@ -369,6 +369,7 @@
         "url": "https://dshdesktop.com/updates/latest/"
       }
     ],
+    "detectUpdateChannel": false,
     "artifactName": "dsh-desktop-${os}-${arch}.${ext}",
     "mac": {
       "category": "public.app-category.developer-tools",

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -183,6 +183,17 @@ describe('GitHub release contract', () => {
     expect(packageJson.build.portable).toBeUndefined()
   })
 
+  it('keeps update metadata on the latest channel for pre-release versions', async () => {
+    const packageJson = JSON.parse(
+      await readFile(path.join(projectRoot, 'package.json'), 'utf8')
+    ) as { build: { detectUpdateChannel?: boolean } }
+
+    // A version like 0.8.0-rc.1 would otherwise make electron-builder write
+    // rc-mac.yml / rc.yml instead of latest-mac.yml / latest.yml, which every
+    // downstream release step expects by name.
+    expect(packageJson.build.detectUpdateChannel).toBe(false)
+  })
+
   it('turns a selected Windows drive root into an application directory', async () => {
     const installer = await readFile(
       path.join(projectRoot, 'build', 'installer.nsh'),
@@ -416,7 +427,8 @@ describe('GitHub release contract', () => {
     expect(workflow).not.toContain('security find-generic-password')
     expect(workflow).not.toContain('WINDOWS_SIGNING_KEYCHAIN_SERVICE')
     expect(workflow).toContain('finalize-windows-release.mjs')
-    expect(workflow).toContain('version="${GITHUB_REF_NAME#v}"')
+    // Version comes from the pre-release input on a dispatch, else the tag ref.
+    expect(workflow).toContain('version="${PRERELEASE_TAG:-${GITHUB_REF_NAME#v}}"')
     expect(workflow).toContain('pattern: macos-*')
     expect(workflow).toMatch(
       /publish:[\s\S]*?needs\.sign-windows\.result == 'success'[\s\S]*?- sign-windows/


### PR DESCRIPTION
`0.8.0-rc.1` 的预发布 run（[33613643832](https://github.com/dataelement/dsh-desktop/actions/runs/33613643832)）三个 build job 全挂，`npm test` 之后卡在 update metadata 步骤。这是**产线级预发布路径第一次真正跑通**（之前 `0.7.2` 那些"预发布"其实走的是旧 `release.yml` 的 dev 隔离路径），暴露两个 bug。

## Bug 1 — electron-builder 按版本后缀分了 update 通道

`app-builder-lib` 的 `AppInfo.channel` = `semver.prerelease(version)[0]`。版本 `0.8.0-rc.1` → channel = `rc` → 写出 `dist/rc-mac.yml` / `dist/rc.yml`，而不是 `latest-mac.yml` / `latest.yml`。

下游全部按 `latest*` 名字取文件：
- macOS `Preserve … update metadata`：`mv dist/latest-mac.yml …` → No such file
- Windows `Rebuild Windows update metadata` / `merge-mac-update-metadata.mjs` / `verify-release-assets.mjs` 同理

**修复**：`package.json` `build` 加 `"detectUpdateChannel": false`。这样任何版本都写 `latest*.yml`。正式 `vX.Y.Z`（无后缀）本来 channel 就是 null，无影响。我们的"通道"是 ModelScope 的目录路径（`releases/prerelease/<tag>/`），不需要 electron-builder 再按版本分。

## Bug 2 — `sign-windows` 从分支名取版本号

`Rebuild Windows update metadata` 用 `version="${GITHUB_REF_NAME#v}"`。workflow_dispatch 时 `GITHUB_REF_NAME` 是分支名（`main`）→ `finalize-windows-release.mjs main` → semver 校验失败抛 `Usage:`。

**修复**：`version="${PRERELEASE_TAG:-${GITHUB_REF_NAME#v}}"`（有预发布输入用输入，否则用 tag ref），与 `publish-prerelease` 里 `verify-release-assets` 的取值方式一致。

## 测试

- 新增 `test/release.test.ts`：断言 `build.detectUpdateChannel === false`、workflow 用新的版本取值表达式
- `test/release.test.ts` / `test/finalize-windows-release.test.ts` / `test/verify-release-assets.test.mjs` 31 通过
- `tsc --noEmit` 通过
- YAML / JSON 语法校验通过

合并后重新触发 `0.8.0-rc.1` 应能走完。