### PR TITLE
AND-408: restore Ctrl+C copying on Windows

### DIFF
--- a/src/main/copy-shortcut.ts
+++ b/src/main/copy-shortcut.ts
@@ -1,0 +1,27 @@
+export interface CopyShortcutInput {
+  type: string
+  key: string
+  control: boolean
+  shift: boolean
+  alt: boolean
+  meta: boolean
+}
+
+/**
+ * Electron normally routes Ctrl+C through the application menu's `copy` role.
+ * Some Windows shells fail to dispatch that hidden-menu accelerator, while the
+ * equivalent WebContents.copy() command still works. Keep the fallback exact so
+ * Ctrl+Shift+C, AltGr combinations, and non-Windows editing remain untouched.
+ */
+export function isWindowsCopyShortcut(
+  input: CopyShortcutInput,
+  platform: NodeJS.Platform
+): boolean {
+  return platform === 'win32' &&
+    input.type === 'keyDown' &&
+    input.key.toLowerCase() === 'c' &&
+    input.control &&
+    !input.shift &&
+    !input.alt &&
+    !input.meta
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -139,6 +139,7 @@ import { upgradePluginToGeneration } from './state/plugin-upgrade'
 import { aboutDetail, bundledHarnessVersion } from './version-info'
 import { windowsMenuViewBounds } from './windows-menu-view'
 import { shouldKeepRunningInBackground } from './close-to-tray'
+import { isWindowsCopyShortcut } from './copy-shortcut'
 import {
   MAIN_WINDOW_RECOVERY_RELOAD_COOLDOWN_MS,
   shouldReloadAfterMainWindowRendererLoss
@@ -966,6 +967,11 @@ function createWindow(): BrowserWindow {
   installPluginRecoveryNavigation(window)
   secureWindow(window)
   installContextMenu(window, harnessLocale)
+  window.webContents.on('before-input-event', (event, input) => {
+    if (!isWindowsCopyShortcut(input, process.platform)) return
+    event.preventDefault()
+    window.webContents.copy()
+  })
   installMainWindowRendererRecovery(window)
   window.on('closed', () => {
     if (mainWindow === window) mainWindow = undefined

--- a/test/copy-shortcut.test.ts
+++ b/test/copy-shortcut.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { isWindowsCopyShortcut, type CopyShortcutInput } from '../src/main/copy-shortcut'
+
+function input(overrides: Partial<CopyShortcutInput> = {}): CopyShortcutInput {
+  return {
+    type: 'keyDown',
+    key: 'c',
+    control: true,
+    shift: false,
+    alt: false,
+    meta: false,
+    ...overrides
+  }
+}
+
+describe('Windows copy shortcut fallback', () => {
+  it('handles Ctrl+C keydown on Windows', () => {
+    expect(isWindowsCopyShortcut(input(), 'win32')).toBe(true)
+    expect(isWindowsCopyShortcut(input({ key: 'C' }), 'win32')).toBe(true)
+  })
+
+  it('does not replace native editing shortcuts on other platforms', () => {
+    expect(isWindowsCopyShortcut(input(), 'darwin')).toBe(false)
+    expect(isWindowsCopyShortcut(input(), 'linux')).toBe(false)
+  })
+
+  it('ignores keyup, other keys, and additional modifiers', () => {
+    expect(isWindowsCopyShortcut(input({ type: 'keyUp' }), 'win32')).toBe(false)
+    expect(isWindowsCopyShortcut(input({ key: 'x' }), 'win32')).toBe(false)
+    expect(isWindowsCopyShortcut(input({ control: false }), 'win32')).toBe(false)
+    expect(isWindowsCopyShortcut(input({ shift: true }), 'win32')).toBe(false)
+    expect(isWindowsCopyShortcut(input({ alt: true }), 'win32')).toBe(false)
+    expect(isWindowsCopyShortcut(input({ meta: true }), 'win32')).toBe(false)
+  })
+})

--- a/test/windows-titlebar.test.ts
+++ b/test/windows-titlebar.test.ts
@@ -24,6 +24,8 @@ describe('Windows titlebar menu', () => {
     expect(main).toContain('autoHideMenuBar: true')
     expect(main).toContain('window.setMenuBarVisibility(false)')
     expect(main).toContain('Menu.setApplicationMenu(Menu.buildFromTemplate(template))')
+    expect(main).toContain("window.webContents.on('before-input-event'")
+    expect(main).toContain('window.webContents.copy()')
   })
 
   it('keeps the entire Windows app full-height without a visible titlebar band', async () => {


### PR DESCRIPTION
## Summary

- add a Windows-only `before-input-event` fallback for Ctrl+C in the main Harness WebContents
- route the fallback through the same `webContents.copy()` operation already proven by the working context-menu path
- leave Ctrl+Shift+C, AltGr combinations, keyup, and non-Windows native editing behavior unchanged
- add shortcut classification and Windows titlebar wiring regression coverage

Fixes #321

## Verification

- `npm test` — 90 files, 753 tests passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Physical Windows UI verification was not available on this macOS worker; the Windows input route and main-window wiring are covered by tests.