### PR TITLE
AND-397: 修复 Windows 移动设备隧道卡死

### DIFF
--- a/src/main/mobile/cloudflared-tunnel.ts
+++ b/src/main/mobile/cloudflared-tunnel.ts
@@ -5,6 +5,7 @@ import { chmod, mkdir, readdir, rm, writeFile } from 'node:fs/promises'
 import { get as httpsGet } from 'node:https'
 import { dirname, join } from 'node:path'
 import { arch, platform } from 'node:os'
+import { pipeline } from 'node:stream/promises'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { InternetTunnelInstance } from './internet-tunnel'
@@ -154,29 +155,42 @@ export async function ensureCloudflaredBinary(options: {
   }
 }
 
-function downloadFileWithRedirects(url: string, destination: string, maxRedirects = 5): Promise<void> {
+export function downloadFileWithRedirects(
+  url: string,
+  destination: string,
+  maxRedirects = 5,
+  timeoutMs = 30_000
+): Promise<void> {
   return new Promise((resolvePromise, rejectPromise) => {
     if (maxRedirects <= 0) {
       return rejectPromise(new Error('Too many redirects while downloading cloudflared'))
     }
 
-    httpsGet(url, (res) => {
+    const request = httpsGet(url, (res) => {
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        return resolvePromise(downloadFileWithRedirects(res.headers.location, destination, maxRedirects - 1))
+        res.resume()
+        return resolvePromise(
+          downloadFileWithRedirects(res.headers.location, destination, maxRedirects - 1, timeoutMs)
+        )
       }
       if (res.statusCode !== 200) {
+        res.resume()
         return rejectPromise(new Error(`Download failed with status ${res.statusCode}`))
       }
 
       const fileStream = createWriteStream(destination)
-      res.pipe(fileStream)
-      fileStream.on('finish', () => {
-        fileStream.close(() => resolvePromise())
+      // pipeline propagates response-side `error` and `aborted` events as well
+      // as destination errors. A plain pipe only observed the file stream, so
+      // a reset after the HTTP 200 headers left this promise pending forever.
+      res.once('aborted', () => {
+        fileStream.destroy(new Error('cloudflared download response was aborted'))
       })
-      fileStream.on('error', (err) => {
-        fileStream.close(() => rejectPromise(err))
-      })
-    }).on('error', rejectPromise)
+      void pipeline(res, fileStream).then(() => resolvePromise(), rejectPromise)
+    })
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error(`cloudflared download timed out after ${timeoutMs / 1000}s`))
+    })
+    request.once('error', rejectPromise)
   })
 }
 

--- a/test/cloudflared-download.test.ts
+++ b/test/cloudflared-download.test.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'node:events'
+import { mkdtemp, rm } from 'node:fs/promises'
+import type { ClientRequest, IncomingMessage } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const httpsMocks = vi.hoisted(() => ({ get: vi.fn() }))
+
+vi.mock('node:https', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:https')>()),
+  get: httpsMocks.get
+}))
+
+import { downloadFileWithRedirects } from '../src/main/mobile/cloudflared-tunnel'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  httpsMocks.get.mockReset()
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('cloudflared download lifecycle', () => {
+  it('rejects when a response resets after its headers instead of hanging', async () => {
+    const response = new PassThrough() as PassThrough & Partial<IncomingMessage>
+    response.statusCode = 200
+    response.headers = {}
+    const request = fakeRequest()
+    httpsMocks.get.mockImplementation((_url, callback) => {
+      callback(response as IncomingMessage)
+      return request as unknown as ClientRequest
+    })
+    const destination = await tempDestination()
+
+    const download = downloadFileWithRedirects('https://example.test/cloudflared', destination)
+    response.write('partial download')
+    response.emit('aborted')
+
+    await expect(download).rejects.toThrow()
+  })
+
+  it('aborts an idle request at the configured timeout', async () => {
+    const request = fakeRequest()
+    request.setTimeout = vi.fn((_timeout: number, callback: () => void) => {
+      queueMicrotask(callback)
+      return request
+    })
+    httpsMocks.get.mockReturnValue(request as unknown as ClientRequest)
+    const destination = await tempDestination()
+
+    await expect(
+      downloadFileWithRedirects('https://example.test/cloudflared', destination, 5, 25)
+    ).rejects.toThrow('cloudflared download timed out after 0.025s')
+    expect(request.destroy).toHaveBeenCalledOnce()
+  })
+})
+
+function fakeRequest(): EventEmitter & {
+  setTimeout: ReturnType<typeof vi.fn>
+  destroy: ReturnType<typeof vi.fn>
+} {
+  const request = new EventEmitter() as EventEmitter & {
+    setTimeout: ReturnType<typeof vi.fn>
+    destroy: ReturnType<typeof vi.fn>
+  }
+  request.setTimeout = vi.fn(() => request)
+  request.destroy = vi.fn((error?: Error) => {
+    if (error) request.emit('error', error)
+    return request
+  })
+  return request
+}
+
+async function tempDestination(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'dsh-cloudflared-download-test-'))
+  tempDirs.push(dir)
+  return join(dir, 'cloudflared')
+}


### PR DESCRIPTION
## 问题

Windows 上下载 cloudflared 时，如果 HTTPS 响应在返回 200 后中途断开，原来的 `pipe()` 只监听目标文件流，下载 Promise 可能永远不结束。移动设备窗口因此一直显示 99%，重开后仍保留 `tunnelLoading`，后续切换会持续返回 “A tunnel switch is already in progress.”。

## 修复

- 使用 `stream.pipeline()` 同时传播响应端和文件端错误
- 显式处理响应 `aborted`，让隧道启动流程进入失败清理
- 为无响应下载增加 30 秒空闲超时并主动销毁请求
- 增加响应中断和请求超时的回归测试

## 验证

- `npm run typecheck`
- `npm test`（90 个测试文件、747 个测试全部通过）
- `git diff --check`

Fixes #349
Resolves AND-397
