### PR TITLE
fix(market): disable the generation pointer when uninstalling the market

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -66,6 +66,7 @@ import {
 } from './state/plugin-recovery'
 import { ensureSafeModeProfile, SAFE_MODE_PROFILE } from './state/safe-mode-profile'
 import {
+  isProjectedGenerationPlugin,
   prepareGenerationsForLaunch,
   uninstallGenerationPlugin
 } from './state/generation-launch'
@@ -1301,21 +1302,56 @@ function restartHarness(): Promise<void> {
   return launchHarness()
 }
 
+/** Drop the market's generation pointer, in the shape the caller reports on. */
+async function disableMarketGeneration(
+  dshHome: string
+): Promise<{ ok: boolean; detail?: string }> {
+  if (await uninstallGenerationPlugin(dshHome, 'dshmarket', (line) => runtime.note(line))) {
+    return { ok: true }
+  }
+  return {
+    ok: false,
+    detail: 'The plugin market generation could not be disabled; it is still enabled for the next launch.'
+  }
+}
+
+/**
+ * Remove the plugin market, in whichever form this profile installed it.
+ *
+ * A generation install is projected from `desired`, NOT owned by the profile
+ * manifest, so `dsh plugin remove` is the wrong tool for it: it edits
+ * `dependencies` and `node_modules`, the pnpm runner restores the projection
+ * fields it suspended, and prepareGenerationsForLaunch() rebuilds the market
+ * from `desired` during the restart below. The uninstall then looked like it
+ * had done nothing at all (#330 by @Lililizi0307).
+ *
+ * The generation branch cannot go through removeProfilePluginCompletely():
+ * dshmarket is a CORE_BUNDLES name, so beginRemoval() refuses it by design —
+ * that guard is what stops recovery and Safe Mode from tearing out a core
+ * bundle, and this deliberate, user-initiated uninstall is not a reason to
+ * weaken it.
+ */
 async function uninstallMarketAndRestart(): Promise<{ ok: boolean }> {
   const dshHome = join(app.getPath('userData'), 'harness')
   await showSplash()
   await runtime.stop()
-  const result = await removeProfilePluginWithDsh(
-    {
-      dshHome,
-      dshEntryPath: dshEntryPath(),
-      nodeExecutablePath: bundledNodePath(),
-      pnpmEntryPath: bundledPnpmEntryPath(),
-      pnpmRunnerPath: bundledPnpmRunnerPath()
-    },
-    'dshmarket',
-    true
-  )
+  // Ask BEFORE removing: once the pointer is gone the question cannot be
+  // answered any more, and a generation whose disable failed must not be
+  // reported as an uninstall that worked.
+  const projected = await isProjectedGenerationPlugin(dshHome, 'dshmarket')
+  const result = projected
+    ? await disableMarketGeneration(dshHome)
+    : await removeProfilePluginWithDsh(
+      {
+        dshHome,
+        dshEntryPath: dshEntryPath(),
+        nodeExecutablePath: bundledNodePath(),
+        pnpmEntryPath: bundledPnpmEntryPath(),
+        pnpmRunnerPath: bundledPnpmRunnerPath()
+      },
+      'dshmarket',
+      true
+    )
   await launchHarness()
   if (!result.ok) {
     throw new Error(result.detail ?? 'Plugin market removal failed.')

--- a/src/main/state/generation-launch.ts
+++ b/src/main/state/generation-launch.ts
@@ -67,6 +67,23 @@ export async function prepareGenerationsForLaunch(dshHome: string, note: Note): 
 }
 
 /**
+ * Whether this plugin is installed as a generation, and so is projected from
+ * `desired` rather than owned by the profile manifest.
+ *
+ * Callers that report success or failure to the user need this BEFORE
+ * attempting the removal. {@link uninstallGenerationPlugin} answers false both
+ * for "not a generation, use pnpm instead" and for "is a generation, and
+ * disabling it failed" — treating those the same is how an uninstall that left
+ * the pointer in place still reported success (#330).
+ */
+export async function isProjectedGenerationPlugin(
+  dshHome: string,
+  pluginName: string
+): Promise<boolean> {
+  return isGenerationPlugin(dshHome, pluginName).catch(() => false)
+}
+
+/**
  * Uninstall a plugin that is a generation: drop it from `desired` and
  * reproject. Returns false when the plugin is not a generation, so the caller
  * can fall through to the shared-tree `dsh plugin remove`.

--- a/test/generation-launch.test.ts
+++ b/test/generation-launch.test.ts
@@ -4,7 +4,9 @@ import { join } from 'node:path'
 import { PROFILE_TEMPLATES } from '@deepseek-ai/dsh-app-boot'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
-  prepareGenerationsForLaunch
+  isProjectedGenerationPlugin,
+  prepareGenerationsForLaunch,
+  uninstallGenerationPlugin
 } from '../src/main/state/generation-launch'
 import {
   ensureRegistryDirectories,
@@ -97,6 +99,77 @@ describe('the launch-process half of the generation model', () => {
     expect(existsSync(join(home, 'profiles', 'web', 'node_modules', 'keeper'))).toBe(true)
     const manifest = JSON.parse(await readFile(join(home, 'profiles', 'web', 'package.json'), 'utf8'))
     expect(manifest.dsh.profile.bundles).toContain('keeper')
+  })
+
+  it('knows a generation install from a plain manifest one', async () => {
+    const home = await freshHome()
+    await ensureRegistryDirectories(home)
+    await fakeGeneration(home, 'dshmarket+1.44.0+af88ab682bc0', 'dshmarket')
+    await writeDesired(home, ['dshmarket+1.44.0+af88ab682bc0'])
+
+    expect(await isProjectedGenerationPlugin(home, 'dshmarket')).toBe(true)
+    expect(await isProjectedGenerationPlugin(home, 'never-installed')).toBe(false)
+  })
+
+  it('does not reproject an uninstalled market generation on the next launch (#330)', async () => {
+    const home = await freshHome()
+    await ensureRegistryDirectories(home)
+    await fakeGeneration(home, 'dshmarket+1.44.0+af88ab682bc0', 'dshmarket')
+    await writeDesired(home, ['dshmarket+1.44.0+af88ab682bc0'])
+    await prepareGenerationsForLaunch(home, silent)
+
+    const profile = join(home, 'profiles', 'web')
+    const { existsSync } = await import('node:fs')
+    expect(existsSync(join(profile, 'node_modules', 'dshmarket'))).toBe(true)
+
+    expect(await uninstallGenerationPlugin(home, 'dshmarket', silent)).toBe(true)
+    // The restart that follows the uninstall is what used to bring it back.
+    await prepareGenerationsForLaunch(home, silent)
+
+    expect(await readDesired(home)).toEqual([])
+    const manifest = JSON.parse(await readFile(join(profile, 'package.json'), 'utf8'))
+    expect(Object.keys(manifest.dependencies ?? {})).not.toContain('dshmarket')
+    expect(manifest.dsh.profile.bundles).not.toContain('dshmarket')
+    expect(manifest.pnpm?.overrides ?? {}).not.toHaveProperty('dshmarket')
+    expect(existsSync(join(profile, 'node_modules', 'dshmarket'))).toBe(false)
+  })
+
+  it('reprojects a generation that only a pnpm-level removal touched (#330)', async () => {
+    const home = await freshHome()
+    await ensureRegistryDirectories(home)
+    await fakeGeneration(home, 'dshmarket+1.44.0+af88ab682bc0', 'dshmarket')
+    await writeDesired(home, ['dshmarket+1.44.0+af88ab682bc0'])
+    await prepareGenerationsForLaunch(home, silent)
+
+    // Exactly what `dsh plugin remove --workspace-root dshmarket` leaves
+    // behind: the manifest rows are gone, `desired` is untouched.
+    const manifestPath = join(home, 'profiles', 'web', 'package.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    delete manifest.dependencies.dshmarket
+    delete manifest.pnpm?.overrides?.dshmarket
+    manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter(
+      (name: string) => name !== 'dshmarket'
+    )
+    await writeFile(manifestPath, JSON.stringify(manifest))
+
+    await prepareGenerationsForLaunch(home, silent)
+
+    // Back, in full — this is the bug the generation branch exists to avoid.
+    const reprojected = JSON.parse(await readFile(manifestPath, 'utf8'))
+    expect(await readDesired(home)).toEqual(['dshmarket+1.44.0+af88ab682bc0'])
+    expect(reprojected.dsh.profile.bundles).toContain('dshmarket')
+  })
+
+  it('uninstalls the market through the generation path rather than pnpm alone', async () => {
+    const main = await readFile('src/main/index.ts', 'utf8')
+    const uninstall = main.slice(
+      main.indexOf('async function disableMarketGeneration'),
+      main.indexOf('function registerHarnessHandlers')
+    )
+    expect(uninstall).toContain('isProjectedGenerationPlugin')
+    expect(uninstall).toContain('uninstallGenerationPlugin')
+    // The pnpm removal stays, for a profile that never used a generation.
+    expect(uninstall).toContain('removeProfilePluginWithDsh')
   })
 
   it('does not retain or restore generations from a stale rollback pointer', async () => {


### PR DESCRIPTION
Fixes #330

## 问题

「设置 → 插件 → 插件市场 → 卸载插件市场」后重启，插件市场原样回来。

卸载走的是 IPC `market:uninstall` → `uninstallMarketAndRestart()` → `removeProfilePluginWithDsh()`，也就是 `dsh plugin remove --workspace-root dshmarket`。这是 **pnpm 层面的删除**，只改 `dependencies` 和 `node_modules`。

但当 dshmarket 是 **generation 形态**时，`desired.json` 才是权威：卸载自身触发的那次重启里，`prepareGenerationsForLaunch()` → `projectGenerations()` 以 `desired.json` 为准，把 junction、`dependencies`、`bundles`、`generationProjection`、`pnpm.overrides` 全部重建回来。加上 pnpm runner 的 `suspendGenerationProjectionForPnpm()` / `restore()` 会在命令前后把投影字段摘除再写回，pnpm 删除的那点效果也留不住。

结果就是：卸载"成功"，重启后一切照旧。

## 修复

按安装形态分支：

- **generation 形态** → `uninstallGenerationPlugin()`（`disableGeneration` + 重新投影 + 校验），也就是恢复流程和安全模式一直在用的那条路；
- **其余形态** → 保持原有的 pnpm 删除，行为不变。

形态在删除**之前**判定（新增 `isProjectedGenerationPlugin()`）。原因是 `uninstallGenerationPlugin()` 的 `false` 有两种含义——"不是 generation，请走 pnpm" 和 "是 generation，但禁用失败"——混为一谈正是"指针还在却报成功"的来源。先问清楚，禁用失败就如实抛错。

### 为什么不复用 `removeProfilePluginCompletely()`

issue 里建议直接改调它，但那条路走不通：`dshmarket` 在 `CORE_BUNDLES` 里，`isThirdPartyPackageName()` 返回 false，`beginRemoval()` 会以 `Refusing to remove core package dshmarket` 拒绝。那个守卫的作用是防止插件恢复/安全模式流程扯掉核心 bundle，不该为这次用户主动发起的卸载而放宽。所以只取它内部的 generation 分支。

## 测试

`test/generation-launch.test.ts` 新增 4 条：

- `isProjectedGenerationPlugin` 能区分 generation 形态与普通 manifest 形态；
- 卸载 market generation 后再走一次启动投影，`desired.json`、`dependencies`、`bundles`、`pnpm.overrides`、`node_modules/dshmarket` 全部干净；
- **回归记录**：只做 manifest 层面删除（模拟 `dsh plugin remove` 的结果）时，下一次启动投影会把它完整重建回来——这正是本 issue 的根因；
- 市场卸载确实经过 generation 路径，同时保留 pnpm 路径。

去掉本 PR 的 src 改动后，其中 2 条失败；加上后全绿。

```
npm run typecheck                          ✅
vitest run test/generation-launch.test.ts  ✅ 9 passed
+ plugin-removal / market-installer / generation-{registry,projection,installer,migration}  ✅ 72 passed
```

全量 `vitest run`：733 passed / 1 failed，3 个文件失败（`ppt-activation`、`ppt-fonts`、`safe-mode-runtime`）。这 3 个在未改动的 `main` 上同样失败（本地缺 PPT 运行时产物），与本 PR 无关。

## 说明

issue 里提到「HTTP 路径是 generation-aware 的，只是桌面端没选它」——实际上市场**自我卸载**的 HTTP 路径 (`runUninstall()`) 也不走 `runPlugin()`，而是直接 `runProfileCommand(buildMarketUninstallArguments())`，同样是纯 pnpm 删除。所以改走 HTTP 并不能解决问题，得在这里修。

issue 末尾「附加信息」里的 `bundles` 残留问题不在本 PR 范围内——那条已由 `8b018c9`（`syncBundles: true`）修复，包含在 0.8.0-rc.3 及以后，v0.7.2 没有。