### PR TITLE
fix(client-ui): reconcile a stale model selection, uncap the status line, add a CDP helper

### DIFF
--- a/patches/@deepseek-ai+dsh-client-ui-chat+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-chat+0.1.2-rc.1.patch
@@ -32,3 +32,14 @@ index a33402f..0f7ba8e 100644
  			"message.turnError": "This turn failed",
  			"message.maxTokens": "Output token limit reached",
  			"message.maxTokens.hint": "The reply was cut off; earlier output is preserved in the conversation. Send \"continue\" to let the model resume.",
+--- a/node_modules/@deepseek-ai/dsh-client-ui-chat/lib/client.js
++++ b/node_modules/@deepseek-ai/dsh-client-ui-chat/lib/client.js
+@@ -3738,7 +3738,7 @@
+ 		}
+ 		//#endregion
+ 		//#region \0dsh-css:/private/tmp/dsh-harness-v0.1.2-rc.1/packages/client/ui-chat/src/client/chat/StatsLine.module.css.mjs
+-		const css$2 = ".XZbVjq_root{text-align:center;max-width:var(--dsh-chat-content-width);box-sizing:border-box;width:100%;padding:4px calc(var(--dsh-composer-side-clearance) + 16px) 0px;font-size:var(--dsh-content-font-size-secondary,13px);line-height:calc(20px + var(--dsh-content-font-delta-secondary,0px));color:var(--dsw-alias-label-tertiary);white-space:nowrap;text-overflow:ellipsis;margin:0 auto;display:block;overflow:hidden}.XZbVjq_sep{color:var(--dsw-alias-separator-primary);margin:0 10px}";
++		const css$2 = ".XZbVjq_root{text-align:center;max-width:none;box-sizing:border-box;width:100%;padding:4px calc(var(--dsh-composer-side-clearance) + 16px) 0px;font-size:var(--dsh-content-font-size-secondary,13px);line-height:calc(20px + var(--dsh-content-font-delta-secondary,0px));color:var(--dsw-alias-label-tertiary);white-space:nowrap;text-overflow:ellipsis;margin:0 auto;display:block;overflow:hidden}.XZbVjq_sep{color:var(--dsw-alias-separator-primary);margin:0 10px}";
+ 		const tagId$2 = "@deepseek-ai/dsh-client-ui-chat/StatsLine.module.css";
+ 		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId$2) + "]") === null) {
+ 			const tag = document.createElement("style");

--- a/patches/@deepseek-ai+dsh-client-ui-model-selection+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-client-ui-model-selection+0.1.2-rc.1.patch
@@ -205,3 +205,146 @@ diff --git a/node_modules/@deepseek-ai/dsh-client-ui-model-selection/lib/client.
  			"blocked.composer": "This model is unavailable — select one to continue",
  			"empty.efforts": "This model provides no reasoning effort levels."
  		};
