### PR TITLE
fix(compaction): name the real reason a manual compaction is refused

### DIFF
--- a/patches/@deepseek-ai+dsh-command-compact+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-command-compact+0.1.2-rc.1.patch
@@ -1,0 +1,34 @@
+--- a/node_modules/@deepseek-ai/dsh-command-compact/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-command-compact/lib/index.js
+@@ -13,12 +13,23 @@
+ 	throw new TypeError(`unknown manual compaction error code: ${String(value)}`);
+ }
+ /* v8 ignore stop */
+-/** Convert expected capability failures into concise human-only outcomes. */
++/**
++ * Convert expected capability failures into concise human-only outcomes.
++ *
++ * Extracted from the command handler so the classification stays testable
++ * without a browser runtime: the codes, not the transport, decide the copy.
++ * @param error - classified manual-compaction failure.
++ * @returns the human-only outcome for that failure class.
++ */
+ function expectedFailure(error) {
+ 	switch (error.code) {
++		case "agent-busy": return {
++			kind: "error",
++			text: "Compaction did not start: the agent is still working on this session. Wait for the turn to finish, then run /compact again."
++		};
+ 		case "busy": return {
+ 			kind: "error",
+-			text: "Compaction is unavailable because this process has an active compaction, or the agent is not idle."
++			text: "Compaction is unavailable because another compaction is already in progress or the session compaction lock is active."
+ 		};
+ 		case "cancelled": return {
+ 			kind: "error",
+@@ -97,4 +108,4 @@
+ 	}, "command-compact lifecycle");
+ }
+ //#endregion
+-export { apply, inject, name };
++export { apply, expectedFailure, inject, name };

--- a/patches/@deepseek-ai+dsh-compaction-basic+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-compaction-basic+0.1.2-rc.1.patch
@@ -1,0 +1,32 @@
+--- a/node_modules/@deepseek-ai/dsh-compaction-basic/lib/index.js
++++ b/node_modules/@deepseek-ai/dsh-compaction-basic/lib/index.js
+@@ -512,6 +512,21 @@
+ * @param session - session whose latest marker state is inspected.
+ * @param stage - operation label included in the busy diagnostic.
+ */
++/**
++ * Whether a maintenance claim was refused because the agent was still working.
++ *
++ * `AgentLoop.runMaintenance` admits maintenance only from an idle phase and has
++ * no other refusal path, but it reports that through a plain `Error` whose text
++ * is the only signal a compaction provider gets. Folding that case into the
++ * generic `busy` code hid which of the two possible causes applied: the agent
++ * still finishing its turn, or the shared durable compaction lock. They need
++ * different copy, because only the first clears by itself within seconds.
++ * @param error - value thrown by the maintenance claim.
++ * @returns whether the agent owned a running phase at claim time.
++ */
++function isAgentWorkingError(error) {
++	return error instanceof Error && /already has active work$/u.test(error.message);
++}
+ function assertNoActiveCompaction(session, stage) {
+ 	const entryState = inspectCompactionEntryState(session);
+ 	assertCompactionInactive(entryState.unmatchedCompactionStart, entryState.latestEndSeedSeq, stage);
+@@ -949,6 +964,7 @@
+ 				}
+ 			});
+ 		} catch (error) {
++			if (isAgentWorkingError(error)) throw new ManualCompactionError("agent-busy", "manual compaction did not start: the agent was still working", { cause: error });
+ 			throw new ManualCompactionError("busy", "manual compaction requires an idle agent with no waking queued work", { cause: error });
+ 		}
+ 	}

