### PR TITLE
AND-400: fix generation peer validation for Desktop links

### DIFF
--- a/packages/dsh-desktop-market-installer/generations/installer.mjs
+++ b/packages/dsh-desktop-market-installer/generations/installer.mjs
@@ -313,6 +313,19 @@ function isInsideDirectory(parent, candidate) {
   return path === '' || (!path.startsWith('..') && !isAbsolute(path))
 }
 
+async function linkedClosurePackageTarget(closure, dependency) {
+  if (!PACKAGE_NAME_PATTERN.test(dependency)) return undefined
+  const packagePath = join(closure, dependency)
+  const info = await pathInfo(packagePath, true)
+  if (info === undefined || !info.isSymbolicLink()) return undefined
+  return realpath(packagePath).catch(() => undefined)
+}
+
+function packageExistsInRoots(roots, dependency) {
+  if (!PACKAGE_NAME_PATTERN.test(dependency)) return false
+  return roots.some((root) => existsSync(join(root, dependency, 'package.json')))
+}
+
 async function pathInfo(path, missingAllowed = false) {
   try {
     return await lstat(path)
@@ -481,7 +494,11 @@ export async function verifyGenerationPeers(dshHome, generation) {
         manifest.peerDependenciesMeta?.[dependency]?.optional !== true
       const optional = !requiredDependency && !requiredPeer
       if (resolved === undefined) {
-        if (!optional) {
+        const installed = packageExistsInRoots(
+          [join(generationRoot, 'node_modules'), closure],
+          dependency
+        )
+        if (!optional && !installed) {
           problems.push(
             isHostSingleton(dependency)
               ? `${prefix}${dependency} does not resolve from the installation closure`
@@ -492,16 +509,23 @@ export async function verifyGenerationPeers(dshHome, generation) {
       }
       const realResolved = await realpath(resolved).catch(() => resolved)
       const insideClosure = isInsideDirectory(closure, realResolved)
+      const linkedClosureTarget = insideClosure
+        ? undefined
+        : await linkedClosurePackageTarget(closure, dependency)
+      const providedByLinkedClosurePackage =
+        linkedClosureTarget !== undefined && isInsideDirectory(linkedClosureTarget, realResolved)
       if (isHostSingleton(dependency)) {
-        if (!insideClosure) {
+        if (!insideClosure && !providedByLinkedClosurePackage) {
           problems.push(
             `${prefix}${dependency} resolves outside the installation closure: ${realResolved}`
           )
         }
       } else if (!insideClosure && !isInsideDirectory(generationRoot, realResolved)) {
-        problems.push(
-          `${prefix}${dependency} resolves outside the generation and installation closure: ${realResolved}`
-        )
+        if (!providedByLinkedClosurePackage) {
+          problems.push(
+            `${prefix}${dependency} resolves outside the generation and installation closure: ${realResolved}`
+          )
+        }
       }
     }
   }

--- a/test/generation-installer.test.ts
+++ b/test/generation-installer.test.ts
@@ -468,6 +468,71 @@ describe('the generation installer', () => {
     )
   })
 
+  it('accepts an installed dependency that has no runtime entry point', async () => {
+    const home = await freshHome()
+    const directory = join(home, 'profiles', '.generations', 'live', 'type-only-dependency')
+    const modules = join(directory, 'node_modules')
+    const plugin = join(modules, 'type-consumer')
+    const typeOnly = join(modules, 'type-only-package')
+    await mkdir(plugin, { recursive: true })
+    await mkdir(typeOnly, { recursive: true })
+    await writeFile(
+      join(plugin, 'package.json'),
+      JSON.stringify({
+        name: 'type-consumer',
+        version: '1.0.0',
+        dependencies: { 'type-only-package': '1.0.0' }
+      })
+    )
+    await writeFile(
+      join(typeOnly, 'package.json'),
+      JSON.stringify({ name: 'type-only-package', version: '1.0.0', exports: {} })
+    )
+
+    const result = await verifyGenerationPeers(home, {
+      id: 'type-only-dependency',
+      pluginName: 'type-consumer',
+      version: '1.0.0',
+      directory
+    })
+
+    expect(result).toEqual({ ok: true, problems: [] })
+  })
+
+  it('accepts host and ordinary dependencies provided through closure directory links', async () => {
+    const home = await freshHome()
+    const directory = join(home, 'profiles', '.generations', 'live', 'linked-closure')
+    const plugin = join(directory, 'node_modules', 'linked-consumer')
+    const closure = join(home, 'profiles', 'node_modules')
+    const hostModules = join(home, 'desktop-app', 'node_modules')
+    await mkdir(plugin, { recursive: true })
+    await mkdir(closure, { recursive: true })
+    await writeFile(
+      join(plugin, 'package.json'),
+      JSON.stringify({
+        name: 'linked-consumer',
+        version: '1.0.0',
+        dependencies: { react: '*', 'ordinary-host-package': '*' }
+      })
+    )
+    for (const name of ['react', 'ordinary-host-package']) {
+      const target = join(hostModules, name)
+      await mkdir(target, { recursive: true })
+      await writeFile(join(target, 'package.json'), JSON.stringify({ name, main: 'index.js' }))
+      await writeFile(join(target, 'index.js'), 'module.exports = {}\n')
+      await symlink(target, join(closure, name), process.platform === 'win32' ? 'junction' : 'dir')
+    }
+
+    const result = await verifyGenerationPeers(home, {
+      id: 'linked-closure',
+      pluginName: 'linked-consumer',
+      version: '1.0.0',
+      directory
+    })
+
+    expect(result).toEqual({ ok: true, problems: [] })
+  })
+
   it('rejects an ordinary dependency that a nested package resolves outside the allowed roots', async () => {
     const home = await freshHome()
     const directory = join(home, 'profiles', '.generations', 'live', 'external-dependency')


### PR DESCRIPTION
## Summary

- accept required packages that are installed with a manifest but intentionally expose no runtime entry point
- recognize host and ordinary dependencies resolved through package links in the installation closure
- preserve failures for genuinely missing dependencies, private host singletons, and resolutions outside all allowed roots
- add regression coverage for no-entry packages and closure directory links

## Verification

- `npm test -- --run test/generation-installer.test.ts` (16 passed)
- `npm run typecheck`
- `git diff --check`
- full `npm test`: 714 passed, 33 unrelated existing patch-artifact tests failed

Fixes #293
Closes AND-400