+--- a/node_modules/@deepseek-ai/dsh-client-ui-model-selection/lib/client.js
++++ b/node_modules/@deepseek-ai/dsh-client-ui-model-selection/lib/client.js
+@@ -89,6 +89,44 @@
+ 		};
+ 		//#endregion
+ 		//#region lib/types/client/directory.js
++		/**
++		* Whether the catalog still serves one exact provider and model.
++		*
++		* A Session's selection is durable and a catalog is not: Settings edits add,
++		* rename, and remove models beneath a selection that was made earlier. A
++		* selection naming a model the catalog no longer lists cannot be rendered
++		* with a name at all.
++		* @param selection - provider and model to look up.
++		* @param catalog - loaded catalog value carrying the provider groups.
++		* @returns true while the catalog lists that provider and model.
++		*/
++		function catalogServes(selection, catalog) {
++			if (selection === null || selection === void 0) return false;
++			return catalog.groups.some((group) => group.id === selection.provider && group.models.some((model) => model.id === selection.model));
++		}
++		/**
++		* Pick the selection that replaces one the catalog no longer serves.
++		*
++		* The deployment default leads — it is the model a new Session would get —
++		* and the served models follow in catalog order, so a default that went
++		* stale in the same edit still resolves to something real. Only routable
++		* providers are offered once any are known, because a replacement the Host
++		* refuses would leave the Session on the same unusable model.
++		* @param current - the selection the catalog no longer serves.
++		* @param catalog - loaded catalog value carrying the default and the groups.
++		* @returns the replacement selection, or undefined when the catalog serves none.
++		*/
++		function replacementSelection(current, catalog) {
++			const served = catalog.groups.flatMap((group) => group.models.map((model) => ({
++				provider: group.id,
++				model: model.id
++			})));
++			const routable = served.filter((candidate) => catalog.routableProviders.includes(candidate.provider));
++			const allowed = routable.length === 0 ? served : routable;
++			const fallback = [catalog.default].filter((candidate) => allowed.includes(candidate));
++			const candidates = [...fallback, ...allowed];
++			return candidates.find((candidate) => candidate.provider !== current.provider || candidate.model !== current.model);
++		}
+ 		/** One session's shared directory controller; disposed with the session scope. */
+ 		var ModelDirectory = class {
+ 			sessions;
+@@ -109,6 +147,10 @@
+ 			generation = 0;
+ 			disposed = false;
+ 			resolved = false;
++			/** Catalog revision already reconciled against the current selection. */
++			reconciledCatalog = "";
++			/** In-flight replacement selection for a model the user removed in Settings. */
++			adopting = false;
+ 			unsubscribeCatalog;
+ 			unsubscribeSelection;
+ 			/**
+@@ -190,6 +232,54 @@
+ 				});
+ 				this.syncInputs();
+ 			}
++			/**
++			* Whether one selection still names a model the current catalog serves.
++			* Settings edits remove and rename models, so a selection that was valid
++			* when it was made can outlive the model it names.
++			* @param selection - provider and model to look up.
++			* @returns true while the catalog lists that exact provider and model.
++			*/
++			serves(selection) {
++				const catalog = this.catalog.store.getSnapshot();
++				if (catalog.status !== "ready" || catalog.value === null) return true;
++				return catalogServes(selection, catalog.value);
++			}
++			/** Identity of the catalog value this directory has already reconciled against. */
++			catalogFingerprint() {
++				const catalog = this.catalog.store.getSnapshot();
++				if (catalog.status !== "ready" || catalog.value === null) return "";
++				return catalog.value.groups.map((group) => `${group.id}/${group.models.map((model) => model.id).join(",")}`).join("|");
++			}
++			/**
++			* Follow the deployment default when the model a Session pins disappears.
++			*
++			* Removing a model in Settings leaves that Session's durable selection
++			* naming a model the Host no longer serves. The composer would render the
++			* bare "provider/model" identifier — a name that looks like the previously
++			* selected model because it literally is it, with nothing able to resolve
++			* it. Follow the deployment default instead, and fall back to the first
++			* served model when that default went stale in the same edit. The
++			* replacement is recorded as a normal selection so the Session and the
++			* deployment default both stop naming a model that no longer exists.
++			*
++			* One attempt per catalog value keeps a rejected replacement from looping.
++			* @param current - the selection the catalog no longer serves.
++			* @param catalog - the loaded catalog carrying the default and the groups.
++			* @returns the replacement selection, or undefined when nothing is served.
++			*/
++			followDefault(current, catalog) {
++				const resolved = replacementSelection(current, catalog);
++				if (resolved === undefined) return void 0;
++				this.adopting = true;
++				this.select({
++					provider: resolved.provider,
++					model: resolved.model,
++					...resolved.reasoningEffort === void 0 ? {} : { reasoningEffort: resolved.reasoningEffort }
++				}).catch(() => {}).finally(() => {
++					this.adopting = false;
++				});
++				return resolved;
++			}
+ 			/** Scope teardown: late settlements lose write access to the store. */
+ 			dispose() {
+ 				this.disposed = true;
+@@ -221,7 +311,18 @@
+ 					});
+ 					return;
+ 				}
+-				const current = projected.next ?? catalog.value.default;
++				const pinned = projected.next ?? catalog.value.default;
++				const fingerprint = this.catalogFingerprint();
++				if (this.adopting) return;
++				const stale = !this.serves(pinned);
++				if (!stale) this.reconciledCatalog = fingerprint;
++				let current = pinned;
++				if (stale && this.reconciledCatalog !== fingerprint) {
++					// Mark first: the replacement's own settlement re-enters here and
++					// must not start a second attempt for the same catalog value.
++					this.reconciledCatalog = fingerprint;
++					current = this.followDefault(pinned, catalog.value) ?? pinned;
++				}
+ 				this.resolved = true;
+ 				this.store.set({
+ 					current,
+@@ -989,7 +1090,9 @@
+ 		exports.ModelDirectory = ModelDirectory;
+ 		exports.ModelDirectoryResolver = ModelDirectoryResolver;
+ 		exports.apply = apply;
++		exports.catalogServes = catalogServes;
+ 		exports.inject = inject;
++		exports.replacementSelection = replacementSelection;
+ 		return module.exports;
+ 	}
+ });

