### PR TITLE
AND-401: stream terminal output while commands run

### DIFF
--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -22,6 +22,7 @@ import {
 } from './generations/registry.mjs'
 import { SIDELINE_MARKER } from './pnpm-runner.mjs'
 import { removeTree } from './remove-tree.mjs'
+import { installLiveTerminalStreaming } from './live-terminal.js'
 
 export const RECOMMENDED_MARKET_VERSION = '^1.40.0'
 export const MARKET_PACKAGE = 'dshmarket'
@@ -680,6 +681,7 @@ function killProcessTree(child) {
 }
 
 export async function apply(ctx) {
+  installLiveTerminalStreaming(ctx)
   const home = dshHome()
   const directory = profileDirectory(home)
   const manifestPath = join(directory, 'package.json')

--- a/packages/dsh-desktop-market-installer/live-terminal.js
+++ b/packages/dsh-desktop-market-installer/live-terminal.js
@@ -1,0 +1,131 @@
+export const LIVE_TERMINAL_PATH = '/dsh-desktop/live-terminal/output'
+export const LIVE_TERMINAL_CALL_ID_ENV = 'DSH_LIVE_TERMINAL_CALL_ID'
+
+const MAX_OUTPUT_BYTES = 300 * 1024
+const POLL_INTERVAL_MS = 100
+const SETTLED_RETENTION_MS = 30 * 1000
+
+function appendBounded(current, chunk) {
+  const next = current + chunk
+  return next.length <= MAX_OUTPUT_BYTES ? next : next.slice(-MAX_OUTPUT_BYTES)
+}
+
+function readCollector(collector, offset) {
+  if (!collector || typeof collector.readFrom !== 'function') return { text: '', nextOffset: offset }
+  const slice = collector.readFrom(offset)
+  return {
+    text: typeof slice?.text === 'string' ? slice.text : '',
+    nextOffset: typeof slice?.nextOffset === 'number' ? slice.nextOffset : offset
+  }
+}
+
+export function renderLiveOutput(stdout, stderr) {
+  if (stderr === '') return stdout
+  const separator = stdout !== '' && !stdout.endsWith('\n') ? '\n' : ''
+  return `${stdout}${separator}[stderr]\n${stderr}`
+}
+
+function sendJson(res, statusCode, payload) {
+  res.statusCode = statusCode
+  res.setHeader('Content-Type', 'application/json; charset=utf-8')
+  res.setHeader('Cache-Control', 'no-store')
+  res.end(JSON.stringify(payload))
+}
+
+/**
+ * Expose the collected stdout/stderr of Desktop-owned shell calls while they
+ * are running. The shell executor already retains both streams; this adapter
+ * reads independent collector cursors, so it neither consumes nor changes the
+ * final tool result.
+ */
+export function installLiveTerminalStreaming(ctx) {
+  ctx.inject(['webServer', 'subprocess'], (hostCtx) => hostCtx.effect(() => {
+    const records = new Map()
+    const originalSpawn = hostCtx.subprocess.spawn.bind(hostCtx.subprocess)
+
+    const wrappedSpawn = (spec) => {
+      const handle = originalSpawn(spec)
+      const callId = spec?.env?.[LIVE_TERMINAL_CALL_ID_ENV]
+      const stdoutCollector = handle?.collected?.stdout
+      const stderrCollector = handle?.collected?.stderr
+      if (typeof callId !== 'string' || callId === '' || (!stdoutCollector && !stderrCollector)) {
+        return handle
+      }
+
+      const record = {
+        callId,
+        stdout: '',
+        stderr: '',
+        stdoutOffset: 0,
+        stderrOffset: 0,
+        startedAt: Date.now(),
+        active: true,
+        drain: undefined,
+        timer: undefined,
+        removalTimer: undefined
+      }
+      records.set(callId, record)
+
+      const drain = () => {
+        const stdout = readCollector(stdoutCollector, record.stdoutOffset)
+        const stderr = readCollector(stderrCollector, record.stderrOffset)
+        record.stdoutOffset = stdout.nextOffset
+        record.stderrOffset = stderr.nextOffset
+        if (stdout.text !== '') record.stdout = appendBounded(record.stdout, stdout.text)
+        if (stderr.text !== '') record.stderr = appendBounded(record.stderr, stderr.text)
+      }
+      record.drain = drain
+
+      record.timer = setInterval(drain, POLL_INTERVAL_MS)
+      record.timer.unref?.()
+      Promise.resolve(handle.done).finally(() => {
+        drain()
+        record.active = false
+        clearInterval(record.timer)
+        record.timer = undefined
+        record.removalTimer = setTimeout(() => {
+          if (records.get(callId) === record) records.delete(callId)
+        }, SETTLED_RETENTION_MS)
+        record.removalTimer.unref?.()
+      }).catch(() => undefined)
+
+      return handle
+    }
+
+    hostCtx.subprocess.spawn = wrappedSpawn
+    const disposeRoute = hostCtx.webServer.register({
+      kind: 'exact',
+      path: LIVE_TERMINAL_PATH,
+      handler: (req, res) => {
+        if (req.method !== 'GET') {
+          sendJson(res, 405, { error: 'Method not allowed.' })
+          return
+        }
+        const requestUrl = new URL(req.url ?? LIVE_TERMINAL_PATH, 'http://127.0.0.1')
+        const callId = requestUrl.searchParams.get('callId')
+        const record = callId === null ? undefined : records.get(callId)
+        if (record === undefined) {
+          sendJson(res, 200, { found: false, active: false, output: '' })
+          return
+        }
+        record.drain?.()
+        sendJson(res, 200, {
+          found: true,
+          active: record.active,
+          output: renderLiveOutput(record.stdout, record.stderr),
+          elapsedMs: Math.max(0, Date.now() - record.startedAt)
+        })
+      }
+    })
+
+    return () => {
+      disposeRoute()
+      if (hostCtx.subprocess.spawn === wrappedSpawn) hostCtx.subprocess.spawn = originalSpawn
+      for (const record of records.values()) {
+        if (record.timer !== undefined) clearInterval(record.timer)
+        if (record.removalTimer !== undefined) clearTimeout(record.removalTimer)
+      }
+      records.clear()
+    }
+  }, 'dsh-desktop-market-installer: live terminal streaming'))
+}

--- a/patches/@deepseek-ai+dsh-client-ui-primitives+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-primitives+0.1.2-rc.1.patch
@@ -1,0 +1,55 @@
+diff --git a/node_modules/@deepseek-ai/dsh-client-ui-primitives/lib/TerminalBlock.module.css b/node_modules/@deepseek-ai/dsh-client-ui-primitives/lib/TerminalBlock.module.css
+index 5198a51..0409faf 100644
+--- a/node_modules/@deepseek-ai/dsh-client-ui-primitives/lib/TerminalBlock.module.css
++++ b/node_modules/@deepseek-ai/dsh-client-ui-primitives/lib/TerminalBlock.module.css
+@@ -61,6 +61,7 @@
+ /* Full-width l2 hairline between the command banner and the body — the same
+    divider the IN/OUT card draws between its sections. A running card is
+    banner-only, so it draws none. */
+-.block:not([data-running]) .header {
++.block:not([data-running]) .header,
++.block[data-has-output] .header {
+   border-bottom: 0.5px solid var(--dsw-alias-border-l2);
+ }
+diff --git a/node_modules/@deepseek-ai/dsh-client-ui-primitives/lib/index.js b/node_modules/@deepseek-ai/dsh-client-ui-primitives/lib/index.js
+index 2021e8f..9749ffe 100644
+--- a/node_modules/@deepseek-ai/dsh-client-ui-primitives/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-client-ui-primitives/lib/index.js
+@@ -4028,6 +4028,7 @@ function renderLine$1(line) {
+ function TerminalBlock({ command, cwd, home, output, exitCode, signal, running = false, maxLines = 16, className, labels }) {
+ 	const copy = labels;
+ 	const text = output ?? "";
++	const outputRef = useRef(null);
+ 	const lines = useMemo(() => {
+ 		const parsed = parseAnsiLines(text);
+ 		const last = parsed[parsed.length - 1];
+@@ -4044,11 +4045,15 @@ function TerminalBlock({ command, cwd, home, output, exitCode, signal, running =
+ 		return (command.endsWith("\n") ? command.slice(0, -1) : command).split("\n");
+ 	}, [command]);
+ 	const empty = lines.every((line) => line.every((span) => span.text.trim() === ""));
+-	const { hidden, capped, headLines, tailLines } = headTailCap(lines.length, maxLines, expanded);
++	const { hidden, capped, headLines, tailLines } = headTailCap(lines.length, running ? Infinity : maxLines, expanded);
++	useLayoutEffect(() => {
++		if (running && outputRef.current !== null) outputRef.current.scrollTop = outputRef.current.scrollHeight;
++	}, [running, text]);
+ 	return jsxs("div", {
+ 		className: clsx(css$15.block, className),
+ 		"data-terminal": "",
+ 		"data-running": running ? "" : void 0,
++		"data-has-output": !empty ? "" : void 0,
+ 		children: [jsxs("div", {
+ 			className: css$15.header,
+ 			children: [
+@@ -4086,10 +4091,11 @@ function TerminalBlock({ command, cwd, home, output, exitCode, signal, running =
+ 					children: copied ? copy.copied : copy.copy
+ 				})
+ 			]
+-		}), !running && (empty ? jsx("div", {
++		}), (!running || !empty) && (empty ? jsx("div", {
+ 			className: css$15.empty,
+ 			children: copy.noOutput
+ 		}) : jsxs("div", {
++			ref: outputRef,
+ 			className: css$15.output,
+ 			children: [
+ 				(capped ? lines.slice(0, headLines) : lines).map((line, index) => jsx("div", {

--- a/patches/@deepseek-ai+dsh-client-ui-tool+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-tool+0.1.2-rc.1.patch
@@ -1,0 +1,95 @@
+diff --git a/node_modules/@deepseek-ai/dsh-client-ui-tool/lib/client.js b/node_modules/@deepseek-ai/dsh-client-ui-tool/lib/client.js
+index e50ccb4..639543a 100644
+--- a/node_modules/@deepseek-ai/dsh-client-ui-tool/lib/client.js
++++ b/node_modules/@deepseek-ai/dsh-client-ui-tool/lib/client.js
+@@ -733,6 +733,43 @@ window.__ModuleLoader__.load({
+ 				background: background === true
+ 			};
+ 		}
++		const LIVE_TERMINAL_PATH = "/dsh-desktop/live-terminal/output";
++		/** Read Desktop's non-consuming view of a running shell collector. */
++		function useLiveTerminalOutput(callId, running) {
++			const [output, setOutput] = (0, react.useState)(void 0);
++			(0, react.useEffect)(() => {
++				setOutput(void 0);
++				if (!running || callId === "") return;
++				let disposed = false;
++				let timer;
++				const poll = async () => {
++					try {
++						const response = await fetch(`${LIVE_TERMINAL_PATH}?callId=${encodeURIComponent(callId)}`, {
++							cache: "no-store",
++							credentials: "same-origin"
++						});
++						if (response.ok) {
++							const payload = await response.json();
++							if (!disposed && payload?.found === true && typeof payload.output === "string") setOutput(payload.output);
++						}
++					} catch {}
++					if (!disposed) timer = window.setTimeout(poll, 150);
++				};
++				void poll();
++				return () => {
++					disposed = true;
++					if (timer !== void 0) window.clearTimeout(timer);
++				};
++			}, [callId, running]);
++			return output;
++		}
++		function LiveTerminalBlock({ callId, ...props }) {
++			const output = useLiveTerminalOutput(callId, props.running === true);
++			return (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.TerminalBlock, {
++				...props,
++				output: props.running === true ? output ?? props.output : props.output
++			});
++		}
+ 		/**
+ 		* Parse the marker literals owned by `@deepseek-ai/dsh-shell/render` without
+ 		* importing that Host-only package into the Client dependency graph.
+@@ -1102,7 +1139,7 @@ window.__ModuleLoader__.load({
+ 				default: return null;
+ 			}
+ 		}
+-		function ToolRow({ t, variant, toolName, icon, title, summary, summarySuffix, bodyRaw, output, askQuestion, errorSummary, terminal, diff, read, search, web, state, filePath, onOpenFile, inspect }) {
++		function ToolRow({ t, callId, variant, toolName, icon, title, summary, summarySuffix, bodyRaw, output, askQuestion, errorSummary, terminal, diff, read, search, web, state, filePath, onOpenFile, inspect }) {
+ 			const [expanded, setExpanded] = (0, react.useState)(false);
+ 			const terminalLabels = (0, react.useMemo)(() => terminalBlockLabels(t), [t]);
+ 			const diffLabels = (0, react.useMemo)(() => diffBlockLabels(t), [t]);
+@@ -1188,7 +1225,8 @@ window.__ModuleLoader__.load({
+ 					] }),
+ 					children: (0, react_jsx_runtime.jsxs)("div", {
+ 						className: ToolRow_module_css_default.bodyWrap,
+-						children: [askQuestionBody !== null ? (0, react_jsx_runtime.jsx)(AskQuestionCard, { card: askQuestionBody }) : terminalBody !== null ? (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.TerminalBlock, {
++						children: [askQuestionBody !== null ? (0, react_jsx_runtime.jsx)(AskQuestionCard, { card: askQuestionBody }) : terminalBody !== null ? (0, react_jsx_runtime.jsx)(LiveTerminalBlock, {
++							callId,
+ 							...terminalBody.card,
+ 							maxLines: Infinity,
+ 							labels: terminalLabels,
+@@ -1286,6 +1324,7 @@ window.__ModuleLoader__.load({
+ 			const singleFile = model.filePath !== void 0;
+ 			return (0, react_jsx_runtime.jsx)(ToolRow, {
+ 				t,
++				callId: block.callId,
+ 				variant: model.variant,
+ 				toolName,
+ 				icon: VARIANT_ICONS[model.variant],
+@@ -1447,7 +1486,8 @@ window.__ModuleLoader__.load({
+ 				return (0, react_jsx_runtime.jsxs)(react_jsx_runtime.Fragment, { children: [terminal.description !== void 0 ? (0, react_jsx_runtime.jsx)("div", {
+ 					className: ToolDetails_module_css_default.description,
+ 					children: terminal.description
+-				}) : null, (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.TerminalBlock, {
++				}) : null, (0, react_jsx_runtime.jsx)(LiveTerminalBlock, {
++					callId: block.callId,
+ 					...terminal.card,
+ 					labels: terminalBlockLabels(t),
+ 					className: ToolDetails_module_css_default.cardBody
+@@ -1773,7 +1813,8 @@ window.__ModuleLoader__.load({
+ 					]
+ 				}), open && (0, react_jsx_runtime.jsxs)("div", {
+ 					className: bash_sample_module_css_default.bodyWrap,
+-					children: [terminal !== null ? (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.TerminalBlock, {
++					children: [terminal !== null ? (0, react_jsx_runtime.jsx)(LiveTerminalBlock, {
++						callId: block.callId,
+ 						...terminal.card,
+ 						maxLines: Infinity,
+ 						labels: terminalBlockLabels(t),

--- a/patches/@deepseek-ai+dsh-tool-bash+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-tool-bash+0.1.2-rc.1.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@deepseek-ai/dsh-tool-bash/lib/index.js b/node_modules/@deepseek-ai/dsh-tool-bash/lib/index.js
+index 714c6ac..afc1475 100644
+--- a/node_modules/@deepseek-ai/dsh-tool-bash/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-tool-bash/lib/index.js
+@@ -392,7 +392,10 @@ function apply(ctx, config = {}) {
+ 				mode: approvedMode
+ 			};
+ 			const workdir = resolveWorkdir(args.workdir, exec, standingPolicy?.workspaceRoot);
+-			const dshEnv = ctx.shellEnv.collect(exec);
++			const dshEnv = {
++				...ctx.shellEnv.collect(exec),
++				DSH_LIVE_TERMINAL_CALL_ID: exec.callId
++			};
+ 			const request = {
+ 				command: args.command,
+ 				...workdir !== void 0 ? { workdir } : {},

--- a/patches/@deepseek-ai+dsh-tool-pwsh+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-tool-pwsh+0.1.2-rc.1.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@deepseek-ai/dsh-tool-pwsh/lib/index.js b/node_modules/@deepseek-ai/dsh-tool-pwsh/lib/index.js
+index ada4471..c2a9df5 100644
+--- a/node_modules/@deepseek-ai/dsh-tool-pwsh/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-tool-pwsh/lib/index.js
+@@ -370,7 +370,10 @@ function apply(ctx, config = {}) {
+ 				command: args.command,
+ 				...workdir !== void 0 ? { workdir } : {},
+ 				...args.timeoutMs !== void 0 ? { timeoutMs: args.timeoutMs } : {},
+-				dshEnv: ctx.shellEnv.collect(exec),
++				dshEnv: {
++					...ctx.shellEnv.collect(exec),
++					DSH_LIVE_TERMINAL_CALL_ID: exec.callId
++				},
+ 				...policy !== void 0 ? { sandboxPolicy: policy } : {}
+ 			};
+ 			if (args.run_in_background === true) {

--- a/test/live-terminal.test.js
+++ b/test/live-terminal.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  LIVE_TERMINAL_CALL_ID_ENV,
+  LIVE_TERMINAL_PATH,
+  installLiveTerminalStreaming,
+  renderLiveOutput
+} from '../packages/dsh-desktop-market-installer/live-terminal.js'
+
+function collector(value) {
+  return {
+    readFrom(offset) {
+      return { text: value.text.slice(offset), nextOffset: value.text.length }
+    }
+  }
+}
+
+function response() {
+  return {
+    headers: {},
+    setHeader(name, value) {
+      this.headers[name] = value
+    },
+    end(body) {
+      this.body = body
+    }
+  }
+}
+
+describe('live terminal streaming', () => {
+  it('renders stderr after stdout without consuming either collector', () => {
+    expect(renderLiveOutput('one', 'two')).toBe('one\n[stderr]\ntwo')
+    expect(renderLiveOutput('one\n', 'two')).toBe('one\n[stderr]\ntwo')
+  })
+
+  it('correlates a running subprocess by tool call id and exposes incremental output', async () => {
+    let settle
+    const done = new Promise((resolve) => { settle = resolve })
+    const stdout = { text: 'first\n' }
+    const stderr = { text: '' }
+    const originalSpawn = vi.fn(() => ({
+      collected: { stdout: collector(stdout), stderr: collector(stderr) },
+      done
+    }))
+    let route
+    let cleanup
+    const hostCtx = {
+      subprocess: { spawn: originalSpawn },
+      webServer: {
+        register(definition) {
+          route = definition
+          return vi.fn()
+        }
+      },
+      effect(factory) {
+        cleanup = factory()
+      }
+    }
+    const ctx = {
+      inject(dependencies, callback) {
+        expect(dependencies).toEqual(['webServer', 'subprocess'])
+        callback(hostCtx)
+      }
+    }
+
+    installLiveTerminalStreaming(ctx)
+    const wrappedSpawn = hostCtx.subprocess.spawn
+    hostCtx.subprocess.spawn({
+      env: { [LIVE_TERMINAL_CALL_ID_ENV]: 'call-7' }
+    })
+
+    expect(route.path).toBe(LIVE_TERMINAL_PATH)
+    const firstResponse = response()
+    route.handler({ method: 'GET', url: `${LIVE_TERMINAL_PATH}?callId=call-7` }, firstResponse)
+    expect(JSON.parse(firstResponse.body)).toMatchObject({
+      found: true,
+      active: true,
+      output: 'first\n'
+    })
+
+    stdout.text += 'second\n'
+    stderr.text += 'warning\n'
+    const secondResponse = response()
+    route.handler({ method: 'GET', url: `${LIVE_TERMINAL_PATH}?callId=call-7` }, secondResponse)
+    expect(JSON.parse(secondResponse.body).output).toBe('first\nsecond\n[stderr]\nwarning\n')
+
+    settle({ exitCode: 0, signal: null })
+    await done
+    await Promise.resolve()
+    cleanup()
+    expect(hostCtx.subprocess.spawn).not.toBe(wrappedSpawn)
+  })
+})


### PR DESCRIPTION
## Summary

- correlate foreground bash/pwsh subprocesses with their tool call IDs
- expose non-consuming incremental stdout/stderr snapshots through a Desktop-local endpoint
- render and auto-scroll live output in running terminal cards, then retain the existing settled terminal result and exit-state UI
- bound retained live output and clean up settled process records

## Verification

- `npm run typecheck`
- `npm run build`
- `npm test -- --reporter=dot` (90 files, 747 tests)
- verified all four new `patch-package` patches apply cleanly to the repository tarballs

Fixes #296
Closes AND-401
