### PR TITLE
fix(packaging): include Windows hidden console helper

### DIFF
--- a/docs/harness-0.1.2-rc.1-upgrade.md
+++ b/docs/harness-0.1.2-rc.1-upgrade.md
@@ -38,6 +38,12 @@ Preview 或其他可选 Bundle 意外打入桌面应用。
 `@deepseek-ai/dsh*` 补丁文件名由 `0.1.2-alpha.4` 改为 `0.1.2-rc.1`。上游本次未变更这些
 补丁覆盖的源码文件，版本标识迁移后仍必须由 `patch-package` 的 clean install 结果验证。
 
+## Windows Harness 运行资源
+
+`build/harness-node-entry.mjs` 在 Windows 启动路径中加载 `windows-hidden-console.mjs`。两者作为
+同一组 `extraResources` 进入安装包，`release.test.ts` 同时校验入口导入和资源清单，保证打包后的
+Harness 可以创建隐藏控制台并继续启动。
+
 ## 验证
 
 - 上游标签：`pnpm install --frozen-lockfile`、`pnpm run build:official`、两类 `release/pack.ts` 成功。

--- a/package.json
+++ b/package.json
@@ -333,6 +333,10 @@
         "to": "harness-node-entry.mjs"
       },
       {
+        "from": "build/windows-hidden-console.mjs",
+        "to": "windows-hidden-console.mjs"
+      },
+      {
         "from": "build/windows-child-process-hide.mjs",
         "to": "windows-child-process-hide.mjs"
       },

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -156,6 +156,10 @@ describe('GitHub release contract', () => {
       to: 'icon.png'
     })
     expect(packageJson.build.extraResources).toContainEqual({
+      from: 'build/windows-hidden-console.mjs',
+      to: 'windows-hidden-console.mjs'
+    })
+    expect(packageJson.build.extraResources).toContainEqual({
       from: 'build/windows-child-process-hide.mjs',
       to: 'windows-child-process-hide.mjs'
     })

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -153,6 +153,10 @@ describe('GitHub release contract', () => {
       path.join(projectRoot, 'build', 'harness-node-entry.mjs'),
       'utf8'
     )
+    const windowsHiddenConsole = await readFile(
+      path.join(projectRoot, 'build', 'windows-hidden-console.mjs'),
+      'utf8'
+    )
 
     expect(packageJson.build.artifactName).toBe('dsh-desktop-${os}-${arch}.${ext}')
     expect(packageJson.build.extraResources).toContainEqual({
@@ -164,6 +168,7 @@ describe('GitHub release contract', () => {
       to: 'windows-hidden-console.mjs'
     })
     expect(harnessNodeEntry).toContain("await import('./windows-hidden-console.mjs')")
+    expect(windowsHiddenConsole).toContain('export function createHiddenConsole')
     expect(packageJson.build.extraResources).toContainEqual({
       from: 'build/windows-child-process-hide.mjs',
       to: 'windows-child-process-hide.mjs'

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -149,6 +149,10 @@ describe('GitHub release contract', () => {
         portable?: unknown
       }
     }
+    const harnessNodeEntry = await readFile(
+      path.join(projectRoot, 'build', 'harness-node-entry.mjs'),
+      'utf8'
+    )
 
     expect(packageJson.build.artifactName).toBe('dsh-desktop-${os}-${arch}.${ext}')
     expect(packageJson.build.extraResources).toContainEqual({
@@ -159,6 +163,7 @@ describe('GitHub release contract', () => {
       from: 'build/windows-hidden-console.mjs',
       to: 'windows-hidden-console.mjs'
     })
+    expect(harnessNodeEntry).toContain("await import('./windows-hidden-console.mjs')")
     expect(packageJson.build.extraResources).toContainEqual({
       from: 'build/windows-child-process-hide.mjs',
       to: 'windows-child-process-hide.mjs'


### PR DESCRIPTION
## Summary

- Follow up merged PR #297 with the Windows Harness runtime resource that landed on the source branch after the merge.
- Package `build/windows-hidden-console.mjs` beside `harness-node-entry.mjs` through Electron Builder `extraResources`.
- Lock the importer, packaged resource, and helper export together with release regressions.
- Document the Windows Harness resource contract in the 0.1.2-rc.1 upgrade note.

## Scope

PR #297 already landed the Kimi PPT route, the reduced 22-template catalog, and template `textCapacity`. This PR is based on current `main` and contains only the post-merge Windows packaging fix; it does not replay the #297 feature diff or change the template catalog.

## Verification

- PASS: `npm test -- test/release.test.ts test/windows-hidden-console.test.ts test/kimi-ppt-integration.test.ts` — 37/37
- PASS: `npm run typecheck`
- PASS: `npm run build`
- PASS: `git diff --check upstream/main...HEAD`
- BASELINE: full `npm test` — 690/700 passed; the remaining 10 failures are in `model-reasoning-efforts-patch` and `model-settings-catalog-ux-patch`, and reproduce unchanged on `upstream/main@8b018c9`

## Acceptance boundary

The source/resource contract and local build pass. A Windows installer build and packaged Harness startup remain CI/runtime acceptance gates.