--- a/scripts/cdp-eval.mjs
+++ b/scripts/cdp-eval.mjs
@@ -1,0 +1,78 @@
+// Minimal Chrome DevTools Protocol driver for a running DSH Desktop renderer.
+//
+// Normally reached through cdp-eval.sh, which resolves the target for you.
+// Args: <websocket-url> [<js expression> | --eval-file <path> | --watch <ms>].
+//
+// Usage: node scripts/cdp-eval.mjs "$WS" 'document.title'  — evaluates in the page and prints JSON.
+//        node scripts/cdp-eval.mjs "$WS" --eval-file <path>
+//        node scripts/cdp-eval.mjs "$WS" --watch <ms>      — streams console output for <ms>.
+import { readFile } from 'node:fs/promises'
+
+const endpoint = process.argv[2]
+const mode = process.argv[3]
+const argument = process.argv[4]
+
+const ws = new WebSocket(endpoint)
+let nextId = 1
+const pending = new Map()
+const consoleLines = []
+
+function send(method, params = {}) {
+  const id = nextId++
+  ws.send(JSON.stringify({ id, method, params }))
+  return new Promise((resolve, reject) => pending.set(id, { resolve, reject }))
+}
+
+ws.addEventListener('message', (event) => {
+  const message = JSON.parse(event.data)
+  if (message.id !== undefined) {
+    const entry = pending.get(message.id)
+    if (entry === undefined) return
+    pending.delete(message.id)
+    if (message.error) entry.reject(new Error(JSON.stringify(message.error)))
+    else entry.resolve(message.result)
+    return
+  }
+  if (message.method === 'Runtime.consoleAPICalled') {
+    const text = (message.params.args ?? [])
+      .map((arg) => (arg.value !== undefined ? String(arg.value) : arg.description ?? arg.type))
+      .join(' ')
+    consoleLines.push(text)
+  }
+  if (message.method === 'Runtime.exceptionThrown') {
+    consoleLines.push(`[exception] ${message.params.exceptionDetails?.text ?? ''}`)
+  }
+})
+
+await new Promise((resolve, reject) => {
+  ws.addEventListener('open', resolve)
+  ws.addEventListener('error', reject)
+})
+
+await send('Runtime.enable')
+
+if (mode === '--watch') {
+  const ms = Number(argument ?? 15000)
+  await new Promise((resolve) => setTimeout(resolve, ms))
+  console.log(consoleLines.join('\n'))
+} else {
+  const expression =
+    mode === '--eval-file' ? await readFile(argument, 'utf8') : (argument ?? mode)
+  const result = await send('Runtime.evaluate', {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+    userGesture: true
+  })
+  if (result.exceptionDetails !== undefined) {
+    console.log('EXCEPTION:', JSON.stringify(result.exceptionDetails, null, 2))
+  } else {
+    console.log(
+      typeof result.result.value === 'string'
+        ? result.result.value
+        : JSON.stringify(result.result.value, null, 2)
+    )
+  }
+}
+
+ws.close()

--- a/scripts/cdp-eval.sh
+++ b/scripts/cdp-eval.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Evaluate one JavaScript expression inside the running DSH Desktop renderer
+# over the Chrome DevTools Protocol, and print its value.
+#
+# Start the app with --remote-debugging-port=9222 and this gives a live view of
+# the real window: the composer, the model selector, and the status line can all
+# be measured here instead of being guessed at from a screenshot.
+#
+# Usage:
+#   cdp-eval.sh 'document.title'
+#   cdp-eval.sh --eval-file /path/to/expression.js
+#   cdp-eval.sh --watch 8000        # stream console output for 8s
+#
+# Env: DSH_CDP_PORT (default 9222), DSH_NODE (default: node on PATH).
+set -u
+
+NODE="${DSH_NODE:-$(command -v node || true)}"
+if [ -z "$NODE" ]; then
+  echo "no node on PATH; set DSH_NODE to a node binary" >&2
+  exit 1
+fi
+
+PORT="${DSH_CDP_PORT:-9222}"
+ENDPOINT="$(curl -s -m 5 "http://127.0.0.1:${PORT}/json/list" \
+  | "$NODE" -e 'let raw="";process.stdin.on("data",(c)=>raw+=c).on("end",()=>{const targets=JSON.parse(raw);const page=targets.find((t)=>t.type==="page");if(page)console.log(page.webSocketDebuggerUrl)})')"
+
+if [ -z "$ENDPOINT" ]; then
+  echo "no debuggable page on 127.0.0.1:${PORT}; start the app with --remote-debugging-port=${PORT}" >&2
+  exit 1
+fi
+
+exec "$NODE" "$(dirname "$0")/cdp-eval.mjs" "$ENDPOINT" "$@"

