### PR TITLE
fix(registry): recover incomplete generation cleanup

### DIFF
--- a/packages/dsh-desktop-market-installer/generations/registry.mjs
+++ b/packages/dsh-desktop-market-installer/generations/registry.mjs
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { mkdir, open, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
@@ -230,8 +230,7 @@ export async function writeGenerationMeta(directory, meta) {
   await writeFile(join(directory, META_NAME), `${JSON.stringify(meta, undefined, 2)}\n`, 'utf8')
 }
 
-/** Every promoted generation currently on disk. */
-export async function listGenerations(dshHome) {
+async function listGenerationDirectoryIds(dshHome) {
   const { generations } = registryLayout(dshHome)
   let entries
   try {
@@ -245,12 +244,28 @@ export async function listGenerations(dshHome) {
       { cause: error }
     )
   }
+  return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name)
+}
+
+/** Every readable promoted generation currently on disk. */
+export async function listGenerations(dshHome) {
+  const { generations } = registryLayout(dshHome)
+  const ids = await listGenerationDirectoryIds(dshHome)
   const found = []
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue
-    const directory = join(generations, entry.name)
-    const meta = await readGenerationMeta(directory)
-    found.push({ id: entry.name, directory, ...meta })
+  for (const id of ids) {
+    const directory = join(generations, id)
+    let meta
+    try {
+      meta = await readGenerationMeta(directory)
+    } catch (error) {
+      // A failed recursive deletion can remove generation.json before Windows
+      // reports a locked descendant. Such an unreferenced shell must be inert
+      // so projection and the next sweep can recover. Other metadata failures
+      // remain fail-closed.
+      if (error?.cause?.code === 'ENOENT') continue
+      throw error
+    }
+    found.push({ id, directory, ...meta })
   }
   return found
 }
@@ -313,16 +328,23 @@ export async function resolveEnabledGenerations(dshHome) {
 
 /** The generation ids not referenced by the authoritative desired pointer. */
 export async function collectUnreferencedGenerations(dshHome) {
-  const [desired, all] = await Promise.all([
+  const layout = registryLayout(dshHome)
+  const [desired, directoryIds] = await Promise.all([
     readDesired(dshHome),
-    listGenerations(dshHome)
+    listGenerationDirectoryIds(dshHome)
   ])
-  const known = new Set(all.map((generation) => generation.id))
+  const known = new Set(directoryIds)
   for (const id of desired) {
     if (!known.has(id)) throw new Error(`Desired generation is missing or unreadable: ${id}`)
+    try {
+      await readGenerationMeta(join(layout.generations, id))
+    } catch (error) {
+      if (error?.cause?.code !== 'ENOENT') throw error
+      throw new Error(`Desired generation is missing or unreadable: ${id}`, { cause: error })
+    }
   }
   const referenced = new Set(desired)
-  return all.filter((generation) => !referenced.has(generation.id)).map((generation) => generation.id)
+  return directoryIds.filter((id) => !referenced.has(id))
 }
 
 /**
@@ -337,16 +359,8 @@ export async function sweepRegistry(dshHome) {
   const failed = []
 
   const unreferenced = await collectUnreferencedGenerations(dshHome)
-  for (const id of unreferenced) {
-    const directory = join(layout.generations, id)
-    try {
-      await rm(directory, { recursive: true, force: true })
-      removed.push(id)
-    } catch {
-      failed.push(id)
-    }
-  }
-
+  // Remove leftovers from earlier runs before moving new generations into
+  // trash. A failed delete below is intentionally left there until next run.
   for (const dir of [layout.staging, layout.trash]) {
     const label = dir === layout.staging ? 'staging' : 'trash'
     let entries = []
@@ -362,6 +376,21 @@ export async function sweepRegistry(dshHome) {
       } catch {
         failed.push(`${label}/${name}`)
       }
+    }
+  }
+
+  await mkdir(layout.trash, { recursive: true })
+  for (const id of unreferenced) {
+    const directory = join(layout.generations, id)
+    const trashed = join(layout.trash, `${id}.${randomUUID()}`)
+    try {
+      // Keep live atomic: even if Windows refuses to delete a locked child,
+      // the incomplete generation can no longer poison registry enumeration.
+      await rename(directory, trashed)
+      await rm(trashed, { recursive: true, force: true })
+      removed.push(id)
+    } catch {
+      failed.push(id)
     }
   }
 

--- a/test/generation-registry.test.ts
+++ b/test/generation-registry.test.ts
@@ -1,7 +1,7 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   collectUnreferencedGenerations,
   disableGeneration,
@@ -17,6 +17,23 @@ import {
   writeDesired,
   writeGenerationMeta
 } from '../packages/dsh-desktop-market-installer/generations/registry'
+
+const removalFault = vi.hoisted(() => ({ trashPrefix: '' }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    rm: async (...args: Parameters<typeof actual.rm>) => {
+      const normalized = String(args[0]).replaceAll('\\', '/')
+      if (removalFault.trashPrefix && normalized.includes(removalFault.trashPrefix)) {
+        removalFault.trashPrefix = ''
+        throw Object.assign(new Error('EPERM: simulated locked generation child'), { code: 'EPERM' })
+      }
+      return actual.rm(...args)
+    }
+  }
+})
 
 describe('the plugin generation registry', () => {
   const homes: string[] = []
@@ -39,6 +56,7 @@ describe('the plugin generation registry', () => {
   }
 
   afterEach(async () => {
+    removalFault.trashPrefix = ''
     await Promise.all(homes.map((home) => rm(home, { recursive: true, force: true })))
     homes.length = 0
   })
@@ -130,6 +148,64 @@ describe('the plugin generation registry', () => {
     expect(removed).toContain('staging/abandoned-uuid')
     const survivors = (await listGenerations(home)).map((generation) => generation.id)
     expect(survivors).toEqual(['keep+1+x'])
+  })
+
+  it('recovers an unreferenced generation left without metadata by a partial deletion', async () => {
+    const home = await freshHome()
+    const layout = await ensureRegistryDirectories(home)
+    await fakeGeneration(home, 'keep+1+x', 'keep', '1')
+    const incomplete = join(layout.generations, 'incomplete+2+y')
+    await mkdir(join(incomplete, 'node_modules', 'locked-plugin'), { recursive: true })
+    await writeFile(join(incomplete, 'node_modules', 'locked-plugin', 'index.js'), 'export {}\n')
+    await writeDesired(home, ['keep+1+x'])
+
+    expect((await listGenerations(home)).map((generation) => generation.id)).toEqual(['keep+1+x'])
+    expect(await collectUnreferencedGenerations(home)).toEqual(['incomplete+2+y'])
+
+    const { removed, failed } = await sweepRegistry(home)
+
+    expect(removed).toContain('incomplete+2+y')
+    expect(failed).toEqual([])
+    await expect(access(incomplete)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('moves an unreferenced generation out of live before deleting its contents', async () => {
+    const home = await freshHome()
+    const layout = await ensureRegistryDirectories(home)
+    const id = 'locked+1+x'
+    await fakeGeneration(home, id, 'locked', '1')
+    removalFault.trashPrefix = `/trash/${id}.`
+
+    const first = await sweepRegistry(home)
+
+    expect(first.removed).not.toContain(id)
+    expect(first.failed).toContain(id)
+    await expect(access(join(layout.generations, id))).rejects.toMatchObject({ code: 'ENOENT' })
+    const trashEntries = await readdir(layout.trash)
+    expect(trashEntries).toHaveLength(1)
+    expect(trashEntries[0]).toMatch(/^locked\+1\+x\./u)
+
+    const second = await sweepRegistry(home)
+    expect(second.removed).toContain(`trash/${trashEntries[0]}`)
+    expect(second.failed).toEqual([])
+    expect(await readdir(layout.trash)).toEqual([])
+  })
+
+  it('does not sweep a desired generation whose metadata is missing', async () => {
+    const home = await freshHome()
+    const layout = await ensureRegistryDirectories(home)
+    const incomplete = join(layout.generations, 'desired+1+x')
+    await mkdir(incomplete, { recursive: true })
+    await writeDesired(home, ['desired+1+x'])
+
+    expect(await listGenerations(home)).toEqual([])
+    await expect(resolveEnabledGenerations(home)).rejects.toThrow(
+      /Desired generation is missing or unreadable: desired\+1\+x/u
+    )
+    await expect(sweepRegistry(home)).rejects.toThrow(
+      /Desired generation is missing or unreadable: desired\+1\+x/u
+    )
+    await expect(access(incomplete)).resolves.toBeUndefined()
   })
 
   it('fails closed without sweeping generations when desired.json is corrupt', async () => {


### PR DESCRIPTION
## Summary

- tolerate generation directories whose `generation.json` disappeared during a partial Windows deletion
- discover unreferenced directories independently of their metadata while retaining fail-closed validation for desired generations
- move unreferenced generations from `live` to uniquely named `trash` entries before recursive deletion
- cover incomplete metadata, desired-generation protection, and locked-child retry behavior

## Verification

- `npm test -- --run test/generation-registry.test.ts test/generation-projection.test.ts test/generation-launch.test.ts` (34 tests passed)
- `npm test -- --run` (854 tests passed)
- `git diff --check`
- `npm run typecheck` (blocked by pre-existing `test/desktop-client-ui.test.ts:108-109` TS18048 errors on `origin/main`)

Fixes #389
