### PR TITLE
AND-402: fix pnpm runner entry detection through junctions

### DIFF
--- a/packages/dsh-desktop-market-installer/pnpm-runner.mjs
+++ b/packages/dsh-desktop-market-installer/pnpm-runner.mjs
@@ -25,7 +25,7 @@
  * output, one pnpm run.
  */
 import { spawn } from 'node:child_process'
-import { existsSync, watch } from 'node:fs'
+import { existsSync, realpathSync, watch } from 'node:fs'
 import { readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -646,8 +646,17 @@ async function readEntries(directory) {
   }
 }
 
+/**
+ * Whether this module is Node's entry script. Resolve the argv spelling first:
+ * Node canonicalizes import.meta.url through Windows junctions and symlinks,
+ * while process.argv[1] preserves the path used to launch the script.
+ */
+export function isMainModule(moduleUrl, entryPath, resolvePath = realpathSync) {
+  return entryPath !== undefined && moduleUrl === pathToFileURL(resolvePath(entryPath)).href
+}
+
 /* v8 ignore start -- the process wrapper around the tested runner */
-if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isMainModule(import.meta.url, process.argv[1])) {
   const [pnpmEntry, ...pnpmArguments] = process.argv.slice(2)
   if (pnpmEntry === undefined) {
     process.stderr.write('dsh-desktop: the pnpm runner needs the pnpm entry path.\n')

--- a/test/pnpm-runner.test.js
+++ b/test/pnpm-runner.test.js
@@ -2,12 +2,14 @@ import { EventEmitter } from 'node:events'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
 import {
   MARKER,
   SIDELINE_MARKER,
   blockedTargets,
   gitPrepareApprovalKey,
+  isMainModule,
   lockedRenameTarget,
   mergeApprovedGitPrepareKey,
   runWithLockRecovery,
@@ -56,6 +58,14 @@ function fakePnpm(runs) {
 }
 
 describe('packaged pnpm runner', () => {
+  it('recognizes the entry script when argv uses an aliased path', () => {
+    const canonical = '/real/profile/.desktop-bin/pnpm-runner.mjs'
+    const alias = '/linked/profile/.desktop-bin/pnpm-runner.mjs'
+
+    expect(isMainModule(pathToFileURL(canonical).href, alias, () => canonical)).toBe(true)
+    expect(isMainModule(pathToFileURL(canonical).href, undefined, () => canonical)).toBe(false)
+  })
+
   it('extracts only a safe exact key from pnpm git prepare failures', () => {
     expect(gitPrepareApprovalKey(GIT_PREPARE_FAILURE)).toBe(GIT_EXACT_KEY)
     expect(gitPrepareApprovalKey(GIT_PREPARE_FAILURE.replace('github.com/', 'evil.example/')))


### PR DESCRIPTION
## Summary

- resolve the runner entry path before comparing it with `import.meta.url`
- preserve normal direct execution while allowing Windows junction/symlink path spellings
- add regression coverage for aliased entry paths

## Verification

- `npm test` (89 files, 746 tests)
- `npm run typecheck`
- manual symlink invocation: runner now executes and returns the expected missing-entry error instead of silently exiting 0

Fixes #341
Closes AND-402