### PR TITLE
feat(release): configure initial 5% rollout on crash service

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -746,6 +746,18 @@ jobs:
           print("✅ Rebuilt releases/versions.json")
           PY
 
+      - name: Configure initial 5% rollout on crash service
+        env:
+          CRASH_ADMIN_TOKEN: ${{ secrets.CRASH_ADMIN_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CRASH_ADMIN_TOKEN:-}" ]; then
+            echo "⚠️ CRASH_ADMIN_TOKEN secret not set; skipping rollout configuration."
+            exit 0
+          fi
+          node scripts/configure-rollout.mjs "${RELEASE_TAG#v}" 5
+
       - name: Build Feishu release note prompt
         env:
           RELEASE_TAG: ${{ github.ref_name }}

--- a/scripts/configure-rollout.mjs
+++ b/scripts/configure-rollout.mjs
@@ -1,0 +1,187 @@
+import { fileURLToPath } from 'node:url'
+
+export const SUPPORTED_PLATFORMS = ['mac', 'mac-intel', 'windows']
+export const DEFAULT_BASE_URL = 'https://dshdesktop.com/crash'
+export const DEFAULT_PERCENTAGE = 5
+
+const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?(?:\+[\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*)?$/
+
+export function isValidVersion(value) {
+  return typeof value === 'string' && value.length <= 80 && SEMVER.test(value)
+}
+
+/**
+ * Configure rollout percentage for all supported desktop platforms.
+ * Idempotent: creates a new release target or updates an existing one.
+ */
+export async function configureRollout(options) {
+  const {
+    version,
+    percentage = DEFAULT_PERCENTAGE,
+    token = process.env.CRASH_ADMIN_TOKEN || process.env.DESKTOP_ADMIN_TOKEN,
+    baseUrl = process.env.CRASH_BASE_URL || DEFAULT_BASE_URL,
+    fetchImpl = globalThis.fetch,
+    notes,
+    log = console.log,
+    warn = console.warn
+  } = options
+
+  if (!isValidVersion(version)) {
+    throw new Error(`Invalid version: "${version}". Expected a canonical SemVer string (e.g. 0.8.2).`)
+  }
+
+  const numPercentage = Number(percentage)
+  if (!Number.isFinite(numPercentage) || numPercentage < 0 || numPercentage > 100) {
+    throw new Error(`Invalid percentage: ${percentage}. Must be between 0 and 100.`)
+  }
+
+  if (!token || typeof token !== 'string' || token.trim().length === 0) {
+    throw new Error('CRASH_ADMIN_TOKEN is required for configuring rollout on crash service.')
+  }
+
+  const cleanBaseUrl = baseUrl.replace(/\/+$/, '')
+  const headers = {
+    Authorization: `Bearer ${token.trim()}`,
+    'Content-Type': 'application/json'
+  }
+
+  // 1. Fetch existing releases to check for existing targets
+  let existingReleases = []
+  const listResponse = await fetchImpl(`${cleanBaseUrl}/admin/api/releases`, {
+    headers,
+    signal: AbortSignal.timeout(10_000)
+  })
+
+  if (!listResponse.ok) {
+    throw new Error(
+      `Failed to list existing releases from ${cleanBaseUrl}/admin/api/releases (${listResponse.status})`
+    )
+  }
+
+  try {
+    existingReleases = await listResponse.json()
+  } catch (error) {
+    throw new Error(`Invalid JSON response from ${cleanBaseUrl}/admin/api/releases: ${error.message}`)
+  }
+
+  const results = []
+
+  // 2. Iterate each platform and configure the rollout rule
+  for (const platform of SUPPORTED_PLATFORMS) {
+    const existing = Array.isArray(existingReleases)
+      ? existingReleases.find((r) => r.version === version && r.platform === platform)
+      : undefined
+
+    const defaultNotes = `Initial ${numPercentage}% rollout configured by release workflow`
+    const releasePayload = {
+      version,
+      platform,
+      percentage: numPercentage,
+      algorithm: existing?.algorithm || 'sha256-installation-v1',
+      seed: existing?.seed || 'desktop-v1',
+      enabled: true,
+      notes: notes ?? existing?.notes ?? defaultNotes
+    }
+
+    if (existing?.id && typeof existing.revision === 'number') {
+      // Update existing release rule
+      const updateResponse = await fetchImpl(`${cleanBaseUrl}/admin/api/releases/${existing.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          revision: existing.revision,
+          ...releasePayload
+        }),
+        signal: AbortSignal.timeout(10_000)
+      })
+
+      if (!updateResponse.ok) {
+        const text = await updateResponse.text().catch(() => '')
+        throw new Error(
+          `Failed to update release rule for ${platform}@${version} (${updateResponse.status}): ${text}`
+        )
+      }
+
+      const updated = await updateResponse.json()
+      log?.(`✅ [${platform}] Updated rollout for ${version} to ${numPercentage}% (rev ${updated.revision})`)
+      results.push({ platform, action: 'updated', data: updated })
+    } else {
+      // Create new release rule
+      const createResponse = await fetchImpl(`${cleanBaseUrl}/admin/api/releases`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(releasePayload),
+        signal: AbortSignal.timeout(10_000)
+      })
+
+      if (createResponse.status === 409) {
+        // Concurrently created or race condition: re-fetch and update
+        warn?.(`⚠️ [${platform}] Conflict (409) while creating release. Retrying via PUT...`)
+        const refreshRes = await fetchImpl(`${cleanBaseUrl}/admin/api/releases`, {
+          headers,
+          signal: AbortSignal.timeout(10_000)
+        })
+        const refreshed = await refreshRes.json()
+        const found = Array.isArray(refreshed)
+          ? refreshed.find((r) => r.version === version && r.platform === platform)
+          : undefined
+
+        if (!found) {
+          throw new Error(`Conflict reported for ${platform}@${version} but entry could not be retrieved`)
+        }
+
+        const putRes = await fetchImpl(`${cleanBaseUrl}/admin/api/releases/${found.id}`, {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify({
+            revision: found.revision,
+            ...releasePayload
+          }),
+          signal: AbortSignal.timeout(10_000)
+        })
+
+        if (!putRes.ok) {
+          const text = await putRes.text().catch(() => '')
+          throw new Error(`Failed to update release rule on conflict retry for ${platform}@${version}: ${text}`)
+        }
+
+        const updated = await putRes.json()
+        log?.(`✅ [${platform}] Updated rollout for ${version} to ${numPercentage}% after conflict retry (rev ${updated.revision})`)
+        results.push({ platform, action: 'updated-after-conflict', data: updated })
+      } else if (!createResponse.ok) {
+        const text = await createResponse.text().catch(() => '')
+        throw new Error(
+          `Failed to create release rule for ${platform}@${version} (${createResponse.status}): ${text}`
+        )
+      } else {
+        const created = await createResponse.json()
+        log?.(`✅ [${platform}] Created new rollout for ${version} at ${numPercentage}%`)
+        results.push({ platform, action: 'created', data: created })
+      }
+    }
+  }
+
+  return results
+}
+
+// CLI entry point
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const rawVersion = process.argv[2] || process.env.RELEASE_TAG || process.env.GITHUB_REF_NAME
+  const cleanVersion = rawVersion?.startsWith('v') ? rawVersion.slice(1) : rawVersion
+  const percentage = process.argv[3] !== undefined ? Number(process.argv[3]) : DEFAULT_PERCENTAGE
+
+  if (!cleanVersion) {
+    console.error('Usage: node scripts/configure-rollout.mjs <version> [percentage]')
+    process.exit(1)
+  }
+
+  configureRollout({ version: cleanVersion, percentage })
+    .then(() => {
+      console.log('🎉 All desktop rollout rules configured successfully.')
+    })
+    .catch((error) => {
+      console.error(`❌ Rollout configuration failed: ${error.message}`)
+      process.exit(1)
+    })
+}

--- a/test/configure-rollout.test.ts
+++ b/test/configure-rollout.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  configureRollout,
+  DEFAULT_BASE_URL,
+  DEFAULT_PERCENTAGE,
+  isValidVersion,
+  SUPPORTED_PLATFORMS
+} from '../scripts/configure-rollout.mjs'
+
+describe('configureRollout', () => {
+  it('validates canonical SemVer versions', () => {
+    expect(isValidVersion('0.8.2')).toBe(true)
+    expect(isValidVersion('1.0.0-rc.1')).toBe(true)
+    expect(isValidVersion('1.0.0+build')).toBe(true)
+    expect(isValidVersion('v0.8.2')).toBe(false)
+    expect(isValidVersion('latest')).toBe(false)
+    expect(isValidVersion('')).toBe(false)
+    expect(isValidVersion(null)).toBe(false)
+  })
+
+  it('creates rollout rules for all 3 platforms when none exist', async () => {
+    const calls: Array<{ url: string; method?: string; body?: unknown; headers?: unknown }> = []
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method || 'GET'
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      calls.push({ url, method, body, headers: init?.headers })
+
+      if (url.endsWith('/admin/api/releases') && method === 'GET') {
+        return new Response(JSON.stringify([]), { status: 200 })
+      }
+      if (url.endsWith('/admin/api/releases') && method === 'POST') {
+        return new Response(JSON.stringify({ ...body, id: `rel-${body.platform}`, revision: 1 }), {
+          status: 201
+        })
+      }
+      return new Response('Not Found', { status: 404 })
+    })
+
+    const logs: string[] = []
+    const results = await configureRollout({
+      version: '0.9.0',
+      percentage: 5,
+      token: 'test-admin-token-12345678901234567890',
+      baseUrl: 'https://test-crash.example.com',
+      fetchImpl,
+      log: (msg: string) => logs.push(msg)
+    })
+
+    expect(results).toHaveLength(3)
+    expect(results.map((r) => r.platform)).toEqual(SUPPORTED_PLATFORMS)
+    expect(results.every((r) => r.action === 'created')).toBe(true)
+
+    // 1 GET + 3 POSTs = 4 calls
+    expect(calls).toHaveLength(4)
+    expect(calls[0].method).toBe('GET')
+    expect(calls[0].headers).toMatchObject({
+      Authorization: 'Bearer test-admin-token-12345678901234567890'
+    })
+
+    const postCalls = calls.slice(1)
+    expect(postCalls.every((c) => c.method === 'POST')).toBe(true)
+    expect(postCalls.map((c) => (c.body as { platform: string }).platform)).toEqual(SUPPORTED_PLATFORMS)
+    expect(postCalls.every((c) => (c.body as { percentage: number }).percentage === 5)).toBe(true)
+    expect(postCalls.every((c) => (c.body as { enabled: boolean }).enabled === true)).toBe(true)
+    expect(postCalls.every((c) => (c.body as { version: string }).version === '0.9.0')).toBe(true)
+  })
+
+  it('updates existing rollout rules via PUT preserving revision and seed', async () => {
+    const calls: Array<{ url: string; method?: string; body?: unknown }> = []
+    const existing = [
+      {
+        id: 'uuid-mac',
+        version: '0.9.0',
+        platform: 'mac',
+        percentage: 0,
+        revision: 2,
+        algorithm: 'sha256-installation-v1',
+        seed: 'desktop-v1',
+        enabled: false,
+        notes: 'Pre-created disabled rule'
+      },
+      {
+        id: 'uuid-win',
+        version: '0.9.0',
+        platform: 'windows',
+        percentage: 1,
+        revision: 5,
+        algorithm: 'sha256-installation-v1',
+        seed: 'desktop-v1',
+        enabled: true,
+        notes: 'Existing 1%'
+      }
+    ]
+
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method || 'GET'
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      calls.push({ url, method, body })
+
+      if (url.endsWith('/admin/api/releases') && method === 'GET') {
+        return new Response(JSON.stringify(existing), { status: 200 })
+      }
+      if (url.includes('/admin/api/releases/') && method === 'PUT') {
+        return new Response(JSON.stringify({ ...body, revision: body.revision + 1 }), { status: 200 })
+      }
+      if (url.endsWith('/admin/api/releases') && method === 'POST') {
+        return new Response(JSON.stringify({ ...body, id: 'new-id', revision: 1 }), { status: 201 })
+      }
+      return new Response('Not Found', { status: 404 })
+    })
+
+    const results = await configureRollout({
+      version: '0.9.0',
+      percentage: 5,
+      token: 'test-token',
+      baseUrl: 'https://test-crash.example.com',
+      fetchImpl
+    })
+
+    expect(results).toHaveLength(3)
+    const macResult = results.find((r) => r.platform === 'mac')
+    const winResult = results.find((r) => r.platform === 'windows')
+    const intelResult = results.find((r) => r.platform === 'mac-intel')
+
+    expect(macResult?.action).toBe('updated')
+    expect(winResult?.action).toBe('updated')
+    expect(intelResult?.action).toBe('created')
+
+    const macPut = calls.find((c) => c.url.endsWith('/admin/api/releases/uuid-mac'))
+    expect(macPut?.method).toBe('PUT')
+    expect((macPut?.body as { revision: number }).revision).toBe(2)
+    expect((macPut?.body as { percentage: number }).percentage).toBe(5)
+    expect((macPut?.body as { enabled: boolean }).enabled).toBe(true)
+  })
+
+  it('handles 409 conflict during POST by re-fetching and updating via PUT', async () => {
+    let listCount = 0
+    const calls: Array<{ url: string; method?: string; body?: unknown }> = []
+
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method || 'GET'
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      calls.push({ url, method, body })
+
+      if (url.endsWith('/admin/api/releases') && method === 'GET') {
+        listCount += 1
+        if (listCount === 1) return new Response(JSON.stringify([]), { status: 200 })
+        // On refresh after 409, return newly created items
+        return new Response(
+          JSON.stringify([
+            { id: 'race-mac', version: '0.9.0', platform: 'mac', revision: 1 },
+            { id: 'race-intel', version: '0.9.0', platform: 'mac-intel', revision: 1 },
+            { id: 'race-win', version: '0.9.0', platform: 'windows', revision: 1 }
+          ]),
+          { status: 200 }
+        )
+      }
+      if (url.endsWith('/admin/api/releases') && method === 'POST') {
+        return new Response(JSON.stringify({ error: 'Release target already exists' }), { status: 409 })
+      }
+      if (url.includes('/admin/api/releases/') && method === 'PUT') {
+        return new Response(JSON.stringify({ ...body, revision: body.revision + 1 }), { status: 200 })
+      }
+      return new Response('Error', { status: 500 })
+    })
+
+    const warnings: string[] = []
+    const results = await configureRollout({
+      version: '0.9.0',
+      percentage: 5,
+      token: 'test-token',
+      fetchImpl,
+      warn: (msg: string) => warnings.push(msg)
+    })
+
+    expect(results).toHaveLength(3)
+    expect(results.every((r) => r.action === 'updated-after-conflict')).toBe(true)
+    expect(warnings.length).toBeGreaterThan(0)
+  })
+
+  it('rejects invalid parameters and missing token', async () => {
+    await expect(
+      configureRollout({ version: 'invalid-version', token: 'token' })
+    ).rejects.toThrow('Invalid version')
+
+    await expect(
+      configureRollout({ version: '0.9.0', percentage: -1, token: 'token' })
+    ).rejects.toThrow('Invalid percentage')
+
+    await expect(
+      configureRollout({ version: '0.9.0', percentage: 105, token: 'token' })
+    ).rejects.toThrow('Invalid percentage')
+
+    await expect(
+      configureRollout({ version: '0.9.0', percentage: 5, token: '' })
+    ).rejects.toThrow('CRASH_ADMIN_TOKEN is required')
+  })
+})


### PR DESCRIPTION
## Summary
- 补齐 v0.8.2 打 tag 后**灰度平台没有写入规则**的缺失：把服务端写规则的那半合入 main。
- 新增 `scripts/configure-rollout.mjs`：对 `mac` / `mac-intel` / `windows` 三个平台幂等地在 crash service 上创建/更新灰度规则（默认 5%）。
- 在 `.github/workflows/release.yml` 的 `publish` job（tag push 时）ModelScope 镜像之后、飞书通知之前，新增 "Configure initial 5% rollout on crash service" 步骤；`CRASH_ADMIN_TOKEN` secret 缺失时跳过而非失败。
- 附带单元测试覆盖 create / update / 409 冲突重试路径。

## Background
v0.8.2（tag 于 2026-09-11）合入了客户端接入 `feat: 接入桌面端灰度更新与异常日志上报` (#395)，客户端会去 `dshdesktop.com/crash/v1/updates/check` 拉策略。但**写策略那半**只在 `feat/release-initial-rollout` 分支上，一直没合入主干、没开 PR。所以 v0.8.2 发布后 crash service 上没有任何 rollout 规则，灰度实际上没生效。

## Follow-up
- 合并后需要在 GitHub 仓库 secrets 里配置 `CRASH_ADMIN_TOKEN`，下一个 v* tag 起会自动执行。
- 对已经发布的 v0.8.2，可在有 token 的机器上手动跑一次 `node scripts/configure-rollout.mjs 0.8.2 5` 补上规则。

## Test plan
- [ ] 合入前跑 `npm test -- configure-rollout` 通过（本地已带单测）
- [ ] 合并后配置 `CRASH_ADMIN_TOKEN` secret
- [ ] 下一个 tag 观察 release workflow 是否出现 "Configure initial 5% rollout on crash service" 步骤且非 skip
- [ ] crash service admin API 中确认对应 version + 3 平台的规则已建立且 `enabled=true, percentage=5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)