--- a/test/model-selection-refresh.test.ts
+++ b/test/model-selection-refresh.test.ts
@@ -1,0 +1,415 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { patchPath, projectRoot } from './patch-path'
+
+const modelSelectionClient = path.join(
+  projectRoot,
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-client-ui-model-selection',
+  'lib',
+  'client.js'
+)
+
+interface Selection {
+  provider: string
+  model: string
+  reasoningEffort?: string
+}
+
+interface Catalog {
+  default: Selection
+  routableProviders: string[]
+  groups: Array<{ id: string; models: Array<{ id: string }> }>
+}
+
+interface ModelSelectionHelpers {
+  catalogServes(selection: Selection | null | undefined, catalog: Catalog): boolean
+  replacementSelection(current: Selection, catalog: Catalog): Selection | undefined
+  ModelDirectory: new (
+    sessions: { selectModel(request: Selection & { sessionId: string }): Promise<{ ok: boolean }> },
+    sessionId: string,
+    available: () => boolean,
+    catalog: { store: SnapshotStore; load(): Promise<unknown> },
+    projected: { getSnapshot(): unknown; subscribe(listener: () => void): () => void }
+  ) => {
+    store: {
+      getSnapshot(): { current: Selection | null; groups: Array<{ id: string }>; status: string; error: string | null }
+      subscribe(listener: () => void): () => void
+    }
+    load(): Promise<unknown>
+    syncInputs(): void
+    dispose(): void
+  }
+}
+
+interface SnapshotStore {
+  getSnapshot(): { value: unknown; status: string; error: string | null }
+  set(next: unknown): void
+  update(mutate: (draft: Record<string, unknown>) => void): void
+  subscribe(listener: () => void): () => void
+}
+
+/**
+ * The bundle's own store primitive is not stubbed: the composer renders from
+ * the store the directory publishes, so the test drives the real engine and
+ * only stands in for the modules the browser loader would have supplied.
+ */
+async function loadBootstrapStore(): Promise<(init: unknown) => SnapshotStore> {
+  const engine = (await import('@deepseek-ai/dsh-client-store')) as {
+    createSnapshotStore(init: unknown): SnapshotStore
+  }
+  if (typeof engine.createSnapshotStore !== 'function') {
+    throw new Error('the pinned store engine exports no createSnapshotStore')
+  }
+  return engine.createSnapshotStore
+}
+
+/** Load the shipped client bundle with the minimum environment its factory needs. */
+async function loadModelSelectionBundle(): Promise<{
+  exports: ModelSelectionHelpers
+  notifyCatalogChanged(): void
+  notifyProjectionChanged(): void
+}> {
+  const source = await readFile(modelSelectionClient, 'utf8')
+  const createSnapshotStore = await loadBootstrapStore()
+  const listeners = new Set<() => void>()
+  const stubs: Record<string, unknown> = {
+    '@deepseek-ai/cordis': { Service: class {} },
+    '@deepseek-ai/dsh-client-store': { createSnapshotStore },
+    'react/jsx-runtime': {},
+    react: {},
+    '@deepseek-ai/dsh-client-ui-primitives': {}
+  }
+  let captured: ModelSelectionHelpers | undefined
+  const window = {
+    __ModuleLoader__: {
+      load({ factory }: { factory: (require: (id: string) => unknown) => unknown }) {
+        captured = factory((id: string) => stubs[id]) as ModelSelectionHelpers
+      }
+    }
+  }
+
+  new Function('window', source)(window)
+  if (captured === undefined) throw new Error('model-selection bundle exported nothing')
+  return {
+    exports: captured,
+    notifyCatalogChanged: () => {
+      for (const listener of [...listeners]) listener()
+    },
+    notifyProjectionChanged: () => {
+      for (const listener of [...listeners]) listener()
+    }
+  }
+}
+
+const catalog: Catalog = {
+  default: { provider: 'deepseek-official', model: 'deepseek-v4-pro' },
+  routableProviders: ['deepseek-official', 'other'],
+  groups: [
+    { id: 'deepseek-official', models: [{ id: 'deepseek-v4-pro' }, { id: 'deepseek-v4-flash' }] },
+    { id: 'other', models: [{ id: 'legacy-model' }] }
+  ]
+}
+
+/**
+ * Editing a model in Settings can leave a Session's durable selection naming a
+ * model the Host no longer serves. That selection has no display name left to
+ * resolve, so the composer used to render the bare "provider/model" identifier
+ * and the model selector only looked fixed after a manual re-selection.
+ */
+describe('DSH Desktop model selection after a Settings model edit', () => {
+  it('recognizes a selection the refreshed catalog no longer serves', async () => {
+    const { exports: { catalogServes } } = await loadModelSelectionBundle()
+
+    expect(catalogServes({ provider: 'deepseek-official', model: 'deepseek-v4-pro' }, catalog)).toBe(true)
+    expect(catalogServes({ provider: 'deepseek-official', model: 'deepseek-v4-flash' }, catalog)).toBe(true)
+    expect(catalogServes({ provider: 'deepseek-official', model: 'removed-model' }, catalog)).toBe(false)
+    expect(catalogServes({ provider: 'retired-provider', model: 'deepseek-v4-pro' }, catalog)).toBe(false)
+    expect(catalogServes(undefined, catalog)).toBe(false)
+    expect(catalogServes(null, catalog)).toBe(false)
+  })
+
+  it('follows the deployment default when the selected model was removed', async () => {
+    const { exports: { replacementSelection } } = await loadModelSelectionBundle()
+
+    expect(
+      replacementSelection({ provider: 'deepseek-official', model: 'deepseek-v4-flash' }, {
+        ...catalog,
+        default: { provider: 'deepseek-official', model: 'deepseek-v4-pro' }
+      })
+    ).toEqual({ provider: 'deepseek-official', model: 'deepseek-v4-pro' })
+  })
+
+  it('falls through a default that went stale in the same edit', async () => {
+    const { exports: { replacementSelection } } = await loadModelSelectionBundle()
+
+    // The removed model is also the deployment default, which is exactly the
+    // state a Settings-driven model rename leaves behind.
+    expect(
+      replacementSelection({ provider: 'deepseek-official', model: 'removed-model' }, {
+        default: { provider: 'deepseek-official', model: 'removed-model' },
+        routableProviders: ['deepseek-official'],
+        groups: [{ id: 'deepseek-official', models: [{ id: 'deepseek-v4-pro' }] }]
+      })
+    ).toEqual({ provider: 'deepseek-official', model: 'deepseek-v4-pro' })
+  })
+
+  it('never replaces with the model it is replacing', async () => {
+    const { exports: { replacementSelection } } = await loadModelSelectionBundle()
+
+    const replacement = replacementSelection({ provider: 'deepseek-official', model: 'deepseek-v4-pro' }, {
+      ...catalog,
+      default: { provider: 'deepseek-official', model: 'deepseek-v4-pro' }
+    })
+
+    expect(replacement).not.toEqual({ provider: 'deepseek-official', model: 'deepseek-v4-pro' })
+    expect(replacement).toEqual({ provider: 'deepseek-official', model: 'deepseek-v4-flash' })
+  })
+
+  it('offers only routable providers when the catalog names any', async () => {
+    const { exports: { replacementSelection } } = await loadModelSelectionBundle()
+
+    const replacement = replacementSelection({ provider: 'deepseek-official', model: 'gone' }, {
+      default: { provider: 'deepseek-official', model: 'also-gone' },
+      routableProviders: ['other'],
+      groups: [
+        { id: 'deepseek-official', models: [{ id: 'unroutable-model' }] },
+        { id: 'other', models: [{ id: 'legacy-model' }] }
+      ]
+    })
+
+    expect(replacement).toEqual({ provider: 'other', model: 'legacy-model' })
+  })
+
+  it('reports no replacement when the catalog serves nothing else', async () => {
+    const { exports: { replacementSelection } } = await loadModelSelectionBundle()
+
+    expect(
+      replacementSelection({ provider: 'deepseek-official', model: 'gone' }, {
+        default: { provider: 'deepseek-official', model: 'gone' },
+        routableProviders: ['deepseek-official'],
+        groups: [{ id: 'deepseek-official', models: [{ id: 'gone' }] }]
+      })
+    ).toBeUndefined()
+  })
+})
+
+describe('DSH Desktop model selection reconciliation wiring', () => {
+  /** Build one directory over a catalog store whose value the test controls. */
+  async function directoryHarness(options: {
+    catalog: Catalog | null
+    selected: Selection | null
+  }): Promise<{
+    directory: InstanceType<ModelSelectionHelpers['ModelDirectory']>
+    selections: Array<Selection & { sessionId: string }>
+    publishCatalog(next: Catalog): void
+    dispose(): void
+  }> {
+    const { exports, notifyCatalogChanged } = await loadModelSelectionBundle()
+    const createSnapshotStore = await loadBootstrapStore()
+    const catalogStore = createSnapshotStore({
+      value: options.catalog,
+      status: options.catalog === null ? 'loading' : 'ready',
+      error: null
+    })
+    const selections: Array<Selection & { sessionId: string }> = []
+    const directory = new exports.ModelDirectory(
+      {
+        selectModel: async (request) => {
+          selections.push(request)
+          return { ok: true }
+        }
+      },
+      'session-1',
+      () => true,
+      {
+        store: catalogStore,
+        load: async () => catalogStore.getSnapshot().value
+      },
+      {
+        getSnapshot: () => (options.selected === null ? undefined : { next: options.selected }),
+        subscribe: () => () => undefined
+      }
+    )
+
+    return {
+      directory,
+      selections,
+      publishCatalog: (next) => {
+        catalogStore.set({ value: next, status: 'ready', error: null })
+        notifyCatalogChanged()
+      },
+      dispose: () => directory.dispose()
+    }
+  }
+
+  it('follows the deployment default and records it as the Session selection', async () => {
+    const harness = await directoryHarness({
+      catalog,
+      selected: { provider: 'deepseek-official', model: 'deepseek-v4-flash-vision-exp' }
+    })
+
+    try {
+      await harness.directory.load()
+
+      // The composer renders the name the catalog carries, not the bare id.
+      expect(harness.directory.store.getSnapshot().current).toEqual({
+        provider: 'deepseek-official',
+        model: 'deepseek-v4-pro'
+      })
+      expect(harness.directory.store.getSnapshot().status).toBe('ready')
+      expect(harness.selections).toEqual([
+        { sessionId: 'session-1', provider: 'deepseek-official', model: 'deepseek-v4-pro' }
+      ])
+    } finally {
+      harness.dispose()
+    }
+  })
+
+  it('replaces a selection whose model disappeared from the refreshed catalog', async () => {
+    const harness = await directoryHarness({
+      catalog,
+      selected: { provider: 'deepseek-official', model: 'deepseek-v4-flash' }
+    })
+
+    try {
+      await harness.directory.load()
+      expect(harness.directory.store.getSnapshot().current).toEqual({
+        provider: 'deepseek-official',
+        model: 'deepseek-v4-flash'
+      })
+      expect(harness.selections).toHaveLength(0)
+
+      // The Settings edit removes the model; the catalog re-fetch is the only
+      // event the selector gets.
+      harness.publishCatalog({
+        default: { provider: 'deepseek-official', model: 'deepseek-v4-pro' },
+        routableProviders: ['deepseek-official'],
+        groups: [{ id: 'deepseek-official', models: [{ id: 'deepseek-v4-pro' }] }]
+      })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(harness.directory.store.getSnapshot().current).toEqual({
+        provider: 'deepseek-official',
+        model: 'deepseek-v4-pro'
+      })
+      expect(harness.selections).toEqual([
+        { sessionId: 'session-1', provider: 'deepseek-official', model: 'deepseek-v4-pro' }
+      ])
+    } finally {
+      harness.dispose()
+    }
+  })
+
+  it('attempts one replacement per catalog value, never a chain', async () => {
+    const harness = await directoryHarness({
+      catalog,
+      selected: { provider: 'deepseek-official', model: 'deepseek-v4-flash' }
+    })
+
+    try {
+      await harness.directory.load()
+      const stale = {
+        default: { provider: 'deepseek-official', model: 'deepseek-v4-pro' },
+        routableProviders: ['deepseek-official'],
+        groups: [{ id: 'deepseek-official', models: [{ id: 'deepseek-v4-pro' }] }]
+      }
+      harness.publishCatalog(stale)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      // Re-delivering the same catalog must not re-select anything.
+      harness.publishCatalog(stale)
+      harness.publishCatalog(stale)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(harness.selections).toHaveLength(1)
+    } finally {
+      harness.dispose()
+    }
+  })
+
+  it('leaves a selection the catalog still serves alone', async () => {
+    const harness = await directoryHarness({
+      catalog,
+      selected: { provider: 'other', model: 'legacy-model' }
+    })
+
+    try {
+      await harness.directory.load()
+      harness.publishCatalog({ ...catalog, default: { provider: 'deepseek-official', model: 'deepseek-v4-pro' } })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(harness.directory.store.getSnapshot().current).toEqual({
+        provider: 'other',
+        model: 'legacy-model'
+      })
+      expect(harness.selections).toHaveLength(0)
+    } finally {
+      harness.dispose()
+    }
+  })
+
+  it('holds the selection while the catalog is unloaded or failed', async () => {
+    const harness = await directoryHarness({
+      catalog: null,
+      selected: { provider: 'deepseek-official', model: 'gone' }
+    })
+
+    try {
+      expect(harness.directory.store.getSnapshot().current).toBeNull()
+      expect(harness.selections).toHaveLength(0)
+      // A failed refresh resolves nothing: the selection survives for the retry.
+      expect(harness.directory.store.getSnapshot().status).toBe('loading')
+    } finally {
+      harness.dispose()
+    }
+  })
+
+  it('adopts the replacement as a real selection so the Session stops naming the removed model', async () => {
+    const client = await readFile(modelSelectionClient, 'utf8')
+
+    expect(client).toContain('reconciledCatalog')
+    expect(client).toContain('this.followDefault(pinned, catalog.value) ?? pinned')
+    expect(client).toContain('this.adopting = true')
+    expect(client).toContain('this.select({')
+  })
+
+  it('marks the catalog value before starting the replacement', async () => {
+    const client = await readFile(modelSelectionClient, 'utf8')
+    const reconcile = client.slice(
+      client.indexOf('const pinned = projected.next ?? catalog.value.default;'),
+      client.indexOf('this.resolved = true;')
+    )
+
+    // Settling the replacement re-enters syncInputs with the same catalog; the
+    // marker has to be recorded before that, or every later notification for
+    // that catalog would select again.
+    expect(reconcile.indexOf('this.reconciledCatalog = fingerprint;')).toBeLessThan(
+      reconcile.indexOf('this.followDefault(pinned, catalog.value)')
+    )
+    expect(reconcile).toContain('if (this.adopting) return;')
+    expect(reconcile).toContain('if (stale && this.reconciledCatalog !== fingerprint)')
+  })
+
+  it('leaves the catalog untouched while it is still loading or failed', async () => {
+    const { exports: { catalogServes } } = await loadModelSelectionBundle()
+
+    // The class returns true for a non-ready catalog, so a failed refresh can
+    // never start a replacement chain against half a catalog.
+    expect(catalogServes({ provider: 'deepseek-official', model: 'removed' }, catalog)).toBe(false)
+    const client = await readFile(modelSelectionClient, 'utf8')
+    expect(client).toContain('if (catalog.status !== "ready" || catalog.value === null) return true;')
+  })
+
+  it('carries the reconciliation in the reproducible dependency patch', async () => {
+    const patch = await readFile(patchPath('@deepseek-ai/dsh-client-ui-model-selection'), 'utf8')
+
+    expect(patch).toContain('function catalogServes(selection, catalog)')
+    expect(patch).toContain('function replacementSelection(current, catalog)')
+    expect(patch).toContain('exports.catalogServes = catalogServes')
+    expect(patch).toContain('exports.replacementSelection = replacementSelection')
+    expect(patch).toContain('reconciledCatalog')
+    expect(patch).toContain('followDefault(pinned, catalog.value)')
+  })
+})