--- a/test/compaction-refusal.test.ts
+++ b/test/compaction-refusal.test.ts
@@ -1,0 +1,111 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { patchPath, projectRoot } from './patch-path'
+
+const commandCompact = path.join(
+  projectRoot,
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-command-compact',
+  'lib',
+  'index.js'
+)
+
+const compactionBasic = path.join(
+  projectRoot,
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-compaction-basic',
+  'lib',
+  'index.js'
+)
+
+interface Outcome {
+  kind: string
+  text: string
+}
+
+/**
+ * The `/compact` command is refused through `ManualCompactionError` codes. Two
+ * very different situations used to share one code and one sentence: the agent
+ * still finishing its turn (clears by itself in seconds) and the shared durable
+ * compaction lock (does not). A user who ran `/compact` right after watching the
+ * agent answer saw a message claiming the agent was not idle and could not tell
+ * which situation they were in.
+ */
+describe('DSH Desktop manual compaction refusals', () => {
+  async function classifier(): Promise<(error: { code: string }) => Outcome> {
+    const module = (await import(commandCompact)) as {
+      expectedFailure(error: { code: string }): Outcome
+    }
+    if (typeof module.expectedFailure !== 'function') {
+      throw new Error('dsh-command-compact exports no failure classifier')
+    }
+    return module.expectedFailure
+  }
+
+  it('tells the user to wait when the agent is still working', async () => {
+    const expectedFailure = await classifier()
+    const outcome = expectedFailure({ code: 'agent-busy' })
+
+    expect(outcome.kind).toBe('error')
+    expect(outcome.text).toContain('still working')
+    expect(outcome.text).toContain('/compact again')
+  })
+
+  it('keeps the lock wording for an active compaction or held lock', async () => {
+    const expectedFailure = await classifier()
+    const outcome = expectedFailure({ code: 'busy' })
+
+    expect(outcome.kind).toBe('error')
+    expect(outcome.text).toContain('compaction lock')
+    // The agent-idle claim belongs to the agent-busy case alone.
+    expect(outcome.text).not.toContain('agent is not idle')
+  })
+
+  it('still classifies every other compaction failure', async () => {
+    const expectedFailure = await classifier()
+
+    for (const code of ['cancelled', 'changed', 'summary', 'commit', 'persistence']) {
+      const outcome = expectedFailure({ code })
+      expect(outcome.kind).toBe('error')
+      expect(outcome.text.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('separates a running agent from the durable lock at the refusal boundary', async () => {
+    const client = await readFile(compactionBasic, 'utf8')
+
+    expect(client).toContain('function isAgentWorkingError(error)')
+    expect(client).toContain('if (isAgentWorkingError(error)) throw new ManualCompactionError("agent-busy"')
+    // The other maintenance refusal stays on the generic code.
+    expect(client).toContain('throw new ManualCompactionError("busy", "manual compaction requires an idle agent')
+  })
+
+  it('recognizes the agent-loop maintenance refusal and nothing else', async () => {
+    const client = await readFile(compactionBasic, 'utf8')
+    const literal = client.match(/function isAgentWorkingError\(error\) \{\n\treturn (.*)\n\}/u)?.[1]
+
+    expect(literal).toBeDefined()
+    const pattern = literal?.slice(literal.indexOf('/'), literal.lastIndexOf('/u') + 2)
+    const matches = (message: string) =>
+      new RegExp(pattern?.slice(1, -2) ?? '', 'u').test(message)
+
+    // This is the exact text AgentLoop.runMaintenance raises for a busy phase.
+    expect(matches('agent "session-1" already has active work')).toBe(true)
+    // A durability refusal from the compaction lock must not be captured here.
+    expect(matches('compaction: compaction already in progress; the session compaction lock is already active')).toBe(false)
+    expect(matches('manual compaction: the session already has an open turn')).toBe(false)
+  })
+
+  it('carries both refusals in the reproducible dependency patches', async () => {
+    const compactionPatch = await readFile(patchPath('@deepseek-ai/dsh-compaction-basic'), 'utf8')
+    const commandPatch = await readFile(patchPath('@deepseek-ai/dsh-command-compact'), 'utf8')
+
+    expect(compactionPatch).toContain('"agent-busy"')
+    expect(compactionPatch).toContain('isAgentWorkingError')
+    expect(commandPatch).toContain('case "agent-busy"')
+    expect(commandPatch).toContain('export { apply, expectedFailure, inject, name };')
+  })
+})


### PR DESCRIPTION
## What

`/compact` answered **every** refusal with one sentence:

> Compaction is unavailable because this process has an active compaction, or the agent is not idle.

That folds two unrelated conditions into one message. The ordinary case — running `/compact` while the agent is still finishing the turn it just answered — was indistinguishable from a real compaction-lock conflict, so the copy sent the reader hunting for a compaction that did not exist.

## Evidence from a real session log

From a DSH Desktop session log (`session.jsonl.zstd`, `ts` fields, epoch ms):

| event | ts | delta |
| --- | --- | --- |
| last `step/end` of the answered turn | 1789070593953 | — |
| `command/run compact` | 1789070596493 | +2.5 s |
| `command/done` kind=error | 1789070596498 | +5 ms |
| next `turn/start` | 1789070640640 | +45 s |

The refusal landed 2.5 s after the turn's last step and 45 s before the next turn started: the agent was still `running`. (Title-generation hooks run before `turn/end`, which is why the UI can look idle when the phase is not.) The rejection came back in 5 ms, so the classifier is the only thing that could have told the two causes apart — and it did not.

## Change

Both packages are host-side plugins and the desktop shell pins the 0.1.2-rc.1 artifacts, so they ship as `patch-package` patches.

- **`dsh-compaction-basic`** — recognises the agent loop's `already has active work` refusal as its own `agent-busy` code. `busy` keeps its real meaning: an actual claim or lock conflict.
- **`dsh-command-compact`** — one message per code. `agent-busy` now reads *"Compaction did not start: the agent is still working on this session. Wait for the turn to finish, then run /compact again."*, and `busy` names the lock instead of claiming the agent is not idle.

## Verification

- Each patch applies to the pristine published 0.1.2-rc.1 tarball and reproduces the installed bundle byte-for-byte: `dsh-compaction-basic` `42a4c68e…`, `dsh-command-compact` `9223f3ad…`.
- `npx vitest run test/compaction-refusal.test.ts` — 6 passed on this branch alone.
- `npm test` — 810 passed / 95 files. `npm run typecheck` clean.

## Scope

This corrects the diagnosis, not the timing: `/compact` still will not start mid-turn. Making it wait for idle changes `AgentLoop.runMaintenance` semantics for every maintenance caller (the scheduler currently defers when the claim is busy), so it belongs in its own change.
