### PR TITLE
fix(session): register browser deletion Remote (#294)

### DIFF
--- a/patches/@deepseek-ai+dsh-api-remotes+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-api-remotes+0.1.2-rc.1.patch
@@ -1,0 +1,50 @@
+diff --git a/node_modules/@deepseek-ai/dsh-api-remotes/lib/client.js b/node_modules/@deepseek-ai/dsh-api-remotes/lib/client.js
+--- a/node_modules/@deepseek-ai/dsh-api-remotes/lib/client.js
++++ b/node_modules/@deepseek-ai/dsh-api-remotes/lib/client.js
+@@ -7473,6 +7473,12 @@
+ 			"sessionId": intersection(string(), unknown()).readonly(),
+ 			"agentPreset": string().readonly().optional()
+ 		});
++		const _deepseek_ai_dsh_api_session_controller_session_delete_parameter_0$schema = object({
++			sessionId: intersection(string(), unknown()).readonly()
++		});
++		const _deepseek_ai_dsh_api_session_controller_session_delete_result$schema = object({
++			deleted: literal(true).readonly()
++		});
+ 		const _deepseek_ai_dsh_api_session_controller_session_follow_parameter_0$schema = object({
+ 			"address": union([object({
+ 				"kind": literal("session").readonly(),
+@@ -8180,6 +8186,33 @@
+ 					}
+ 				},
+ 				{
++					id: "@deepseek-ai/dsh-api-session-controller#session/delete",
++					service: "sessionController",
++					namespace: "session",
++					method: "delete",
++					invocation: { kind: "direct" },
++					parameters: [{
++						name: "request",
++						wire: "request",
++						source: "json",
++						codec: {
++							mode: "strict",
++							typeSymbol: "@deepseek-ai/dsh-api-session-controller/types#SessionDeleteRequest",
++							schema: _deepseek_ai_dsh_api_session_controller_session_delete_parameter_0$schema
++						}
++					}],
++					result: {
++						mode: "strict",
++						typeSymbol: "@deepseek-ai/dsh-api-session-controller/types#SessionDeleteValue",
++						schema: _deepseek_ai_dsh_api_session_controller_session_delete_result$schema
++					},
++					sourceLocation: {
++						"file": "packages/api/session-controller/src/index.ts",
++						"line": 312,
++						"column": 3
++					}
++				},
++				{
+ 					id: "@deepseek-ai/dsh-api-session-controller#session/follow",
+ 					service: "sessionController",
+ 					namespace: "session",

--- a/test/session-delete-remote.test.ts
+++ b/test/session-delete-remote.test.ts
@@ -1,0 +1,76 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import vm from 'node:vm'
+import { SessionId } from '@deepseek-ai/dsh-session'
+import type { TypertCodec } from '@deepseek-ai/dsh-typert-protocol'
+import { Context } from '@deepseek-ai/cordis'
+import * as gateway from '../node_modules/@deepseek-ai/dsh-api-gateway/lib/types/client/index.js'
+import * as registry from '../node_modules/@deepseek-ai/dsh-typert-registry/lib/types/client/index.js'
+import sessionRemote from '@deepseek-ai/dsh-api-session-controller/remote'
+import { describe, expect, it, vi } from 'vitest'
+
+// Load the browser assembly itself: its inlined descriptors can drift from
+// session-controller/remote even when the Host and TypeScript declarations agree.
+async function browserRemotes() {
+  const source = await readFile(path.resolve('node_modules/@deepseek-ai/dsh-api-remotes/lib/client.js'), 'utf8')
+  let plugin!: { apply(ctx: unknown): Promise<() => Promise<void>> }
+  vm.runInNewContext(source, {
+    window: { __ModuleLoader__: { load(definition: { factory(require: unknown): typeof plugin }) {
+      plugin = definition.factory((id: string) => { throw new Error(`Unexpected dependency: ${id}`) })
+    } } }
+  })
+  return plugin
+}
+
+function accepts(codec: TypertCodec, value: unknown) {
+  if (codec.mode !== 'strict') throw new Error('Expected strict Remote codec')
+  try { codec.schema.parse(value); return true } catch { return false }
+}
+
+describe('browser session deletion Remote', () => {
+  it('registers the deletion contract and sends the request through the real gateway', async () => {
+    const ctx = new Context()
+    const call = vi.fn().mockResolvedValue({ ok: true, value: { deleted: true } })
+    ctx.provide('connection', {
+      rpc: { call, open: vi.fn() },
+      start: () => ({ stop() {} }),
+      registerGenerationSource: () => () => {},
+      generation: { getSnapshot: () => undefined }
+    })
+    const registryFiber = await ctx.plugin(registry)
+    const gatewayFiber = await ctx.plugin(gateway)
+    const plugin = await browserRemotes()
+    let dispose: (() => Promise<void>) | undefined
+    try {
+      dispose = await plugin.apply(ctx)
+      expect(typeof ctx.remote.session.delete).toBe('function')
+      const request = { sessionId: SessionId('delete-regression-session') }
+      await expect(ctx.remote.session.delete(request)).resolves.toEqual({ ok: true, value: { deleted: true } })
+      expect(call).toHaveBeenCalledWith('/api', 'session/delete', { args: { request } }, expect.any(AbortSignal))
+      call.mockResolvedValueOnce({ ok: false, error: { code: 'SESSION_BUSY', message: 'Session is running' } })
+      await expect(ctx.remote.session.delete(request)).resolves.toMatchObject({ ok: false, error: { code: 'SESSION_BUSY' } })
+    } finally {
+      await dispose?.()
+      await gatewayFiber.dispose()
+      await registryFiber.dispose()
+    }
+  })
+
+  it('keeps browser deletion codecs aligned with the standalone Remote contribution', async () => {
+    const contributions: Array<typeof sessionRemote> = []
+    await (await browserRemotes()).apply({ remote: { $mount: async (value: typeof sessionRemote) => {
+      contributions.push(value)
+      return async () => {}
+    } } })
+    const browser = contributions.flatMap(value => value.descriptors).find(value => value.namespace === 'session' && value.method === 'delete')
+    const standalone = sessionRemote.descriptors.find(value => value.namespace === 'session' && value.method === 'delete')!
+    expect(browser).toBeDefined()
+    expect(browser!.id).toBe(standalone.id)
+    for (const value of [{ sessionId: 'one' }, {}, { sessionId: 12 }]) {
+      expect(accepts(browser!.parameters[0]!.codec, value)).toBe(accepts(standalone.parameters[0]!.codec, value))
+    }
+    for (const value of [{ deleted: true }, { deleted: false }, {}]) {
+      expect(accepts(browser!.result, value)).toBe(accepts(standalone.result, value))
+    }
+  })
+})


### PR DESCRIPTION
## 问题与修复

点击「删除会话」确认后报 `this.remote.session.delete is not a function`，请求尚未到达后端。现有补丁已提供删除 UI、Host 端点和独立 Remote 描述，但遗漏了 `dsh-api-remotes/lib/client.js` 内打包的客户端描述，因此浏览器没有挂载该方法。

为浏览器 Remote assembly 补齐 `session/delete` 描述和严格的请求、结果 schema，与已有独立 Remote 契约一致。现有后端删除流程不变。

Closes #294

## 验证

- 新增两项回归测试在修复前失败、修复后通过：加载真实浏览器 assembly 并经实际客户端 Gateway 调用，验证 `/api` → `session/delete` 的请求参数、成功结果和后端拒绝的传递；核对内联与独立 Remote 的 codec 行为。
- 删除相关测试 11/11 通过，包含现有 JSONL 删除与保留其他会话的测试；类型检查和 `git diff --check` 通过。
- 对原始 vendored tarball 使用 `patch-package --error-on-fail` 应用成功，输出与测试所用 bundle 字节一致。
- 全量测试：731 passed / 1 failed，另有两个测试文件无法加载。三个失败文件为 `ppt-activation`、`ppt-fonts`、`safe-mode-runtime`；去掉本补丁后同样失败，原因是本地缺少 `dsh-ppt` / `dsh-ppt-composer` 依赖。
- 本轮未进行打包应用的人工删除验收，也未删除用户真实会话。
