### PR TITLE
fix(types): add declaration file for windows-hidden-console

### DIFF
--- a/build/windows-hidden-console.d.mts
+++ b/build/windows-hidden-console.d.mts
@@ -1,0 +1,5 @@
+export interface CreateHiddenConsoleOptions {
+  load?: (name: string) => any
+}
+
+export function createHiddenConsole(options?: CreateHiddenConsoleOptions): boolean


### PR DESCRIPTION
## Summary

PR #289 added `build/windows-hidden-console.mjs` and its unit test `test/windows-hidden-console.test.ts`. However, it missed the TypeScript declaration file `build/windows-hidden-console.d.mts` (matching `build/windows-child-process-hide.d.mts`), causing `npm run typecheck` to fail with TS7016:

```
test/windows-hidden-console.test.ts(2,37): error TS7016: Could not find a declaration file for module '../build/windows-hidden-console.mjs'.
```

## Fix

Add `build/windows-hidden-console.d.mts` with typings for `createHiddenConsole`.

## Verification

- `npm run typecheck`: PASS
- `npx vitest run test/windows-hidden-console.test.ts`: PASS
