### PR TITLE
refactor(desktop): 移除启动维护阶段无效的 pnpm install 阻塞调用

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1163,19 +1163,6 @@ function launchHarness(): Promise<void> {
         if (upgradedMarket) {
           runtime.note(`[desktop] upgraded dshmarket baseline to ^${VERIFIED_MARKET_BASELINE} in profile manifest`)
           await clearProfileInstallMarker(dshHome)
-          const result = await installProfileDependenciesWithDsh({
-            dshHome,
-            dshEntryPath: dshEntryPath(),
-            nodeExecutablePath: bundledNodePath(),
-            pnpmEntryPath: bundledPnpmEntryPath(),
-            pnpmRunnerPath: bundledPnpmRunnerPath()
-          })
-          if (result.ok) {
-            await markProfileInstallComplete(dshHome)
-            runtime.note('[desktop] successfully installed upgraded dshmarket baseline')
-          } else {
-            runtime.note(`[desktop] failed to install upgraded dshmarket baseline: ${result.detail}`)
-          }
         }
       },
       enforcePendingPluginRemovals: () =>


### PR DESCRIPTION
清理之前在 preparePackageStore 中尝试调用的 installProfileDependenciesWithDsh 无效调用，保持启动流程干净，避免启动阶段不必要的阻塞。