--- a/test/stats-line-width.test.ts
+++ b/test/stats-line-width.test.ts
@@ -1,0 +1,63 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { patchPath, projectRoot } from './patch-path'
+
+const chatClient = path.join(
+  projectRoot,
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-client-ui-chat',
+  'lib',
+  'client.js'
+)
+
+/** Extract one CSS-module rule out of the served bundle. */
+function rule(css: string, selector: string): string {
+  const match = css.match(new RegExp(`\\${selector}\\{([^}]*)\\}`, 'u'))
+  const body = match?.[1]
+  if (body === undefined) throw new Error(`the bundle carries no ${selector} rule`)
+  return body
+}
+
+/**
+ * The composer's statistics line reports turns, steps, phase durations,
+ * throughput, cache hits, and token counts. It used to be capped at the chat
+ * content width, which is 64% of the conversation column, so a normal session
+ * summary was ellipsized into a tooltip on a wide window.
+ */
+describe('DSH Desktop composer statistics line', () => {
+  it('fills the conversation column instead of the narrower chat content width', async () => {
+    const client = await readFile(chatClient, 'utf8')
+    const root = rule(client, '.XZbVjq_root')
+
+    expect(root).toContain('max-width:none')
+    expect(root).not.toContain('max-width:var(--dsh-chat-content-width)')
+    // Still one responsive full-width block: the fix changes the cap, not the
+    // box model, so a narrow window keeps wrapping behaviour and the ellipsis
+    // stays as the last resort rather than being removed.
+    expect(root).toContain('width:100%')
+    expect(root).toContain('box-sizing:border-box')
+    expect(root).toContain('text-overflow:ellipsis')
+  })
+
+  it('keeps the line aligned with the composer chrome it sits under', async () => {
+    const client = await readFile(chatClient, 'utf8')
+    const root = rule(client, '.XZbVjq_root')
+
+    // The horizontal inset is what keeps the wider line from touching the
+    // column edges, so it has to survive the width change.
+    expect(root).toContain('padding:4px calc(var(--dsh-composer-side-clearance) + 16px) 0px')
+    expect(root).toContain('text-align:center')
+    expect(root).toContain('margin:0 auto')
+  })
+
+  it('carries the width in the reproducible dependency patch', async () => {
+    const patch = await readFile(patchPath('@deepseek-ai/dsh-client-ui-chat'), 'utf8')
+
+    expect(patch).toContain('max-width:none')
+    // The provider-failure copy this package already patches stays intact.
+    expect(patch).toContain('"message.failure.quota"')
+    expect(patch).toContain('"message.failure.forbidden"')
+  })
+})


