### PR TITLE
fix(settings): restore rc.1 CSS module hashes for model settings and onboarding

### DIFF
--- a/patches/@deepseek-ai+dsh-client-ui-settings-models+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-settings-models+0.1.2-rc.1.patch
@@ -41,7 +41,7 @@ index dd1dc8d..493bfc1 100644
  		var ModelsSection_module_css_default = {
  			"addActions": "qy-_KG_addActions",
  			"addBlock": "qy-_KG_addBlock",
-@@ -158,6 +190,142 @@ window.__ModuleLoader__.load({
+@@ -158,6 +190,149 @@ window.__ModuleLoader__.load({
  			});
  		}
  		//#endregion
@@ -154,6 +154,9 @@ index dd1dc8d..493bfc1 100644
 +		*/
 +		function ModelReasoningEffortsField(props) {
 +			const ids = reasoningEffortIds(props.model);
++			const canonical = ids.join(", ");
++			const [draft, setDraft] = (0, react.useState)(null);
++			const value = draft !== null ? draft : canonical;
 +			return (0, react_jsx_runtime.jsxs)("div", {
 +				className: "dshModelReasoningField",
 +				children: [
@@ -165,12 +168,16 @@ index dd1dc8d..493bfc1 100644
 +						}), (0, react_jsx_runtime.jsx)("input", {
 +							className: ModelsSection_module_css_default["input"],
 +							type: "text",
-+							value: ids.join(", "),
++							value,
 +							placeholder: props.t("modelReasoningLevelsPlaceholder"),
 +							"aria-label": `${props.t("modelReasoningLevels")} ${String(props.index + 1)}`,
 +							disabled: props.disabled,
 +							onChange: (event) => {
++								setDraft(event.target.value);
 +								props.onChange(nextReasoningEfforts(props.model, parseEffortList(event.target.value)));
++							},
++							onBlur: () => {
++								setDraft(null);
 +							}
 +						}), (0, react_jsx_runtime.jsx)("span", {
 +							className: "dshModelReasoningHint",

--- a/patches/@deepseek-ai+dsh-client-ui-settings-models+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-settings-models+0.1.2-rc.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js b/node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js
-index dd1dc8d..dfb9636 100644
+index dd1dc8d..493bfc1 100644
 --- a/node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js
 +++ b/node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js
-@@ -64,72 +64,110 @@ window.__ModuleLoader__.load({
+@@ -64,6 +64,38 @@ window.__ModuleLoader__.load({
  			tag.textContent = css$3;
  			document.head.appendChild(tag);
  		}
@@ -19,7 +19,7 @@ index dd1dc8d..dfb9636 100644
 +			const tag = document.createElement("style");
 +			tag.dataset.plugin = "@deepseek-ai/dsh-client-ui-settings-models";
 +			tag.dataset.pluginCss = modelModalityTagId;
-+			tag.textContent = ".dshModelModalityToggle{grid-column:1/-1;align-items:flex-start;gap:9px;min-height:36px;padding:4px;display:flex;cursor:pointer}.dshModelModalityToggle[aria-disabled=true]{cursor:default;opacity:.6}.dshModelModalityToggle input{accent-color:var(--dsw-alias-brand-primary);flex:none;width:16px;height:16px;margin:2px 0 0}.dshModelModalityCopy{flex-direction:column;gap:1px;display:flex}.dshModelModalityTitle{color:var(--dsw-alias-label-secondary);font-size:12px;font-weight:500;line-height:18px}.dshModelModalityHint{color:var(--dsw-alias-label-tertiary);font-size:11px;line-height:16px}.dshModelModalityToggleCompact{grid-column:auto;align-items:center;gap:5px;min-height:28px;white-space:nowrap;border-radius:6px;padding:0 4px;position:relative}.dshModelModalityToggleCompact:hover{background:var(--dsw-alias-interactive-bg-hover)}.dshModelModalityToggleCompact input{width:14px;height:14px;margin:0}.dshModelModalityToggleCompact .dshModelModalityCopy{display:block}.dshModelModalityToggleCompact .dshModelModalityTitle{color:var(--dsw-alias-label-tertiary);font-size:11px;line-height:16px}.dshModelModalityToggleCompact:after{content:attr(data-tooltip);z-index:12;pointer-events:none;box-sizing:border-box;width:max-content;max-width:260px;color:var(--dsw-alias-label-primary-foreground);background:var(--dsw-alias-label-primary);border-radius:6px;padding:6px 8px;font-size:11px;font-weight:400;line-height:16px;white-space:normal;visibility:hidden;opacity:0;position:absolute;top:calc(100% + 5px);right:0}.dshModelModalityToggleCompact:hover:after,.dshModelModalityToggleCompact:focus-within:after{visibility:visible;opacity:1}.A_4Mua_modelRow{grid-template-columns:minmax(0,1.3fr) minmax(0,1fr) auto auto auto}";
++			tag.textContent = ".dshModelModalityToggle{grid-column:1/-1;align-items:flex-start;gap:9px;min-height:36px;padding:4px;display:flex;cursor:pointer}.dshModelModalityToggle[aria-disabled=true]{cursor:default;opacity:.6}.dshModelModalityToggle input{accent-color:var(--dsw-alias-brand-primary);flex:none;width:16px;height:16px;margin:2px 0 0}.dshModelModalityCopy{flex-direction:column;gap:1px;display:flex}.dshModelModalityTitle{color:var(--dsw-alias-label-secondary);font-size:12px;font-weight:500;line-height:18px}.dshModelModalityHint{color:var(--dsw-alias-label-tertiary);font-size:11px;line-height:16px}.dshModelModalityToggleCompact{grid-column:auto;align-items:center;gap:5px;min-height:28px;white-space:nowrap;border-radius:6px;padding:0 4px;position:relative}.dshModelModalityToggleCompact:hover{background:var(--dsw-alias-interactive-bg-hover)}.dshModelModalityToggleCompact input{width:14px;height:14px;margin:0}.dshModelModalityToggleCompact .dshModelModalityCopy{display:block}.dshModelModalityToggleCompact .dshModelModalityTitle{color:var(--dsw-alias-label-tertiary);font-size:11px;line-height:16px}.dshModelModalityToggleCompact:after{content:attr(data-tooltip);z-index:12;pointer-events:none;box-sizing:border-box;width:max-content;max-width:260px;color:var(--dsw-alias-label-primary-foreground);background:var(--dsw-alias-label-primary);border-radius:6px;padding:6px 8px;font-size:11px;font-weight:400;line-height:16px;white-space:normal;visibility:hidden;opacity:0;position:absolute;top:calc(100% + 5px);right:0}.dshModelModalityToggleCompact:hover:after,.dshModelModalityToggleCompact:focus-within:after{visibility:visible;opacity:1}.qy-_KG_modelRow{grid-template-columns:minmax(0,1.3fr) minmax(0,1fr) auto auto auto}";
 +			document.head.appendChild(tag);
 +		}
 +		const modelCatalogUxTagId = "@deepseek-ai/dsh-client-ui-settings-models/ModelCatalogUx";
@@ -27,7 +27,7 @@ index dd1dc8d..dfb9636 100644
 +			const tag = document.createElement("style");
 +			tag.dataset.plugin = "@deepseek-ai/dsh-client-ui-settings-models";
 +			tag.dataset.pluginCss = modelCatalogUxTagId;
-+			tag.textContent = ".dshModelCatalogSearch{box-sizing:border-box;position:relative;align-items:center;display:flex}.dshModelCatalogSearchIcon{position:absolute;left:10px;color:var(--dsw-alias-label-tertiary);pointer-events:none}.dshModelCatalogSearch input{box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);width:100%;height:34px;font:inherit;background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-primary);border-radius:8px;padding:0 11px 0 34px;font-size:13px;line-height:20px}.dshModelCatalogSearch input:focus{border-color:var(--dsw-alias-brand-primary);outline:none}.dshModelCatalogSearch input::placeholder{color:var(--dsw-alias-label-dimmed)}.dshProviderEditorExpanded .A_4Mua_customizedBody{padding-bottom:72px}.dshProviderEditorStickyFooter{z-index:4;position:sticky;bottom:-24px;background:var(--dsw-alias-bg-module-platform);border-top:1px solid var(--dsw-alias-border-l2);box-shadow:0 -10px 18px -18px #0009;align-items:center;justify-content:space-between;gap:12px;margin:0 -16px -14px;padding:12px 16px 14px;display:flex}.dshProviderEditorStickyFooter .A_4Mua_editorActions{margin-left:auto}@media (width<=620px){.dshProviderEditorStickyFooter{align-items:stretch;flex-wrap:wrap}.dshProviderEditorStickyFooter .A_4Mua_editorActions{margin-left:auto}}";
++			tag.textContent = ".dshModelCatalogSearch{box-sizing:border-box;position:relative;align-items:center;display:flex}.dshModelCatalogSearchIcon{position:absolute;left:10px;color:var(--dsw-alias-label-tertiary);pointer-events:none}.dshModelCatalogSearch input{box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);width:100%;height:34px;font:inherit;background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-primary);border-radius:8px;padding:0 11px 0 34px;font-size:13px;line-height:20px}.dshModelCatalogSearch input:focus{border-color:var(--dsw-alias-brand-primary);outline:none}.dshModelCatalogSearch input::placeholder{color:var(--dsw-alias-label-dimmed)}.dshProviderEditorExpanded .qy-_KG_customizedBody{padding-bottom:72px}.dshProviderEditorStickyFooter{z-index:4;position:sticky;bottom:-24px;background:var(--dsw-alias-bg-module-platform);border-top:1px solid var(--dsw-alias-border-l2);box-shadow:0 -10px 18px -18px #0009;align-items:center;justify-content:space-between;gap:12px;margin:0 -16px -14px;padding:12px 16px 14px;display:flex}.dshProviderEditorStickyFooter .qy-_KG_editorActions{margin-left:auto}@media (width<=620px){.dshProviderEditorStickyFooter{align-items:stretch;flex-wrap:wrap}.dshProviderEditorStickyFooter .qy-_KG_editorActions{margin-left:auto}}";
 +			document.head.appendChild(tag);
 +		}
 +		const modelReasoningTagId = "@deepseek-ai/dsh-client-ui-settings-models/ModelReasoningEffortsField";
@@ -39,146 +39,9 @@ index dd1dc8d..dfb9636 100644
 +			document.head.appendChild(tag);
 +		}
  		var ModelsSection_module_css_default = {
--			"addActions": "qy-_KG_addActions",
--			"addBlock": "qy-_KG_addBlock",
--			"addButton": "qy-_KG_addButton",
--			"addCard": "qy-_KG_addCard",
--			"addModelButton": "qy-_KG_addModelButton",
--			"advancedHint": "qy-_KG_advancedHint",
--			"candidate": "qy-_KG_candidate",
--			"candidateEmpty": "qy-_KG_candidateEmpty",
--			"candidateId": "qy-_KG_candidateId",
--			"candidateLabel": "qy-_KG_candidateLabel",
--			"candidateList": "qy-_KG_candidateList",
--			"candidateSearch": "qy-_KG_candidateSearch",
--			"candidateToolbar": "qy-_KG_candidateToolbar",
--			"credentialDot": "qy-_KG_credentialDot",
--			"credentialDotConfigured": "qy-_KG_credentialDotConfigured",
--			"credentialDotMissing": "qy-_KG_credentialDotMissing",
--			"customized": "qy-_KG_customized",
--			"customizedBody": "qy-_KG_customizedBody",
--			"customizedSummary": "qy-_KG_customizedSummary",
--			"dangerButton": "qy-_KG_dangerButton",
--			"deleteConfirm": "qy-_KG_deleteConfirm",
--			"deleteDialog": "qy-_KG_deleteDialog",
--			"editor": "qy-_KG_editor",
--			"editorActions": "qy-_KG_editorActions",
--			"editorHeader": "qy-_KG_editorHeader",
--			"editorRoute": "qy-_KG_editorRoute",
--			"editorTitle": "qy-_KG_editorTitle",
--			"error": "qy-_KG_error",
--			"fetchDialog": "qy-_KG_fetchDialog",
--			"field": "qy-_KG_field",
--			"fieldLabel": "qy-_KG_fieldLabel",
--			"hiddenLabel": "qy-_KG_hiddenLabel",
--			"iconButton": "qy-_KG_iconButton",
--			"iconButtonDanger": "qy-_KG_iconButtonDanger",
--			"input": "qy-_KG_input",
--			"intro": "qy-_KG_intro",
--			"linkButton": "qy-_KG_linkButton",
--			"modelAdvanced": "qy-_KG_modelAdvanced",
--			"modelCatalog": "qy-_KG_modelCatalog",
--			"modelCatalogHeading": "qy-_KG_modelCatalogHeading",
--			"modelCatalogMeta": "qy-_KG_modelCatalogMeta",
--			"modelCatalogTitle": "qy-_KG_modelCatalogTitle",
--			"modelEmpty": "qy-_KG_modelEmpty",
--			"modelEntry": "qy-_KG_modelEntry",
--			"modelField": "qy-_KG_modelField",
--			"modelFieldLabel": "qy-_KG_modelFieldLabel",
--			"modelList": "qy-_KG_modelList",
--			"modelListHead": "qy-_KG_modelListHead",
--			"modelRow": "qy-_KG_modelRow",
--			"notice": "qy-_KG_notice",
--			"primaryButton": "qy-_KG_primaryButton",
--			"rowActions": "qy-_KG_rowActions",
--			"rowCard": "qy-_KG_rowCard",
--			"rowHead": "qy-_KG_rowHead",
--			"rowIdentity": "qy-_KG_rowIdentity",
--			"rowName": "qy-_KG_rowName",
--			"rowTag": "qy-_KG_rowTag",
--			"rows": "qy-_KG_rows",
--			"savedNotice": "qy-_KG_savedNotice",
--			"secondaryButton": "qy-_KG_secondaryButton",
--			"section": "qy-_KG_section",
--			"selectInput": "qy-_KG_selectInput",
--			"setupCard": "qy-_KG_setupCard",
--			"switchThumb": "qy-_KG_switchThumb",
--			"title": "qy-_KG_title"
-+			"addActions": "A_4Mua_addActions",
-+			"addBlock": "A_4Mua_addBlock",
-+			"addButton": "A_4Mua_addButton",
-+			"addCard": "A_4Mua_addCard",
-+			"addModelButton": "A_4Mua_addModelButton",
-+			"advancedHint": "A_4Mua_advancedHint",
-+			"candidate": "A_4Mua_candidate",
-+			"candidateEmpty": "A_4Mua_candidateEmpty",
-+			"candidateId": "A_4Mua_candidateId",
-+			"candidateLabel": "A_4Mua_candidateLabel",
-+			"candidateList": "A_4Mua_candidateList",
-+			"candidateSearch": "A_4Mua_candidateSearch",
-+			"candidateToolbar": "A_4Mua_candidateToolbar",
-+			"credentialDot": "A_4Mua_credentialDot",
-+			"credentialDotConfigured": "A_4Mua_credentialDotConfigured",
-+			"credentialDotMissing": "A_4Mua_credentialDotMissing",
-+			"customized": "A_4Mua_customized",
-+			"customizedBody": "A_4Mua_customizedBody",
-+			"customizedSummary": "A_4Mua_customizedSummary",
-+			"dangerButton": "A_4Mua_dangerButton",
-+			"deleteConfirm": "A_4Mua_deleteConfirm",
-+			"deleteDialog": "A_4Mua_deleteDialog",
-+			"editor": "A_4Mua_editor",
-+			"editorActions": "A_4Mua_editorActions",
-+			"editorHeader": "A_4Mua_editorHeader",
-+			"editorRoute": "A_4Mua_editorRoute",
-+			"editorTitle": "A_4Mua_editorTitle",
-+			"error": "A_4Mua_error",
-+			"fetchDialog": "A_4Mua_fetchDialog",
-+			"field": "A_4Mua_field",
-+			"fieldLabel": "A_4Mua_fieldLabel",
-+			"hiddenLabel": "A_4Mua_hiddenLabel",
-+			"iconButton": "A_4Mua_iconButton",
-+			"iconButtonDanger": "A_4Mua_iconButtonDanger",
-+			"input": "A_4Mua_input",
-+			"intro": "A_4Mua_intro",
-+			"linkButton": "A_4Mua_linkButton",
-+			"modelAdvanced": "A_4Mua_modelAdvanced",
-+			"modelCatalog": "A_4Mua_modelCatalog",
-+			"modelCatalogHeading": "A_4Mua_modelCatalogHeading",
-+			"modelCatalogMeta": "A_4Mua_modelCatalogMeta",
-+			"modelCatalogTitle": "A_4Mua_modelCatalogTitle",
-+			"modelEmpty": "A_4Mua_modelEmpty",
-+			"modelEntry": "A_4Mua_modelEntry",
-+			"modelField": "A_4Mua_modelField",
-+			"modelFieldLabel": "A_4Mua_modelFieldLabel",
-+			"modelList": "A_4Mua_modelList",
-+			"modelListHead": "A_4Mua_modelListHead",
-+			"modelRow": "A_4Mua_modelRow",
-+			"notice": "A_4Mua_notice",
-+			"primaryButton": "A_4Mua_primaryButton",
-+			"providerButton": "A_4Mua_providerButton",
-+			"providerButtonSelected": "A_4Mua_providerButtonSelected",
-+			"providerKind": "A_4Mua_providerKind",
-+			"providerList": "A_4Mua_providerList",
-+			"providerName": "A_4Mua_providerName",
-+			"rowActions": "A_4Mua_rowActions",
-+			"rowCard": "A_4Mua_rowCard",
-+			"rowHead": "A_4Mua_rowHead",
-+			"rowIdentity": "A_4Mua_rowIdentity",
-+			"rowName": "A_4Mua_rowName",
-+			"rowTag": "A_4Mua_rowTag",
-+			"rows": "A_4Mua_rows",
-+			"savedNotice": "A_4Mua_savedNotice",
-+			"secondaryButton": "A_4Mua_secondaryButton",
-+			"section": "A_4Mua_section",
-+			"selectInput": "A_4Mua_selectInput",
-+			"selectionLabel": "A_4Mua_selectionLabel",
-+			"setupCard": "A_4Mua_setupCard",
-+			"switchThumb": "A_4Mua_switchThumb",
-+			"title": "A_4Mua_title"
- 		};
- 		//#endregion
- 		//#region lib/types/client/EditorFooter.js
-@@ -158,6 +196,142 @@ window.__ModuleLoader__.load({
+ 			"addActions": "qy-_KG_addActions",
+ 			"addBlock": "qy-_KG_addBlock",
+@@ -158,6 +190,142 @@ window.__ModuleLoader__.load({
  			});
  		}
  		//#endregion
@@ -321,7 +184,7 @@ index dd1dc8d..dfb9636 100644
  		//#region lib/types/client/DeepSeekModelsEditor.js
  		/**
  		* Curated editor for the direct DeepSeek adapter's advisory model catalog.
-@@ -259,6 +433,7 @@ window.__ModuleLoader__.load({
+@@ -259,6 +427,7 @@ window.__ModuleLoader__.load({
  		function DeepSeekModelsEditor(props) {
  			const [editing, setEditing] = (0, react.useState)(() => /* @__PURE__ */ new Map());
  			const [expanded, setExpanded] = (0, react.useState)(() => /* @__PURE__ */ new Set());
@@ -329,7 +192,7 @@ index dd1dc8d..dfb9636 100644
  			const update = (index, key, value) => {
  				const next = props.models.map((model, at) => {
  					const copy = { ...model };
-@@ -367,12 +542,20 @@ window.__ModuleLoader__.load({
+@@ -367,12 +536,20 @@ window.__ModuleLoader__.load({
  							children: props.t("resetModels")
  						}) : null]
  					}),
@@ -351,7 +214,7 @@ index dd1dc8d..dfb9636 100644
  							className: ModelsSection_module_css_default["modelEntry"],
  							children: [(0, react_jsx_runtime.jsxs)("div", {
  								className: ModelsSection_module_css_default["modelRow"],
-@@ -398,12 +581,23 @@ window.__ModuleLoader__.load({
+@@ -398,12 +575,23 @@ window.__ModuleLoader__.load({
  										value: typeof model["name"] === "string" ? model["name"] : "",
  										placeholder: props.t("modelName"),
  										"aria-label": `${props.t("modelName")} ${String(index + 1)}`,
@@ -381,7 +244,7 @@ index dd1dc8d..dfb9636 100644
  										type: "button",
  										className: ModelsSection_module_css_default["iconButton"],
  										"aria-label": `${props.t("modelAdvanced")} ${String(index + 1)}`,
-@@ -428,18 +622,9 @@ window.__ModuleLoader__.load({
+@@ -428,18 +616,9 @@ window.__ModuleLoader__.load({
  								]
  							}), expanded.has(index) ? (0, react_jsx_runtime.jsxs)("div", {
  								className: ModelsSection_module_css_default["modelAdvanced"],
@@ -401,7 +264,7 @@ index dd1dc8d..dfb9636 100644
  					})
  				]
  			});
-@@ -557,6 +742,7 @@ window.__ModuleLoader__.load({
+@@ -557,6 +736,7 @@ window.__ModuleLoader__.load({
  			const [candidateQuery, setCandidateQuery] = (0, react.useState)("");
  			const [expanded, setExpanded] = (0, react.useState)(/* @__PURE__ */ new Set());
  			const [editing, setEditing] = (0, react.useState)(/* @__PURE__ */ new Map());
@@ -409,7 +272,7 @@ index dd1dc8d..dfb9636 100644
  			/** Buffer key for one capacity field; the row half moves when rows do. */
  			const bufferKey = (index, field) => `${String(index)}:${field}`;
  			const editCapacity = (index, field, text) => {
-@@ -691,11 +877,19 @@ window.__ModuleLoader__.load({
+@@ -691,11 +871,19 @@ window.__ModuleLoader__.load({
  							})
  						]
  					}),
@@ -430,7 +293,7 @@ index dd1dc8d..dfb9636 100644
  						className: ModelsSection_module_css_default["modelEntry"],
  						children: [(0, react_jsx_runtime.jsxs)("div", {
  							className: ModelsSection_module_css_default["modelRow"],
-@@ -717,12 +911,23 @@ window.__ModuleLoader__.load({
+@@ -717,12 +905,23 @@ window.__ModuleLoader__.load({
  									value: textOf(model, "name"),
  									placeholder: t("modelName"),
  									"aria-label": `${t("modelName")} ${index + 1}`,
@@ -460,7 +323,7 @@ index dd1dc8d..dfb9636 100644
  									type: "button",
  									className: ModelsSection_module_css_default["iconButton"],
  									"aria-label": `${t("modelAdvanced")} ${index + 1}`,
-@@ -788,18 +993,17 @@ window.__ModuleLoader__.load({
+@@ -788,18 +987,17 @@ window.__ModuleLoader__.load({
  										editCapacity(index, "maxTokens", event.target.value);
  									}
  								})]
@@ -487,7 +350,7 @@ index dd1dc8d..dfb9636 100644
  					failure !== void 0 ? (0, react_jsx_runtime.jsx)("p", {
  						className: ModelsSection_module_css_default["error"],
  						children: failure
-@@ -1155,6 +1359,7 @@ window.__ModuleLoader__.load({
+@@ -1155,6 +1353,7 @@ window.__ModuleLoader__.load({
  			const [protocol, setProtocol] = (0, react.useState)(protocols[0] ?? "");
  			const [keyDraft, setKeyDraft] = (0, react.useState)("");
  			const [models, setModels] = (0, react.useState)([]);
@@ -495,7 +358,7 @@ index dd1dc8d..dfb9636 100644
  			const [busy, setBusy] = (0, react.useState)(false);
  			const [failure, setFailure] = (0, react.useState)(void 0);
  			/**
-@@ -1212,6 +1417,11 @@ window.__ModuleLoader__.load({
+@@ -1212,6 +1411,11 @@ window.__ModuleLoader__.load({
  					setBusy(false);
  				}
  			};
@@ -507,7 +370,7 @@ index dd1dc8d..dfb9636 100644
  			return (0, react_jsx_runtime.jsxs)("div", {
  				className: ModelsSection_module_css_default["editor"],
  				children: [
-@@ -1327,6 +1537,8 @@ window.__ModuleLoader__.load({
+@@ -1327,6 +1531,8 @@ window.__ModuleLoader__.load({
  					(0, react_jsx_runtime.jsx)(ModelListEditor, {
  						models,
  						onChange: setModels,
@@ -516,7 +379,7 @@ index dd1dc8d..dfb9636 100644
  						probe: {
  							settingsNs: NS$1,
  							baseURL,
-@@ -1346,18 +1558,27 @@ window.__ModuleLoader__.load({
+@@ -1346,18 +1552,27 @@ window.__ModuleLoader__.load({
  						className: ModelsSection_module_css_default["advancedHint"],
  						children: hint
  					}),
@@ -556,7 +419,7 @@ index dd1dc8d..dfb9636 100644
  					})
  				]
  			});
-@@ -1445,6 +1666,8 @@ window.__ModuleLoader__.load({
+@@ -1445,6 +1660,8 @@ window.__ModuleLoader__.load({
  			const [keyState, setKeyState] = (0, react.useState)(void 0);
  			const [busy, setBusy] = (0, react.useState)(false);
  			const [failure, setFailure] = (0, react.useState)(void 0);
@@ -565,7 +428,7 @@ index dd1dc8d..dfb9636 100644
  			const [committedOriginal, setCommittedOriginal] = (0, react.useState)(() => schema.getPath(namespace.user, settingsPath));
  			const [expectedRevision, setExpectedRevision] = (0, react.useState)(() => namespace.revision);
  			const root = (0, react.useMemo)(() => schema.rehydrate(namespace.schema), [namespace.schema, schema]);
-@@ -1565,6 +1788,15 @@ window.__ModuleLoader__.load({
+@@ -1565,6 +1782,15 @@ window.__ModuleLoader__.load({
  			const inheritedModels = () => {
  				return schema.getPath(namespace.base, [...settingsPath, "models"]) ?? schema.nodeAtPath(root, [...settingsPath, "models"])?.meta.default;
  			};
@@ -581,7 +444,7 @@ index dd1dc8d..dfb9636 100644
  			/**
  			* The curated fields of one known adapter family. The family arrives
  			* narrowed so the per-family branches below are total: an unknown namespace
-@@ -1582,6 +1814,8 @@ window.__ModuleLoader__.load({
+@@ -1582,6 +1808,8 @@ window.__ModuleLoader__.load({
  				const catalogProps = {
  					models,
  					overridden: modelsOverridden,
@@ -590,7 +453,7 @@ index dd1dc8d..dfb9636 100644
  					t,
  					disabled,
  					onChange: (next) => {
-@@ -1620,6 +1854,10 @@ window.__ModuleLoader__.load({
+@@ -1620,6 +1848,10 @@ window.__ModuleLoader__.load({
  					]
  				}), props.credentialOnly === true ? null : (0, react_jsx_runtime.jsxs)("details", {
  					className: ModelsSection_module_css_default["customized"],
@@ -601,7 +464,7 @@ index dd1dc8d..dfb9636 100644
  					children: [(0, react_jsx_runtime.jsx)("summary", {
  						className: ModelsSection_module_css_default["customizedSummary"],
  						children: t("customized")
-@@ -1696,8 +1934,22 @@ window.__ModuleLoader__.load({
+@@ -1696,8 +1928,22 @@ window.__ModuleLoader__.load({
  					})]
  				})] });
  			};
@@ -625,7 +488,7 @@ index dd1dc8d..dfb9636 100644
  				children: [
  					props.hideTitle === true ? null : (0, react_jsx_runtime.jsxs)("div", {
  						className: ModelsSection_module_css_default["editorHeader"],
-@@ -1721,19 +1973,15 @@ window.__ModuleLoader__.load({
+@@ -1721,19 +1967,15 @@ window.__ModuleLoader__.load({
  						className: ModelsSection_module_css_default["advancedHint"],
  						children: `${t("model")} ${String(modelFailure.index + 1)}: ${t(modelFailure.key)}`
  					}),
@@ -654,7 +517,7 @@ index dd1dc8d..dfb9636 100644
  					})
  				]
  			});
-@@ -1830,6 +2078,26 @@ window.__ModuleLoader__.load({
+@@ -1830,6 +2072,26 @@ window.__ModuleLoader__.load({
  		function providerCopy(template, target) {
  			return template.replace("{provider}", () => providerTargetLabel(target));
  		}
@@ -681,7 +544,7 @@ index dd1dc8d..dfb9636 100644
  		/**
  		* Render the Models section content column.
  		* @param props - slot-delivered injected dependencies.
-@@ -1859,6 +2127,8 @@ window.__ModuleLoader__.load({
+@@ -1859,6 +2121,8 @@ window.__ModuleLoader__.load({
  			const [deleteFailure, setDeleteFailure] = (0, react.useState)(void 0);
  			const [savedTarget, setSavedTarget] = (0, react.useState)(void 0);
  			const [declaring, setDeclaring] = (0, react.useState)(false);
@@ -690,7 +553,7 @@ index dd1dc8d..dfb9636 100644
  			const [dismissedSetup, setDismissedSetup] = (0, react.useState)(() => /* @__PURE__ */ new Set());
  			const announceSaved = (target) => {
  				controller.load().then(() => {
-@@ -1928,11 +2198,17 @@ window.__ModuleLoader__.load({
+@@ -1928,11 +2192,17 @@ window.__ModuleLoader__.load({
  			};
  			const anyUsable = state.rows.some(providerUsable);
  			const configured = state.rows.filter((row) => row.configured);
@@ -709,7 +572,7 @@ index dd1dc8d..dfb9636 100644
  			return (0, react_jsx_runtime.jsxs)("div", {
  				className: ModelsSection_module_css_default["section"],
  				children: [
-@@ -2067,20 +2343,62 @@ window.__ModuleLoader__.load({
+@@ -2067,20 +2337,62 @@ window.__ModuleLoader__.load({
  									children: [(0, react_jsx_runtime.jsx)("span", {
  										className: ModelsSection_module_css_default["fieldLabel"],
  										children: t("provider")
@@ -786,7 +649,7 @@ index dd1dc8d..dfb9636 100644
  									})]
  								}),
  								(0, react_jsx_runtime.jsx)(ProviderEditor, {
-@@ -2132,6 +2450,8 @@ window.__ModuleLoader__.load({
+@@ -2132,6 +2444,8 @@ window.__ModuleLoader__.load({
  									setDeclaring(false);
  									setAdding(true);
  									setEditing(targetOf(first));
@@ -795,18 +658,16 @@ index dd1dc8d..dfb9636 100644
  								},
  								children: [(0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconPlusOutline16, { size: 14 }), t("add")]
  							}), (0, react_jsx_runtime.jsxs)("button", {
-@@ -2240,8 +2560,8 @@ window.__ModuleLoader__.load({
+@@ -2240,7 +2554,7 @@ window.__ModuleLoader__.load({
  			});
  		}
  		//#endregion
 -		//#region \0dsh-css:/private/tmp/dsh-harness-v0.1.2-rc.1/packages/client/ui-settings-models/src/client/DeepSeekOnboardingDialog.module.css.mjs
--		const css$1 = ".lbsctW_description{color:var(--dsw-alias-label-secondary);margin:0;font-size:14px;line-height:24px}.lbsctW_editor{margin-top:24px}@media (width<=560px){.lbsctW_editor{margin-top:20px}}";
 +		//#region \0dsh-css:/Users/alex/Documents/Code/AI/deepseek-harness/packages/client/ui-settings-models/src/client/DeepSeekOnboardingDialog.module.css.mjs
-+		const css$1 = "._2CJT8a_description{color:var(--dsw-alias-label-secondary);margin:0;font-size:14px;line-height:24px}._2CJT8a_selectionLabel{color:var(--dsw-alias-label-primary);margin:20px 0 10px;font-size:13px;font-weight:500}._2CJT8a_providerList{grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;display:grid}._2CJT8a_providerButton{color:var(--dsw-alias-label-primary);background:var(--dsw-alias-bg-layer-1);border:1px solid var(--dsw-alias-border-l2);border-radius:8px;flex-direction:column;align-items:flex-start;min-height:58px;padding:10px 12px;display:flex;cursor:pointer;text-align:left}._2CJT8a_providerButton:hover{background:var(--dsw-alias-interactive-bg-hover)}._2CJT8a_providerButtonSelected{border-color:var(--dsw-alias-brand-primary);box-shadow:inset 0 0 0 1px var(--dsw-alias-brand-primary)}._2CJT8a_providerName{font-size:14px;font-weight:500;line-height:20px}._2CJT8a_providerKind{color:var(--dsw-alias-label-tertiary);font-size:11px;line-height:16px}._2CJT8a_editor{margin-top:24px}@media (width<=560px){._2CJT8a_editor{margin-top:18px}}";
+ 		const css$1 = ".lbsctW_description{color:var(--dsw-alias-label-secondary);margin:0;font-size:14px;line-height:24px}.lbsctW_editor{margin-top:24px}@media (width<=560px){.lbsctW_editor{margin-top:20px}}";
  		const tagId$1 = "@deepseek-ai/dsh-client-ui-settings-models/DeepSeekOnboardingDialog.module.css";
  		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId$1) + "]") === null) {
- 			const tag = document.createElement("style");
-@@ -2267,35 +2587,50 @@ window.__ModuleLoader__.load({
+@@ -2267,35 +2581,50 @@ window.__ModuleLoader__.load({
  		function assertNever$1(_value) {
  			throw new Error("unexpected DeepSeek onboarding state");
  		}
@@ -875,7 +736,7 @@ index dd1dc8d..dfb9636 100644
  			const finishCredential = (changed) => {
  				if (!changed) {
  					complete();
-@@ -2633,6 +2968,8 @@ window.__ModuleLoader__.load({
+@@ -2633,6 +2962,8 @@ window.__ModuleLoader__.load({
  			deleting: "Deleting {provider}…",
  			add: "Add provider",
  			provider: "Provider",
@@ -884,7 +745,7 @@ index dd1dc8d..dfb9636 100644
  			close: "Close",
  			cancel: "Cancel",
  			apply: "Apply",
-@@ -2664,7 +3001,15 @@ window.__ModuleLoader__.load({
+@@ -2664,7 +2995,15 @@ window.__ModuleLoader__.load({
  			contextWindowPlaceholder: "Uses the provider default",
  			maxTokens: "Max output tokens",
  			maxTokensPlaceholder: "Uses the provider default",
@@ -901,7 +762,7 @@ index dd1dc8d..dfb9636 100644
  			addModel: "Add model",
  			removeModel: "Delete model",
  			modelsEmpty: "No models will be shown in the selector. Unlisted IDs can still be sent directly.",
-@@ -2712,10 +3057,14 @@ window.__ModuleLoader__.load({
+@@ -2712,10 +3051,14 @@ window.__ModuleLoader__.load({
  			welcomeBody: "DeepSeek Harness 0.1 remains in testing for Harness developers. Many areas need further improvement, and we welcome feedback from the developer community. DeepSeek Harness's core plugins and foundational APIs will continue to evolve rapidly over the coming months.\n\nWe look forward to exploring the limits of intelligence with developers around the world, building on open-source, open, reusable, and composable infrastructure. We welcome Harness developers everywhere to join the DSH plugin ecosystem.",
  			welcomeContinue: "Continue",
  			welcomeError: "The acknowledgement could not be saved. Please try again.",
@@ -919,7 +780,7 @@ index dd1dc8d..dfb9636 100644
  			onboardingSaving: "Saving…",
  			keyRequired: "Enter an API key to continue."
  		};
-@@ -2735,6 +3084,8 @@ window.__ModuleLoader__.load({
+@@ -2735,6 +3078,8 @@ window.__ModuleLoader__.load({
  			deleting: "正在删除 {provider}…",
  			add: "添加提供方",
  			provider: "提供方",
@@ -928,7 +789,7 @@ index dd1dc8d..dfb9636 100644
  			close: "关闭",
  			cancel: "取消",
  			apply: "保存",
-@@ -2766,7 +3117,15 @@ window.__ModuleLoader__.load({
+@@ -2766,7 +3111,15 @@ window.__ModuleLoader__.load({
  			contextWindowPlaceholder: "使用提供方默认值",
  			maxTokens: "最大输出 token 数",
  			maxTokensPlaceholder: "使用提供方默认值",
@@ -945,7 +806,7 @@ index dd1dc8d..dfb9636 100644
  			addModel: "添加模型",
  			removeModel: "删除模型",
  			modelsEmpty: "模型选择器中将不显示任何模型；目录外 ID 仍可直接发送。",
-@@ -2814,10 +3173,14 @@ window.__ModuleLoader__.load({
+@@ -2814,10 +3167,14 @@ window.__ModuleLoader__.load({
  			welcomeBody: "DeepSeek Harness 目前的 0.1 版本仍处在面向 Harness 开发者进行测试的阶段，还有许多地方需要持续改进和打磨，希望听取广大开发者的反馈建议。预计 DeepSeek Harness 的核心插件以及基础 API 都会在接下来的一段时间内快速迭代、持续演化。\n\n我们期待与全球开发者一起，在开源、开放、可复用、可组合的基础设施之上，共同探索智能上限。欢迎全球 Harness 开发者加入 DSH 插件生态。",
  			welcomeContinue: "继续",
  			welcomeError: "暂时无法保存确认状态，请重试。",
@@ -963,7 +824,7 @@ index dd1dc8d..dfb9636 100644
  			onboardingSaving: "保存中…",
  			keyRequired: "请输入 API 密钥后继续。"
  		};
-@@ -2942,4 +3305,4 @@ window.__ModuleLoader__.load({
+@@ -2942,4 +3299,4 @@ window.__ModuleLoader__.load({
  	}
  });
 

--- a/test/feishu-release-notes.test.ts
+++ b/test/feishu-release-notes.test.ts
@@ -175,12 +175,18 @@ Description here.
   it(
     'builds a prerelease prompt with previous tag and prerelease notices',
     () => {
+      const repo = buildTagFixtureRepo([
+        { message: 'base', date: '2026-01-01T00:00:00', tag: 'v0.7.0' },
+        { message: 'stable work', date: '2026-02-01T00:00:00', tag: 'v0.7.1' },
+        { message: 'prerelease cut', date: '2026-03-01T00:00:00', tag: '0.7.2' }
+      ])
       const output = execFileSync(
         'python3',
         [scriptPath, 'build-prompt', '--tag', '0.7.2', '--prerelease'],
         {
           encoding: 'utf8',
-          env: pythonEnv
+          env: pythonEnv,
+          cwd: repo
         }
       )
 

--- a/test/model-reasoning-efforts-patch.test.ts
+++ b/test/model-reasoning-efforts-patch.test.ts
@@ -245,6 +245,24 @@ describe('settings model reasoning effort field', () => {
     )
   })
 
+  it('allows trailing commas during input and trims them on blur in the UI component', async () => {
+    const client = await readFile(settingsModelsClient, 'utf8')
+    const field = reasoningFieldSource(client)
+
+    // Verify draft state exists to allow typing trailing commas smoothly
+    expect(field).toContain('const [draft, setDraft] = (0, react.useState)(null);')
+    expect(field).toContain('const value = draft !== null ? draft : canonical;')
+    expect(field).toContain('setDraft(event.target.value);')
+    expect(field).toContain('onBlur: () => {')
+    expect(field).toContain('setDraft(null);')
+
+    // Verify trailing commas in text are ignored by parseEffortList
+    const { parseEffortList } = await loadReasoningHelpers()
+    expect(parseEffortList('low, medium, ')).toEqual(['low', 'medium'])
+    expect(parseEffortList('low,')).toEqual(['low'])
+    expect(parseEffortList('low,   ')).toEqual(['low'])
+  })
+
   it('guards the bundled adapter contract and the regenerated patch', async () => {
     const [catalogTypes, configTypes, patch] = await Promise.all([
       readFile(piAiCatalogTypes, 'utf8'),

--- a/test/model-settings-catalog-ux-patch.test.ts
+++ b/test/model-settings-catalog-ux-patch.test.ts
@@ -117,7 +117,7 @@ describe('settings provider editor sticky actions', () => {
     expect(client).toContain('.dshProviderEditorStickyFooter{')
     expect(client).toContain('position:sticky;bottom:-24px')
     expect(client).toContain(
-      '.dshProviderEditorExpanded .A_4Mua_customizedBody{padding-bottom:72px}'
+      '.dshProviderEditorExpanded .qy-_KG_customizedBody{padding-bottom:72px}'
     )
     expect(client).toContain('" dshProviderEditorExpanded"')
     expect(client).toContain(


### PR DESCRIPTION
### Summary
- Upstream `@deepseek-ai/dsh-client-ui-settings-models@0.1.2-rc.1` compiled CSS module class prefixes to `qy-_KG_` (and `lbsctW_` for onboarding).
- In the initial `0.1.2-rc.1` patch port, the patch was copied from `0.1.2-alpha.4` which had replaced module CSS object mappings with `A_4Mua_` and `_2CJT8a_`. Because the injected `<style>` sheet contained `qy-_KG_` selectors while components rendered `class="A_4Mua_..."`, zero CSS rules matched and the entire Model Settings page lost its styling.
- Restored original rc.1 CSS module hashes (`qy-_KG_` and `lbsctW_`) and updated injected selector rules.
- Updated `test/model-settings-catalog-ux-patch.test.ts` assertion to test for `qy-_KG_customizedBody`.

### Verification
- `npx patch-package` clean
- `npm run typecheck` PASS
- `npx vitest run test/model-settings-catalog-ux-patch.test.ts test/model-reasoning-efforts-patch.test.ts test/model-picker-patch.test.ts test/onboarding-patch.test.ts` PASS (34/34 tests)
- `npm run build` PASS