### PR TITLE
fix(windows): hide child console windows via a hidden Harness console

### DIFF
--- a/build/harness-node-entry.mjs
+++ b/build/harness-node-entry.mjs
@@ -41,6 +41,12 @@ process.stdout.write(`[harness-node] DSH_HOME=${process.env.DSH_HOME ?? ''}\n`)
 // third-party plugins alike — without needing an upstream fix in each of
 // them. A caller that explicitly sets windowsHide keeps its own choice.
 if (process.platform === 'win32') {
+  // The Harness is spawned console-less (detached + windowsHide), so child
+  // console apps flash their own window unless the Harness owns a hidden
+  // console for them to inherit (issue #233).
+  const { createHiddenConsole } = await import('./windows-hidden-console.mjs')
+  createHiddenConsole()
+
   enforceWindowsChildProcessHide(childProcess, syncBuiltinESMExports)
 
   process.stdout.write('[harness-node] windowsHide enforcement enabled for child processes\n')

--- a/build/windows-hidden-console.mjs
+++ b/build/windows-hidden-console.mjs
@@ -1,0 +1,42 @@
+import koffi from 'koffi'
+
+/** SW_HIDE: hide the window (and activate another window). */
+const SW_HIDE = 0
+
+/**
+ * Attach a hidden console to the current (console-less) process.
+ *
+ * The desktop spawns the Harness node process with `detached: true` and
+ * `windowsHide: true` (`DETACHED_PROCESS | CREATE_NO_WINDOW` — see
+ * `buildHarnessSpawnOptions`), so the Harness itself has no console. On
+ * Windows, spawning a console child (pwsh, git, ripgrep, …) from a
+ * console-less parent with only `windowsHide` (`CREATE_NO_WINDOW`) still lets
+ * the child allocate a fresh, briefly-visible console — the flash reported in
+ * issue #233.
+ *
+ * Giving the Harness its own console and hiding it makes its children inherit
+ * a console that is already hidden, so `CREATE_NO_WINDOW` suppresses their
+ * windows the same way it does for a console-attached parent. `detached` is
+ * left in place, so the #208 Ctrl+C process-group isolation is preserved;
+ * `AllocConsole` on a detached process is exactly the escape hatch Microsoft
+ * documents for it.
+ *
+ * @param load - library loader, injectable for tests (defaults to `koffi.load`).
+ * @returns true when a console was attached and hidden.
+ */
+export function createHiddenConsole({ load = koffi.load } = {}) {
+  try {
+    const kernel32 = load('kernel32.dll')
+    const user32 = load('user32.dll')
+    const allocConsole = kernel32.func('AllocConsole', 'bool', [])
+    const getConsoleWindow = kernel32.func('GetConsoleWindow', 'void *', [])
+    const showWindow = user32.func('ShowWindow', 'bool', ['void *', 'int'])
+    if (!allocConsole()) return false
+    const window = getConsoleWindow()
+    if (window) showWindow(window, SW_HIDE)
+    return true
+  } catch {
+    // Best-effort: a failure here must never block Harness startup.
+    return false
+  }
+}

--- a/test/windows-hidden-console.test.ts
+++ b/test/windows-hidden-console.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createHiddenConsole } from '../build/windows-hidden-console.mjs'
+
+describe('createHiddenConsole', () => {
+  it('allocates a console and hides it with SW_HIDE', () => {
+    const allocConsole = vi.fn(() => true)
+    const getConsoleWindow = vi.fn(() => 123n)
+    const showWindow = vi.fn(() => true)
+
+    const load = vi.fn((name: string) => {
+      if (name === 'kernel32.dll') {
+        return {
+          func: vi.fn((fn: string) =>
+            fn === 'AllocConsole' ? allocConsole : getConsoleWindow
+          )
+        }
+      }
+      if (name === 'user32.dll') {
+        return { func: vi.fn(() => showWindow) }
+      }
+      throw new Error(`unexpected library ${name}`)
+    })
+
+    expect(createHiddenConsole({ load })).toBe(true)
+    expect(allocConsole).toHaveBeenCalledOnce()
+    expect(showWindow).toHaveBeenCalledWith(123n, 0)
+  })
+
+  it('returns false without hiding when AllocConsole fails', () => {
+    const allocConsole = vi.fn(() => false)
+    const showWindow = vi.fn()
+    const load = vi.fn((name: string) => {
+      if (name === 'kernel32.dll') {
+        return {
+          func: vi.fn((fn: string) => (fn === 'AllocConsole' ? allocConsole : vi.fn(() => 0n)))
+        }
+      }
+      return { func: vi.fn(() => showWindow) }
+    })
+
+    expect(createHiddenConsole({ load })).toBe(false)
+    expect(showWindow).not.toHaveBeenCalled()
+  })
+
+  it('skips ShowWindow when GetConsoleWindow returns a null window', () => {
+    const allocConsole = vi.fn(() => true)
+    const showWindow = vi.fn()
+    const load = vi.fn((name: string) => {
+      if (name === 'kernel32.dll') {
+        return {
+          func: vi.fn((fn: string) => (fn === 'AllocConsole' ? allocConsole : vi.fn(() => null)))
+        }
+      }
+      return { func: vi.fn(() => showWindow) }
+    })
+
+    expect(createHiddenConsole({ load })).toBe(true)
+    expect(showWindow).not.toHaveBeenCalled()
+  })
+
+  it('swallows loader errors and returns false', () => {
+    const load = vi.fn(() => {
+      throw new Error('win32 unavailable')
+    })
+    expect(createHiddenConsole({ load })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

On Windows, every `pwsh` (and other console tool) call briefly flashes a console window. The root cause: the desktop spawns the Harness with `detached: true` + `windowsHide: true` (`DETACHED_PROCESS | CREATE_NO_WINDOW`), so the Harness has no console. A console child spawned from a console-less parent with only `windowsHide` (`CREATE_NO_WINDOW`) still allocates a fresh, briefly-visible console — the flash (issue #233).

## Fix

Give the Harness its own console and hide it at startup (`AllocConsole` + `ShowWindow(..., SW_HIDE)`). Its children then inherit a console that is already hidden, so `CREATE_NO_WINDOW` suppresses their windows the same way it does for a console-attached parent.

`detached` is left in place, so the #208 Ctrl+C process-group isolation is preserved — `AllocConsole` on a detached process is the documented escape hatch for exactly this situation.

## Changes

- `build/windows-hidden-console.mjs` (new): `createHiddenConsole()` wraps the `AllocConsole` / `GetConsoleWindow` / `ShowWindow(SW_HIDE)` koffi calls, best-effort (never blocks Harness startup), with an injectable loader for tests.
- `build/harness-node-entry.mjs`: call `createHiddenConsole()` on Windows before the existing `windowsHide` child-process patch.
- `test/windows-hidden-console.test.ts` (new): unit tests for the call sequence (alloc → hide with `SW_HIDE`), `AllocConsole` failure, null window, and loader-error fallbacks.

## Validation

- `node --check` passes on both changed `build/*.mjs` files.
- `createHiddenConsole` logic exercised with a fake loader (alloc → hide with `SW_HIDE`=0; returns `false` on `AllocConsole` failure and on loader errors).
- **Not tested on a real Windows machine** — the fix is Windows-only and this change was prepared on macOS; the full vitest suite was not run locally (no `node_modules` in this checkout). Please treat the console-flash behaviour as needing on-Windows confirmation.

Fixes #233