### PR DESCRIPTION
## What

Three follow-ups left over from the work in #381 and #382. The two fixes are independent of each other and of that pair; the third commit is the dev tooling used to verify all of it. Happy to split any of them out on request.

### 1. The model selector kept naming a model that Settings had removed

A Session's model selection is durable; the catalog is not. Removing or renaming a model in Settings left the composer rendering the bare `provider/model` identifier — which looks exactly like the previously selected model, because it literally is it, with nothing left able to resolve the name. It reads as "the selector didn't update", and it never repaired itself: the client fetched the catalog on every save, but never reconciled the selection against it.

The directory now reconciles on every catalog push. When the catalog stops serving the pinned selection it adopts the deployment default (the model a new Session would get), falling back to the first served model if that default went stale in the same edit. Only routable providers are offered, so the Host cannot reject the replacement and strand the Session on the same dead name. The replacement is recorded as a normal selection, so neither the Session nor the stored default keeps naming a model that no longer exists.

Two traps, both of which I hit while building it and both of which the tests now pin:

- **One attempt per catalog value.** The first version marked the catalog as reconciled *after* starting the replacement, so an identical catalog push re-ran adoption every time. The marker is now written before the replacement starts.
- **A loading catalog is not an empty one.** Treating `status !== 'ready'` as "serves nothing" made the selector rewrite itself on a cold load.

