### PR TITLE
修正 Intel CI 发布说明集成测试的执行时限

### DIFF
--- a/test/github-release-notes.test.ts
+++ b/test/github-release-notes.test.ts
@@ -20,7 +20,7 @@ async function work(): Promise<string> {
   return dir
 }
 
-const run = (args: string[]) => execFile('python3', [script, ...args], { cwd: projectRoot })
+const run = (args: string[]) => execFile('python3', [script, ...args], { cwd: projectRoot, timeout: 20_000 })
 
 const VALID = `# DSH Desktop v9.9.9 — 测试主题
 
@@ -36,7 +36,9 @@ const VALID = `# DSH Desktop v9.9.9 — 测试主题
 `
 
 describe('github_release_notes build-prompt', () => {
-  it('emits the evidence blocks, the style reference, and the Chinese contract', async () => {
+  // Reading repository history and generating diffs can exceed the default
+  // five seconds on native Intel CI. Keep the subprocess independently bounded.
+  it('emits the evidence blocks, the style reference, and the Chinese contract', { timeout: 30_000 }, async () => {
     const dir = await work()
     const out = path.join(dir, 'prompt.txt')
     await run(['build-prompt', '--tag', 'v9.9.9', '--output', out])
@@ -77,7 +79,7 @@ describe('github_release_notes validate', () => {
 })
 
 describe('github_release_notes generate-fallback', () => {
-  it('produces a note that passes validate and starts with the contract title', async () => {
+  it('produces a note that passes validate and starts with the contract title', { timeout: 30_000 }, async () => {
     const dir = await work()
     const file = path.join(dir, 'fb.md')
     await run(['generate-fallback', '--tag', 'v9.9.9', '--output', file])


### PR DESCRIPTION
原生 Intel Mac 预发布构建连续两次被发布说明生成测试的默认 5 秒超时阻断；第二次其余 738 项测试全部通过。两项测试会启动 Python 并读取 Git 历史、生成差异，需给出合理的集成测试时间预算。

仅将这两项测试的期限设为 30 秒，并为脚本子进程增加 20 秒超时；保留所有内容断言，不跳过测试，不改产品代码。

验证：本地发布说明测试与类型检查通过。失败记录：Actions 34121497279，第 1、2 次 Intel 运行。
