### PR TITLE
fix(cache): reuse stable Harness loopback origin (#361)

### DIFF
--- a/src/main/cache-maintenance.ts
+++ b/src/main/cache-maintenance.ts
@@ -1,22 +1,43 @@
+import { readFile, writeFile } from 'node:fs/promises'
+
 export interface HttpCacheSession {
   clearCache(): Promise<void>
 }
 
 /**
- * Harness listens on a new random loopback port after each start, so Chromium
- * cannot reuse entries from the previous origin. Clear only the HTTP cache;
- * cookies and storage data belong to separate Electron APIs and stay intact.
+ * Keep cache entries while Harness stays on the same origin. When the stable
+ * preferred port is unavailable, or when upgrading from the former random-port
+ * behavior, clear only the HTTP cache before loading the new origin. Cookies
+ * and storage data belong to separate Electron APIs and stay intact.
  */
 export async function clearStaleLoopbackHttpCache(
   session: HttpCacheSession,
+  originStatePath: string,
+  nextOrigin: string,
   note: (line: string) => void
-): Promise<boolean> {
+): Promise<'unchanged' | 'cleared' | 'failed'> {
+  try {
+    if ((await readFile(originStatePath, 'utf8')).trim() === nextOrigin) return 'unchanged'
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      const detail = error instanceof Error ? error.message : String(error)
+      note(`[desktop] loopback HTTP cache origin state read failed: ${detail}`)
+    }
+  }
+
   try {
     await session.clearCache()
-    return true
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error)
     note(`[desktop] stale loopback HTTP cache cleanup failed: ${detail}`)
-    return false
+    return 'failed'
   }
+
+  try {
+    await writeFile(originStatePath, `${nextOrigin}\n`, 'utf8')
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    note(`[desktop] loopback HTTP cache origin state write failed: ${detail}`)
+  }
+  return 'cleared'
 }