`test/model-selection-refresh.test.ts` — 15 tests. It loads the real client bundle and drives the real `ModelDirectory` against the real store engine: adoption, one attempt per catalog value, no repair while the selection is served, the loading-catalog hold, and that an unroutable catalog default never wins.

### 2. The status line was capped to the message column

The token/cost line under the conversation inherited the chat content width cap and ellipsized inside it: 782px of text in a 704px box. With the cap lifted, the same content fits on one line in the 1092px actually available. Only that line's own root rule changes (`max-width:none`); its box-sizing, padding, ellipsis behaviour, and centered separators are untouched.

`test/stats-line-width.test.ts` — 3 tests.

### 3. A CDP helper for measuring the live window (tooling)

Judging client-plugin styling by eye is unreliable — a theme override that silently resolves to its light branch looks like a working fix in a screenshot, and I shipped exactly that mistake once while doing #382. `scripts/cdp-eval.sh '<expression>'` evaluates an expression inside the running renderer over the Chrome DevTools Protocol, so computed styles, geometry, and console output come from the real window. Requires the app started with `--remote-debugging-port=9222`; `DSH_CDP_PORT` selects another port and `DSH_NODE` another node binary.

## Verification

- `npx vitest run test/model-selection-refresh.test.ts test/stats-line-width.test.ts` — 18 passed on this branch alone.
- `npm test` — 810 passed / 95 files. `npm run typecheck` clean.
- `scripts/cdp-eval.sh` exercised against a running dev app after making its node resolution portable.
- `cdp-eval.sh` committed 100755, `cdp-eval.mjs` 100644.

## Note

Adoption goes through the normal selection path, so the adopted model's settings travel with it — including `reasoningEffort` when the deployment default carries one. In our install that rewrote the stored default's reasoning effort. That is the intent (stop naming a dead model) but it is a persisted side effect worth knowing before merging.
