### PR TITLE
稳定 Intel CI 的集成测试资源与时间预算

### DIFF
--- a/test/ppt-validation.test.mjs
+++ b/test/ppt-validation.test.mjs
@@ -111,7 +111,7 @@ describe('PPT validation authoring loop', () => {
     await expect(f.run('pptd_write_file', { ...args, file_path: 'pages/2.page', expected_sha256: 'a'.repeat(64) })).rejects.toThrow('only when replacing')
   })
 
-  it('groups misplaced text styles, skips cascading overflow, and supplies directly usable read arguments', async () => {
+  it('groups misplaced text styles, skips cascading overflow, and supplies directly usable read arguments', { timeout: 15_000 }, async () => {
     const f = await fixture()
     const file = path.join(f.project, 'pages/1.page')
     const page = { elements: [{ elementId: 'shared-caption', elementType: 'text', bounds: [48, 80, 800, 16],
@@ -180,5 +180,5 @@ describe('PPT validation authoring loop', () => {
     const imported = spawnSync(process.execPath, ['--input-type=module', '-e', `await import(${JSON.stringify(pathToFileURL(cli).href)})`], { encoding: 'utf8', timeout: 10_000 })
     expect(imported.status).toBe(0)
     expect(imported.stdout).toBe('')
-  }, 30_000) // Several cold CLI starts can exceed 5s on the native Windows runner.
+  }, 80_000) // Up to seven cold CLI starts on macOS, each independently limited to 10s.
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['test/**/*.{test,spec}.{ts,js,mjs}']
+    include: ['test/**/*.{test,spec}.{ts,js,mjs}'],
+    // Native Intel runners contend for CPU and disk while integration suites
+    // unpack archives and launch subprocesses. Keep every test, but serialize files.
+    fileParallelism: !(process.env.CI && process.platform === 'darwin' && process.arch === 'x64')
   }
 })


### PR DESCRIPTION
Intel CI 多轮运行的失败均为集成测试超时，且失败位置随资源负载变化。最近一轮 739 项通过，仅 PPT 文件读写校验测试超过默认 5 秒；上一轮 Mac CLI 测试的 7 次冷启动合计超过 30 秒。

Intel macOS CI 改为按文件串行运行，减少解包、导出与子进程启动之间的资源争用；该文件校验测试限定 15 秒，CLI 合计限定 80 秒，每个 CLI 子进程仍限定 10 秒。保留全部测试和断言，不改变产品代码。

验证：本地 PPT 校验测试、类型检查通过。原生 Intel 全量验证将随构建运行。
