### PR TITLE
fix: preserve market peer policy in generation installs

### DIFF
--- a/packages/dsh-desktop-market-installer/generations/installer.d.ts
+++ b/packages/dsh-desktop-market-installer/generations/installer.d.ts
@@ -5,6 +5,8 @@ export interface GenerationInstallOptions {
   dshHome: string
   profile?: string
   strictDepBuilds?: boolean
+  /** Explicit market peer policy; omitted retains pnpm's default behavior. */
+  autoInstallPeers?: boolean
   minimumReleaseAge?: number
   expectedVersion?: string
   pluginSpec: string

--- a/packages/dsh-desktop-market-installer/generations/installer.d.ts
+++ b/packages/dsh-desktop-market-installer/generations/installer.d.ts
@@ -5,7 +5,7 @@ export interface GenerationInstallOptions {
   dshHome: string
   profile?: string
   strictDepBuilds?: boolean
-  /** Explicit market peer policy; omitted retains pnpm's default behavior. */
+  /** Explicit market peer policy; otherwise inherit the Profile's explicit boolean. */
   autoInstallPeers?: boolean
   minimumReleaseAge?: number
   expectedVersion?: string

--- a/packages/dsh-desktop-market-installer/generations/installer.mjs
+++ b/packages/dsh-desktop-market-installer/generations/installer.mjs
@@ -218,6 +218,20 @@ function diagnosticLine(output) {
 }
 
 export async function installGeneration(options) {
+  // A standalone staging workspace cannot see the Profile's peer policy.
+  // Carry its explicit boolean into the subprocess before the first attempt:
+  // the market may spend its single retry on a different failure (release age).
+  // Explicit command-line policy takes precedence; do not copy workspace paths.
+  if (typeof options.autoInstallPeers !== 'boolean') {
+    const workspace = await readFile(
+      join(options.dshHome, 'profiles', options.profile ?? 'web', 'pnpm-workspace.yaml'), 'utf8'
+    ).catch(error => {
+      if (error.code === 'ENOENT') return ''
+      throw error
+    })
+    const policy = /^autoInstallPeers:[ \t]*(true|false)[ \t]*(?:#.*)?\r?$/m.exec(workspace)
+    if (policy) options = { ...options, autoInstallPeers: policy[1] === 'true' }
+  }
   const { dshHome, pluginSpec, onTrace } = options
   const trace = (line) => onTrace?.(`generation-install: ${line}`)
   const layout = await ensureRegistryDirectories(dshHome)

--- a/packages/dsh-desktop-market-installer/generations/installer.mjs
+++ b/packages/dsh-desktop-market-installer/generations/installer.mjs
@@ -135,6 +135,8 @@ async function defaultRunInstall(options, stagingDir) {
       options.nodeExecutablePath,
       [options.pnpmEntryPath, 'add', options.pluginSpec,
         ...(options.registry ? [`--registry=${options.registry}`] : []),
+        ...(typeof options.autoInstallPeers === 'boolean'
+          ? [`--config.auto-install-peers=${options.autoInstallPeers}`] : []),
         ...(options.strictDepBuilds === true ? ['--config.strict-dep-builds=true'] : []),
         ...(Number.isSafeInteger(options.minimumReleaseAge) && options.minimumReleaseAge >= 0
           ? [`--config.minimum-release-age=${options.minimumReleaseAge}`] : [])

--- a/packages/dsh-desktop-market-installer/index.js
+++ b/packages/dsh-desktop-market-installer/index.js
@@ -589,6 +589,12 @@ export function createDesktopPnpmService(options) {
           dshHome: home,
           pluginSpec: spec,
           expectedVersion: spec.slice(spec.lastIndexOf('@') + 1),
+          // Preserve the market's peer-fetch recovery policy across the
+          // Profile -> isolated generation boundary (including camelCase).
+          autoInstallPeers: args.reduce((value, arg) => {
+            const match = /^--config\.(?:autoInstallPeers|auto-install-peers)=(true|false)$/.exec(arg)
+            return match ? match[1] === 'true' : value
+          }, undefined),
           minimumReleaseAge: args.some(arg => /^--config\.(?:minimumReleaseAge|minimum-release-age)=0$/.test(arg)) ? 0 : 1440,
           nodeExecutablePath: executablePath,
           pnpmEntryPath,

--- a/test/generation-boundary.test.js
+++ b/test/generation-boundary.test.js
@@ -112,6 +112,46 @@ describe('the market install boundary', () => {
     expect(typeof svc.runExternalMarketPluginInstall).toBe('function')
   })
 
+  it.each(['auto-install-peers', 'autoInstallPeers'])('preserves %s on a peer-fetch retry through the pnpm subprocess', async key => {
+    const home = await freshHome()
+    const calls = []
+    const svc = createDesktopPnpmService({
+      binDirectory: join(home, '.desktop-bin'),
+      dshEntryPath: join(home, 'bin.js'),
+      executablePath: process.execPath,
+      home,
+      spawnProcess: (_exe, args, options) => {
+        calls.push(args)
+        const child = new EventEmitter()
+        child.stdout = new EventEmitter()
+        child.stderr = new EventEmitter()
+        child.kill = () => {}
+        queueMicrotask(async () => {
+          if (!args.includes('--config.auto-install-peers=false')) {
+            child.stderr.emit('data', Buffer.from('ERR_PNPM_FETCH_404 @deepseek-ai/dsh-type-meta Not Found'))
+            child.emit('close', 1)
+            return
+          }
+          await stubGenerationInstall('demo-plugin', '1.2.4')(options.cwd)
+          child.emit('close', 0)
+        })
+        return child
+      }
+    })
+    const profile = join(home, 'profiles', 'web')
+    const first = await drainHandle(svc.runExternalMarketPluginInstall(['add', 'demo-plugin@1.2.4'], profile))
+    expect(first.exitCode).toBe(1)
+    expect(first.stderr).toContain('ERR_PNPM_FETCH_404')
+    const retry = await drainHandle(svc.runExternalMarketPluginInstall(
+      ['add', `--config.${key}=false`, 'demo-plugin@1.2.4'], profile))
+    expect(retry.exitCode).toBe(0)
+    expect(calls).toHaveLength(2)
+    expect(calls[0]).not.toContain('--config.auto-install-peers=false')
+    expect(calls[1]).toContain('--config.auto-install-peers=false')
+    for (const args of calls) expect(args[2]).toBe('demo-plugin@1.2.4')
+    expect(readInstalledVersion('web', 'demo-plugin', profile)).toBe('1.2.4')
+  })
+
   it('fetches from the registry the market read version metadata from (#337)', async () => {
     const home = await freshHome()
     await mkdir(join(home, 'profiles', 'web', '.dsh-market'), { recursive: true })

--- a/test/generation-boundary.test.js
+++ b/test/generation-boundary.test.js
@@ -112,8 +112,10 @@ describe('the market install boundary', () => {
     expect(typeof svc.runExternalMarketPluginInstall).toBe('function')
   })
 
-  it.each(['auto-install-peers', 'autoInstallPeers'])('preserves %s on a peer-fetch retry through the pnpm subprocess', async key => {
+  it.each(['auto-install-peers', 'autoInstallPeers', 'profile'])('preserves %s on a retry through the pnpm subprocess', async key => {
     const home = await freshHome()
+    if (key === 'profile') await writeFile(join(home, 'profiles', 'web', 'pnpm-workspace.yaml'),
+      'packages:\n  - .\nautoInstallPeers: false # host provides peers\n')
     const calls = []
     const svc = createDesktopPnpmService({
       binDirectory: join(home, '.desktop-bin'),
@@ -127,6 +129,11 @@ describe('the market install boundary', () => {
         child.stderr = new EventEmitter()
         child.kill = () => {}
         queueMicrotask(async () => {
+          if (key === 'profile' && calls.length === 1) {
+            child.stderr.emit('data', Buffer.from('ERR_PNPM_MINIMUM_RELEASE_AGE_FAILURE'))
+            child.emit('close', 1)
+            return
+          }
           if (!args.includes('--config.auto-install-peers=false')) {
             child.stderr.emit('data', Buffer.from('ERR_PNPM_FETCH_404 @deepseek-ai/dsh-type-meta Not Found'))
             child.emit('close', 1)
@@ -141,12 +148,13 @@ describe('the market install boundary', () => {
     const profile = join(home, 'profiles', 'web')
     const first = await drainHandle(svc.runExternalMarketPluginInstall(['add', 'demo-plugin@1.2.4'], profile))
     expect(first.exitCode).toBe(1)
-    expect(first.stderr).toContain('ERR_PNPM_FETCH_404')
+    expect(first.stderr).toContain(key === 'profile' ? 'ERR_PNPM_MINIMUM_RELEASE_AGE_FAILURE' : 'ERR_PNPM_FETCH_404')
     const retry = await drainHandle(svc.runExternalMarketPluginInstall(
-      ['add', `--config.${key}=false`, 'demo-plugin@1.2.4'], profile))
+      ['add', key === 'profile' ? '--config.minimumReleaseAge=0' : `--config.${key}=false`, 'demo-plugin@1.2.4'], profile))
     expect(retry.exitCode).toBe(0)
     expect(calls).toHaveLength(2)
-    expect(calls[0]).not.toContain('--config.auto-install-peers=false')
+    if (key === 'profile') expect(calls[0]).toContain('--config.auto-install-peers=false')
+    else expect(calls[0]).not.toContain('--config.auto-install-peers=false')
     expect(calls[1]).toContain('--config.auto-install-peers=false')
     for (const args of calls) expect(args[2]).toBe('demo-plugin@1.2.4')
     expect(readInstalledVersion('web', 'demo-plugin', profile)).toBe('1.2.4')


### PR DESCRIPTION
Desktop discarded the market’s `--config.auto-install-peers=false` retry option when converting an install into an isolated generation. Installing `@kenz1117/dsh-ui-usage-billing@1.2.5` could therefore keep fetching an obsolete host peer and fail on the unpublished `dsh-type-meta` dependency even after the market requested recovery.

Forward the explicit boolean peer policy to the generation pnpm subprocess, supporting both kebab-case and camelCase. When omitted, inherit the Profile workspace’s explicit autoInstallPeers boolean so release-age recovery cannot consume the only retry before peer recovery. Without either setting pnpm retains its default. This is a targeted contract fix, not arbitrary pnpm argument forwarding or a change to third-party market code. Only the peer boolean is inherited; workspace paths and upstream version re-resolution are outside this change.

Validation:
- 58 tests passed across generation-boundary, generation-installer, and market-installer.
- Regression exercises failure then retry through the actual subprocess boundary, verifies both option spellings, and checks that version 1.2.4 is retained and visible after publication.
- Production build and git diff --check passed.
- Typecheck is blocked by existing TS18048 errors in test/desktop-client-ui.test.ts:108–109; that file is byte-identical to base main (5a93138).
- Real dev Profile installation of the reported plugin succeeded through the generation boundary and published version 1.2.5. Added coverage for release-age failure followed by retry with inherited peer policy. Packaged Windows acceptance remains unverified.