--- a/src/main/cache-maintenance.ts
+++ b/src/main/cache-maintenance.ts
@@ -1,0 +1,22 @@
+export interface HttpCacheSession {
+  clearCache(): Promise<void>
+}
+
+/**
+ * Harness listens on a new random loopback port after each start, so Chromium
+ * cannot reuse entries from the previous origin. Clear only the HTTP cache;
+ * cookies and storage data belong to separate Electron APIs and stay intact.
+ */
+export async function clearStaleLoopbackHttpCache(
+  session: HttpCacheSession,
+  note: (line: string) => void
+): Promise<boolean> {
+  try {
+    await session.clearCache()
+    return true
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    note(`[desktop] stale loopback HTTP cache cleanup failed: ${detail}`)
+    return false
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,11 @@ import {
   type MessageBoxOptions
 } from 'electron'
 import { clearStaleLoopbackHttpCache } from './cache-maintenance'
-import { extractFailureCause, HarnessRuntime } from './runtime/harness-runtime'
+import {
+  DEFAULT_HARNESS_PORT,
+  extractFailureCause,
+  HarnessRuntime
+} from './runtime/harness-runtime'
 import { launchDisclaimedUtilityProcess } from './runtime/disclaimed-utility-process'
 import {
   installProfileDependenciesWithDsh,
@@ -995,6 +999,8 @@ async function openHarness(
     window.webContents.stop()
     await clearStaleLoopbackHttpCache(
       window.webContents.session,
+      join(app.getPath('userData'), 'http-cache-origin'),
+      new URL(url).origin,
       (line) => runtime.note(line)
     )
     const clearedCookies = await clearStaleHarnessAuthCookies(
@@ -2603,6 +2609,9 @@ async function bootstrap(): Promise<void> {
     dshSafePatchPath: desktopResourcePath('dsh-desktop-safe.patch.yml'),
     dshHome: join(app.getPath('userData'), 'harness'),
     logPath: join(app.getPath('logs'), 'harness.log'),
+    // Keep the Harness origin stable across launches. These ports are separate
+    // from the production/development mobile bridge ports (43127/43128).
+    preferredPort: DEFAULT_HARNESS_PORT + (developmentBuild ? 1 : 0),
     launchProcess: (executablePath, args, options) =>
       process.platform === 'darwin'
         ? launchDisclaimedUtilityProcess(utilityProcess, args, options, {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,7 @@ import {
   type IpcMainInvokeEvent,
   type MessageBoxOptions
 } from 'electron'
+import { clearStaleLoopbackHttpCache } from './cache-maintenance'
 import { extractFailureCause, HarnessRuntime } from './runtime/harness-runtime'
 import { launchDisclaimedUtilityProcess } from './runtime/disclaimed-utility-process'
 import {
@@ -992,6 +993,10 @@ async function openHarness(
     const navigationVersion = ++mainWindowNavigationVersion
     rendererPluginFailureLogs = []
     window.webContents.stop()
+    await clearStaleLoopbackHttpCache(
+      window.webContents.session,
+      (line) => runtime.note(line)
+    )
     const clearedCookies = await clearStaleHarnessAuthCookies(
       window.webContents.session.cookies,
       rendererUrl,

--- a/src/main/runtime/harness-runtime.ts
+++ b/src/main/runtime/harness-runtime.ts
@@ -20,6 +20,7 @@ export interface HarnessRuntimeOptions {
     args: string[],
     options: SpawnOptionsWithoutStdio
   ): HarnessChildProcess
+  preferredPort?: number
   startupTimeoutMs?: number
   onChanged(snapshot: RuntimeSnapshot): void
 }
@@ -30,6 +31,8 @@ export interface HarnessChildProcess extends EventEmitter {
   readonly exitCode: number | null
   kill(signal?: NodeJS.Signals): boolean
 }
+
+export const DEFAULT_HARNESS_PORT = 43129
 
 /**
  * Resolve the user's interactive login shell environment.
@@ -380,7 +383,8 @@ export class HarnessRuntime {
     await mkdir(dirname(this.options.logPath), { recursive: true })
     this.logStream ??= createWriteStream(this.options.logPath, { flags: 'a' })
 
-    const port = await reservePort()
+    const preferredPort = this.options.preferredPort ?? DEFAULT_HARNESS_PORT
+    const { port, usedPreferredPort } = await reserveLoopbackPort(preferredPort)
     const url = `http://127.0.0.1:${port}`
     const args = buildNodeArguments(
       this.options.nodeEntryPath,
@@ -396,6 +400,11 @@ export class HarnessRuntime {
     this.writeLog(`[desktop] launch directory ${launchDirectory}`)
     this.writeLog(`[desktop] profile ${profile}`)
     this.writeLog(`[desktop] patch ${patchPath}`)
+    if (!usedPreferredPort) {
+      this.writeLog(
+        `[desktop] preferred endpoint http://127.0.0.1:${preferredPort} is unavailable; using a temporary port`
+      )
+    }
     this.writeLog(`[desktop] endpoint ${url}`)
     this.setState('starting', 'Starting DeepSeek Harness…')
 
@@ -778,12 +787,12 @@ export function formatExitCode(code: number): string {
   return `exit code ${code} (${hexadecimal})`
 }
 
-async function reservePort(): Promise<number> {
+async function reservePort(port: number): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = createServer()
     server.unref()
     server.once('error', reject)
-    server.listen({ host: '127.0.0.1', port: 0 }, () => {
+    server.listen({ host: '127.0.0.1', port }, () => {
       const address = server.address()
       if (!address || typeof address === 'string') {
         server.close()
@@ -794,6 +803,21 @@ async function reservePort(): Promise<number> {
       server.close((error) => (error ? reject(error) : resolve(port)))
     })
   })
+}
+
+/**
+ * Prefer a stable loopback origin so Chromium can reuse the Harness frontend
+ * cache across launches. A conflicting local process must not prevent Desktop
+ * from starting, so an ephemeral port remains the fallback.
+ */
+export async function reserveLoopbackPort(
+  preferredPort = DEFAULT_HARNESS_PORT
+): Promise<{ port: number; usedPreferredPort: boolean }> {
+  try {
+    return { port: await reservePort(preferredPort), usedPreferredPort: true }
+  } catch {
+    return { port: await reservePort(0), usedPreferredPort: false }
+  }
 }
 
 async function waitUntilReady(

--- a/test/cache-maintenance.test.ts
+++ b/test/cache-maintenance.test.ts
@@ -1,0 +1,43 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { clearStaleLoopbackHttpCache } from '../src/main/cache-maintenance'
+
+const projectRoot = path.resolve(import.meta.dirname, '..')
+
+describe('loopback HTTP cache maintenance', () => {
+  it('clears the HTTP cache without reporting a healthy cleanup', async () => {
+    const clearCache = vi.fn(async () => undefined)
+    const note = vi.fn()
+
+    await expect(clearStaleLoopbackHttpCache({ clearCache }, note)).resolves.toBe(true)
+    expect(clearCache).toHaveBeenCalledOnce()
+    expect(note).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed cleanup without rejecting desktop startup', async () => {
+    const clearCache = vi.fn(async () => {
+      throw new Error('cache is locked')
+    })
+    const note = vi.fn()
+
+    await expect(clearStaleLoopbackHttpCache({ clearCache }, note)).resolves.toBe(false)
+    expect(note).toHaveBeenCalledWith(
+      '[desktop] stale loopback HTTP cache cleanup failed: cache is locked'
+    )
+  })
+
+  it('clears the cache after stopping old requests and before loading a new Harness origin', async () => {
+    const main = await readFile(path.join(projectRoot, 'src/main/index.ts'), 'utf8')
+    const start = main.indexOf('async function openHarness(')
+    const end = main.indexOf('\nfunction ', start)
+    const openHarness = main.slice(start, end)
+
+    expect(openHarness.indexOf('window.webContents.stop()')).toBeLessThan(
+      openHarness.indexOf('await clearStaleLoopbackHttpCache(')
+    )
+    expect(openHarness.indexOf('await clearStaleLoopbackHttpCache(')).toBeLessThan(
+      openHarness.indexOf('await window.loadURL(rendererUrl)')
+    )
+  })
+})

--- a/test/cache-maintenance.test.ts
+++ b/test/cache-maintenance.test.ts
@@ -1,4 +1,5 @@
-import { readFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { clearStaleLoopbackHttpCache } from '../src/main/cache-maintenance'
@@ -6,25 +7,95 @@ import { clearStaleLoopbackHttpCache } from '../src/main/cache-maintenance'
 const projectRoot = path.resolve(import.meta.dirname, '..')
 
 describe('loopback HTTP cache maintenance', () => {
-  it('clears the HTTP cache without reporting a healthy cleanup', async () => {
+  it('clears legacy origins and records the next stable origin', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'dsh-cache-test-'))
+    const statePath = path.join(directory, 'http-cache-origin')
     const clearCache = vi.fn(async () => undefined)
     const note = vi.fn()
 
-    await expect(clearStaleLoopbackHttpCache({ clearCache }, note)).resolves.toBe(true)
-    expect(clearCache).toHaveBeenCalledOnce()
-    expect(note).not.toHaveBeenCalled()
+    try {
+      await expect(
+        clearStaleLoopbackHttpCache(
+          { clearCache },
+          statePath,
+          'http://127.0.0.1:43129',
+          note
+        )
+      ).resolves.toBe('cleared')
+      expect(clearCache).toHaveBeenCalledOnce()
+      expect(await readFile(statePath, 'utf8')).toBe('http://127.0.0.1:43129\n')
+      expect(note).not.toHaveBeenCalled()
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps reusable cache entries when the loopback origin is unchanged', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'dsh-cache-test-'))
+    const statePath = path.join(directory, 'http-cache-origin')
+    await writeFile(statePath, 'http://127.0.0.1:43129\n', 'utf8')
+    const clearCache = vi.fn(async () => undefined)
+
+    try {
+      await expect(
+        clearStaleLoopbackHttpCache(
+          { clearCache },
+          statePath,
+          'http://127.0.0.1:43129',
+          vi.fn()
+        )
+      ).resolves.toBe('unchanged')
+      expect(clearCache).not.toHaveBeenCalled()
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('clears a fallback origin before returning to the stable origin', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'dsh-cache-test-'))
+    const statePath = path.join(directory, 'http-cache-origin')
+    await writeFile(statePath, 'http://127.0.0.1:54421\n', 'utf8')
+    const clearCache = vi.fn(async () => undefined)
+
+    try {
+      await expect(
+        clearStaleLoopbackHttpCache(
+          { clearCache },
+          statePath,
+          'http://127.0.0.1:43129',
+          vi.fn()
+        )
+      ).resolves.toBe('cleared')
+      expect(clearCache).toHaveBeenCalledOnce()
+      expect(await readFile(statePath, 'utf8')).toBe('http://127.0.0.1:43129\n')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 
   it('reports a failed cleanup without rejecting desktop startup', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'dsh-cache-test-'))
+    const statePath = path.join(directory, 'http-cache-origin')
     const clearCache = vi.fn(async () => {
       throw new Error('cache is locked')
     })
     const note = vi.fn()
 
-    await expect(clearStaleLoopbackHttpCache({ clearCache }, note)).resolves.toBe(false)
-    expect(note).toHaveBeenCalledWith(
-      '[desktop] stale loopback HTTP cache cleanup failed: cache is locked'
-    )
+    try {
+      await expect(
+        clearStaleLoopbackHttpCache(
+          { clearCache },
+          statePath,
+          'http://127.0.0.1:43129',
+          note
+        )
+      ).resolves.toBe('failed')
+      expect(note).toHaveBeenCalledWith(
+        '[desktop] stale loopback HTTP cache cleanup failed: cache is locked'
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 
   it('clears the cache after stopping old requests and before loading a new Harness origin', async () => {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises'
+import { createServer } from 'node:net'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
@@ -16,6 +17,7 @@ import {
   isHarnessStartupProbeHealthy,
   resolveEnvironmentPath,
   resolveShellEnvironment,
+  reserveLoopbackPort,
   updateReadyStability
 } from '../src/main/runtime/harness-runtime'
 import { canGrantWindowPermission, isTrustedAppUrl } from '../src/main/security-policy'
@@ -28,6 +30,43 @@ import {
 } from '../src/main/window-navigation'
 
 describe('Harness launch contract', () => {
+  it('reuses a preferred loopback port when it is available', async () => {
+    const probe = createServer()
+    await new Promise<void>((resolve, reject) => {
+      probe.once('error', reject)
+      probe.listen({ host: '127.0.0.1', port: 0 }, resolve)
+    })
+    const address = probe.address()
+    if (!address || typeof address === 'string') throw new Error('Expected a TCP address')
+    await new Promise<void>((resolve, reject) =>
+      probe.close((error) => (error ? reject(error) : resolve()))
+    )
+
+    await expect(reserveLoopbackPort(address.port)).resolves.toEqual({
+      port: address.port,
+      usedPreferredPort: true
+    })
+  })
+
+  it('falls back to an ephemeral port when the preferred port is occupied', async () => {
+    const occupied = createServer()
+    await new Promise<void>((resolve, reject) => {
+      occupied.once('error', reject)
+      occupied.listen({ host: '127.0.0.1', port: 0 }, resolve)
+    })
+    const address = occupied.address()
+    if (!address || typeof address === 'string') throw new Error('Expected a TCP address')
+
+    try {
+      const selected = await reserveLoopbackPort(address.port)
+      expect(selected.usedPreferredPort).toBe(false)
+      expect(selected.port).not.toBe(address.port)
+      expect(selected.port).toBeGreaterThan(0)
+    } finally {
+      await new Promise<void>((resolve) => occupied.close(() => resolve()))
+    }
+  })
+
   it('does not treat a briefly reachable port as a completed Harness startup', () => {
     const firstProbe = updateReadyStability(undefined, true, 1_000)
     expect(firstProbe).toEqual({ readySince: 1_000, ready: false })
@@ -49,7 +88,7 @@ describe('Harness launch contract', () => {
     expect(isHarnessStartupProbeHealthy(500, 'launch-token')).toBe(false)
   })
 
-  it('binds the web server to a random loopback port', () => {
+  it('builds the web server arguments for the selected loopback port', () => {
     expect(buildHarnessArguments(43127)).toEqual([
       'web',
       '--no-open',


### PR DESCRIPTION
## Summary

- prefer a stable Harness loopback port: `43129` in production and `43130` in development
- fall back to an ephemeral port when the preferred port is occupied, so startup remains resilient
- remember the last loaded Harness origin and clear Electron HTTP Cache only when that origin changes
- preserve cookies, Local Storage, Session Storage, DSH_HOME, profiles, plugins, settings, credentials, and sessions

## Root cause

Harness previously selected a fresh random `127.0.0.1:<port>` for every launch. Chromium includes the port in the origin, so frontend cache entries could not be reused and old loopback origins accumulated. Clearing the whole HTTP cache on every launch bounded disk use but also discarded cache that becomes reusable once the origin is stable.

## Fix

`HarnessRuntime` now probes a dedicated stable Desktop port first and records a diagnostic before falling back to an ephemeral port. The production/development Harness ports are separate from the existing mobile bridge ports `43127` and `43128`.

Cache maintenance stores the last loaded origin in `http-cache-origin`. The first launch after this update clears legacy random-origin cache and records the stable origin. Later launches on the same origin keep the cache. A preferred-port conflict changes the origin, so stale cache is cleared before navigation and the fallback origin is recorded. Cleanup and state-file failures remain non-blocking and diagnosable.

## Verification

- `npm test -- --run test/runtime.test.ts test/cache-maintenance.test.ts test/window-navigation.test.ts` — 58 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed
- full `npm test -- --reporter=dot` — 87 files and 736 tests passed; the existing `ppt-activation`, `ppt-fonts`, and `safe-mode-runtime` failures remain because the reused dependency tree lacks `dsh-ppt` / `dsh-ppt-composer`

Closes #361
