### PR TITLE
fix(llm): recover missing terminal content

### DIFF
--- a/patches/@deepseek-ai+dsh-llm-pi-ai+0.1.2-rc.1.patch
+++ b/patches/@deepseek-ai+dsh-llm-pi-ai+0.1.2-rc.1.patch
@@ -13,3 +13,123 @@ index 5c89b80..193f5b7 100644
  	if (/\b429\b|rate.?limit/i.test(message)) return "RATE_LIMIT";
  	if (/\b413\b|failed to buffer the request body:\s*length limit exceeded|payload too large|request body too large/i.test(message)) return "INVALID_REQUEST";
  	if (/\b400\b|invalid.?request/i.test(message)) return "INVALID_REQUEST";
+@@ -1365,6 +1366,15 @@ function mapStopReason(message, contextWindow) {
+ 		}
+ 	}
+ }
++
++/** Restore the terminal content array from completed stream blocks when a provider omits it. */
++function completeTerminalMessage(message, completed) {
++	if (Array.isArray(message.content)) return message;
++	return {
++		...message,
++		content: [...completed.entries()].sort(([left], [right]) => left - right).map(([, block]) => block)
++	};
++}
+ /**
+ * Translate the pi-ai event stream into StreamChunks. pi-ai never throws
+ * mid-stream — failures arrive as `error` events, which become error/aborted
+@@ -1378,6 +1388,7 @@ function mapStopReason(message, contextWindow) {
+ */
+ async function* toStreamChunks(events, contextWindow, callerSignal) {
+ 	const toolIds = /* @__PURE__ */ new Map();
++	const completed = /* @__PURE__ */ new Map();
+ 	for await (const event of events) switch (event.type) {
+ 		case "start": break;
+ 		case "text_start":
+@@ -1394,16 +1405,19 @@ async function* toStreamChunks(events, contextWindow, callerSignal) {
+ 				text: event.delta
+ 			};
+ 			break;
+-		case "text_end":
++		case "text_end": {
++			const block = {
++				type: "text",
++				text: event.content
++			};
++			completed.set(event.contentIndex, block);
+ 			yield {
+ 				type: "block-end",
+ 				index: event.contentIndex,
+-				block: {
+-					type: "text",
+-					text: event.content
+-				}
++				block
+ 			};
+ 			break;
++		}
+ 		case "thinking_start":
+ 			yield {
+ 				type: "block-start",
+@@ -1418,16 +1432,19 @@ async function* toStreamChunks(events, contextWindow, callerSignal) {
+ 				text: event.delta
+ 			};
+ 			break;
+-		case "thinking_end":
++		case "thinking_end": {
++			const block = {
++				type: "reasoning",
++				text: event.content
++			};
++			completed.set(event.contentIndex, block);
+ 			yield {
+ 				type: "block-end",
+ 				index: event.contentIndex,
+-				block: {
+-					type: "reasoning",
+-					text: event.content
+-				}
++				block
+ 			};
+ 			break;
++		}
+ 		case "toolcall_start": {
+ 			const partial = event.partial.content[event.contentIndex];
+ 			const id = partial?.type === "toolCall" ? partial.id : "";
+@@ -1454,29 +1471,34 @@ async function* toStreamChunks(events, contextWindow, callerSignal) {
+ 			};
+ 			break;
+ 		}
+-		case "toolcall_end":
++		case "toolcall_end": {
++			const block = {
++				type: "tool-call",
++				id: brandString(event.toolCall.id),
++				name: event.toolCall.name,
++				arguments: JSON.stringify(event.toolCall.arguments)
++			};
++			completed.set(event.contentIndex, block);
+ 			yield {
+ 				type: "block-end",
+ 				index: event.contentIndex,
+-				block: {
+-					type: "tool-call",
+-					id: brandString(event.toolCall.id),
+-					name: event.toolCall.name,
+-					arguments: JSON.stringify(event.toolCall.arguments)
+-				}
++				block
+ 			};
+ 			break;
+-		case "done":
++		}
++		case "done": {
++			const message = completeTerminalMessage(event.message, completed);
+ 			yield {
+ 				type: "usage",
+-				usage: mapUsage(event.message.usage)
++				usage: mapUsage(message.usage)
+ 			};
+ 			yield {
+ 				type: "finish",
+-				reason: mapStopReason(event.message, contextWindow),
+-				replayState: toPiReplayState(event.message)
++				reason: mapStopReason(message, contextWindow),
++				replayState: toPiReplayState(message)
+ 			};
+ 			return;
++		}
+ 		case "error":
+ 			yield {
+ 				type: "usage",

--- a/test/provider-error-patch.test.ts
+++ b/test/provider-error-patch.test.ts
@@ -52,4 +52,43 @@ describe('provider error classification patches', () => {
       )
     }
   })
+
+  it('recovers a provider terminal message that omits its content array', async () => {
+    const patch = await readPatch('@deepseek-ai/dsh-llm-pi-ai')
+    const additions = patch
+      .split('\n')
+      .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+      .map((line) => line.slice(1))
+      .join('\n')
+    const helper = additions.match(
+      /function completeTerminalMessage\(message, completed\) \{[\s\S]*?^\}/m
+    )?.[0]
+
+    expect(helper).toBeDefined()
+    const completeTerminalMessage = new Function(
+      `${helper}; return completeTerminalMessage`
+    )() as (
+      message: Record<string, unknown>,
+      completed: Map<number, Record<string, unknown>>
+    ) => Record<string, unknown>
+    const completed = new Map([
+      [1, { type: 'text', text: 'second' }],
+      [0, { type: 'reasoning', text: 'first' }]
+    ])
+    const malformed = { model: 'custom-model', stopReason: 'stop' }
+
+    expect(completeTerminalMessage(malformed, completed)).toEqual({
+      ...malformed,
+      content: [
+        { type: 'reasoning', text: 'first' },
+        { type: 'text', text: 'second' }
+      ]
+    })
+    const valid = { ...malformed, content: [] }
+    expect(completeTerminalMessage(valid, completed)).toBe(valid)
+    expect(patch).toContain(
+      '+\tconst message = completeTerminalMessage(event.message, completed);'
+    )
+    expect(patch).toContain('+\t\t\treplayState: toPiReplayState(message)')
+  })
 })


### PR DESCRIPTION
## Summary

- retain completed text, reasoning, and tool-call blocks while translating pi-ai streams
- reconstruct a missing terminal `message.content` array before stop classification and replay persistence
- preserve valid provider terminal messages unchanged

## Verification

- patch applies cleanly to the vendored `@deepseek-ai/dsh-llm-pi-ai@0.1.2-rc.1` bundle
- patched bundle passes `node --check`
- focused behavioral assertion covers missing terminal content, content-index ordering, and valid-message identity preservation
- `git diff --check`

Full Vitest execution was not available because the workspace disk had only about 357 MiB free and `npm ci` could not complete.

Fixes #379
