### PR TITLE
fix(deliverables): keep scoped packages and emails out of file links

### DIFF
--- a/patches/@deepseek-ai+dsh-client-ui-deliverables+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-deliverables+0.1.2-rc.1.patch
@@ -10,7 +10,7 @@ diff --git a/node_modules/@deepseek-ai/dsh-client-ui-deliverables/lib/client.js 
  				if (path === void 0) return void 0;
  				return {
  					open: () => {
-@@ -218,6 +218,21 @@
+@@ -218,6 +218,28 @@
  					title: path
  				};
  			} };
@@ -20,12 +20,19 @@ diff --git a/node_modules/@deepseek-ai/dsh-client-ui-deliverables/lib/client.js 
 +		* in the current turn. Keep bare identifiers inert: without a slash, an
 +		* absolute-path prefix, or a conventional filename suffix, inline code is
 +		* much more likely to be a command, package, or symbol than a local path.
++		*
++		* A leading `@` plus a single slash is a scoped package name, and a bare
++		* `local@domain.tld` is an email address; both are far more common in
++		* assistant prose than files with those exact shapes, and neither is
++		* openable. An explicit `./@scope/pkg` still resolves as a path above.
 +		*/
 +		function localPathReference(value) {
 +			const candidate = value.trim();
 +			if (candidate === "" || /[\r\n]/.test(candidate) || /^(?:https?|data|javascript):/i.test(candidate)) return void 0;
 +			const path = candidate.replace(/(?:#L\d+(?:C\d+)?|:\d+(?::\d+)?)$/, "");
 +			if (/^(?:\/|~[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|\\\\)/.test(path)) return path;
++			if (/^@[^\\/@\s]+\/[^\\/@\s]+$/.test(path)) return void 0;
++			if (/^[^@\s\\/]+@[^@\s\\/]+\.[A-Za-z]{2,}$/.test(path)) return void 0;
 +			if (/[\\/]/.test(path) || /[\\/]$/.test(path)) return path;
 +			if (/^[^\\/]+\.[A-Za-z0-9][A-Za-z0-9._-]{0,15}$/.test(path)) return path;
 +			return void 0;

--- a/test/local-path-links.test.ts
+++ b/test/local-path-links.test.ts
@@ -1,6 +1,35 @@
 import { readFile } from 'node:fs/promises'
 import { describe, expect, it } from 'vitest'
-import { patchPath, projectRoot } from './patch-path'
+import { patchPath } from './patch-path'
+
+/**
+ * The patch is the source of truth for this helper: `node_modules` may hold a
+ * different Harness build than the one the patch targets, so read the added
+ * lines straight out of the patch and evaluate them.
+ */
+async function loadLocalPathReference(): Promise<
+  (value: string) => string | undefined
+> {
+  const patch = await readFile(
+    patchPath('@deepseek-ai/dsh-client-ui-deliverables'),
+    'utf8'
+  )
+  const added = patch
+    .split('\n')
+    .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+    .map((line) => line.slice(1))
+    .join('\n')
+  // The function's closing brace is a context line, not an added one, so the
+  // extracted body stops at the last `return` and is closed here.
+  const source = added.match(
+    /function localPathReference\(value\) \{[\s\S]*?\n\t\t\treturn void 0;/
+  )?.[0]
+
+  expect(source).toBeDefined()
+  return new Function(
+    `${source}\n}; return localPathReference`
+  )() as (value: string) => string | undefined
+}
 
 describe('assistant local path links', () => {
   it('links Codex-style path references even when they are not turn deliverables', async () => {
@@ -14,5 +43,66 @@ describe('assistant local path links', () => {
     expect(patch).toContain('#L\\d+')
     expect(patch).toContain('[A-Za-z]:[\\\\/]')
     expect(patch).toContain('owner.openFile')
+  })
+
+  it('resolves real local paths', async () => {
+    const localPathReference = await loadLocalPathReference()
+
+    for (const value of [
+      'src/main.ts',
+      './scripts/build.mjs',
+      '../sibling/file.txt',
+      'C:\\Users\\me\\file.txt',
+      '/etc/hosts',
+      '~/notes.md',
+      'package.json',
+      'vitest.config.ts',
+      'docs/',
+    ]) {
+      expect(localPathReference(value), value).toBe(value)
+    }
+  })
+
+  it('keeps scoped package names and email addresses inert', async () => {
+    const localPathReference = await loadLocalPathReference()
+
+    for (const value of [
+      '@deepseek-ai/cordis',
+      '@deepseek-ai/dsh-client-ui-deliverables',
+      '@foo/bar',
+      '@plugin/name',
+      'user@example.com',
+      'first.last@sub.example.co',
+    ]) {
+      expect(localPathReference(value), value).toBeUndefined()
+    }
+  })
+
+  it('still resolves paths that merely contain an @ segment', async () => {
+    const localPathReference = await loadLocalPathReference()
+
+    for (const value of [
+      './@scope/pkg',
+      '/tmp/@scope/pkg/index.js',
+      'patches/@deepseek-ai+dsh-client-ui-deliverables+0.1.2-rc.1.patch',
+      'node_modules/@foo/bar/lib/client.js',
+    ]) {
+      expect(localPathReference(value), value).toBe(value)
+    }
+  })
+
+  it('keeps bare identifiers and commands inert', async () => {
+    const localPathReference = await loadLocalPathReference()
+
+    for (const value of ['npm install', 'someFunction', '', '   ']) {
+      expect(localPathReference(value), value).toBeUndefined()
+    }
+  })
+
+  it('strips line and column suffixes from resolved paths', async () => {
+    const localPathReference = await loadLocalPathReference()
+
+    expect(localPathReference('src/main.ts#L42')).toBe('src/main.ts')
+    expect(localPathReference('src/main.ts:42:7')).toBe('src/main.ts')
   })
 })


### PR DESCRIPTION
Fixes #85

### Problem

`localPathReference` renders inline code as a clickable produced-file chip. Its fallback accepted two shapes far too eagerly:

- anything containing `/` → a scoped package name like `@deepseek-ai/cordis` looked like a path
- anything matching `name.suffix` → an email address like `user@example.com` looked like a filename

So assistant prose mentioning a package or an email rendered a file chip that opens a path which never existed. Verified against the pristine vendored `0.1.2-rc.1` bundle with only the current `main` patch applied:

```
LINK   "@deepseek-ai/cordis"       -> "@deepseek-ai/cordis"
LINK   "@foo/bar"                  -> "@foo/bar"
LINK   "@plugin/name"              -> "@plugin/name"
LINK   "user@example.com"          -> "user@example.com"
LINK   "first.last@sub.example.co" -> "first.last@sub.example.co"
```

### Change

Two rejection rules in `patches/@deepseek-ai+dsh-client-ui-deliverables+0.1.2-rc.1.patch`, placed **after** the absolute/relative prefix check so explicit paths keep winning:

```js
if (/^@[^\\/@\s]+\/[^\\/@\s]+$/.test(path)) return void 0;              // @scope/name
if (/^[^@\s\\/]+@[^@\s\\/]+\.[A-Za-z]{2,}$/.test(path)) return void 0;  // local@domain.tld
```

Only a bare `@scope/name` with a single slash, or a bare `local@domain.tld`, goes inert. Paths that merely *contain* an `@` segment are unaffected — `./@scope/pkg`, `/tmp/@scope/pkg/index.js` and `node_modules/@foo/bar/lib/client.js` still resolve, because the prefix check or the multi-segment slash rule matches first.

Nothing else moves: produced-file resolution, basename matching, `#L42` / `:42:7` suffix stripping, and the `paths ?? []` fallback are untouched.

### Verification

Ran against the real target, not the installed tree — my `node_modules` held `0.1.1-rc.1`, so I extracted the vendored `packages/harness-0.1.2-rc.1/npm-dsh/deepseek-ai-dsh-client-ui-deliverables-0.1.2-rc.1.tgz` and worked from that.

- `patch-package` applies to pristine `0.1.2-rc.1`: `@deepseek-ai/dsh-client-ui-deliverables@0.1.2-rc.1 ✔`
- Behaviour on the patched real bundle: all 7 inert cases inert, all 7 path cases resolve unchanged
- Bug reproduced first on `main`'s patch against the same pristine bundle (5 false links above), confirming this is not an artifact of my setup
- `npx vitest run test/local-path-links.test.ts` → 6/6 pass
- Reverting only the patch and rerunning fails **exactly one** test (the scoped-package/email case) and passes the other five, so the new test pins this regression specifically
- Full suite unchanged vs. `main` baseline: 29 failed / 656 passed before, 29 failed / 661 passed after — same 12 failing files, the 5 extra passes are the new cases. Pre-existing failures come from stale local deps, not this change
- `npm run typecheck`: 10 errors before and after, none in the touched files

### Test

`test/local-path-links.test.ts` keeps the 5 original text assertions and adds behavioural coverage. It evaluates the helper extracted from the **patch text** rather than from `node_modules`, so it stays honest when the installed Harness build and the patch target disagree.

### Note for reviewers

One judgement call: `Array.prototype.map` and `v0.7.1` also come back as links from the same `name.suffix` rule. I left them alone — tightening that needs either an extension allowlist or a stricter last-segment test, and both risk dropping legitimate uncommon file types. Happy to follow up separately if you want it narrowed.
